### PR TITLE
feat(skills): add backend-api skill and refiner follow-ups

### DIFF
--- a/.refiner-runs.json
+++ b/.refiner-runs.json
@@ -131,5 +131,75 @@
       "lines_removed": 191,
       "commits": 14
     }
+  },
+  {
+    "run_id": "2026-04-06-backend-api",
+    "branch": "skill-refiner/2026-04-06-backend-api",
+    "date": "2026-04-06",
+    "primary": {
+      "harness": "codex",
+      "model": "gpt-5.4",
+      "effort": "high"
+    },
+    "secondary": {
+      "harness": "claude",
+      "model": "unspecified via claude -p",
+      "weight": "10%",
+      "note": "one invalid important flag was reviewed and discarded after primary verification"
+    },
+    "config": {
+      "iterations_min_requested": 5,
+      "iterations_used": 6,
+      "threshold": 95,
+      "mode": "circuit-breaker",
+      "plateau": 2,
+      "ceiling": "none"
+    },
+    "pool": ["backend-api"],
+    "termination": "plateau",
+    "score_basis": "estimated from lint/spec validation, targeted behavioral prompts, source verification, and manual AI-self-check review; not from exhaustive automated rubric execution",
+    "scores": {
+      "backend-api": {
+        "before": {
+          "structural": 100,
+          "ai_self_check_est": 90,
+          "behavioral_est": 86,
+          "composite_est": 91.2
+        },
+        "after": {
+          "structural": 100,
+          "ai_self_check_est": 98,
+          "behavioral_est": 96,
+          "cross_model": 100,
+          "composite_est": 97.4
+        }
+      }
+    },
+    "iteration_log": [
+      { "iteration": 1, "type": "baseline", "score_est": 91.2, "notes": "spec warning on description length; behavior generally sound but under-specified around service house style" },
+      { "iteration": 2, "delta_est": 2.8, "score_est": 94.0, "notes": "trimmed description and clarified service-convention matching" },
+      { "iteration": 3, "delta_est": 1.1, "score_est": 95.1, "notes": "tightened compatibility wording and added cookie/CSRF self-check guidance" },
+      { "iteration": 4, "delta_est": 0.8, "score_est": 95.9, "notes": "refined auth reference: OAuth vs OIDC, CSRF, machine-client language" },
+      { "iteration": 5, "delta_est": 0.9, "score_est": 96.8, "notes": "refined HTTP reference: validation-status and pagination-parameter consistency" },
+      { "iteration": 6, "delta_est": 0.6, "score_est": 97.4, "notes": "added ownership-hiding and command retry semantics; further peer review showed no valid high-signal follow-up changes" }
+    ],
+    "reverted": 0,
+    "contested": 0,
+    "cross_model_flags": 0,
+    "discarded_flags": 1,
+    "changes_summary": {
+      "files_changed": 3,
+      "lines_added": 552,
+      "lines_removed": 0,
+      "commits": 1
+    },
+    "sources_verified": [
+      "PyPI fastapi",
+      "npm express",
+      "npm @nestjs/core",
+      "OpenAPI specification site",
+      "RFC 9457",
+      "RFC 9700"
+    ]
   }
 ]

--- a/.refiner-runs.json
+++ b/.refiner-runs.json
@@ -193,6 +193,20 @@
       "lines_removed": 0,
       "commits": 1
     },
+    "phase2": {
+      "approved": true,
+      "commits": [
+        "644c9e2",
+        "a897b51"
+      ],
+      "meta_changes": [
+        "skill-creator: align description-length guidance with collection validation and forward-test rules",
+        "skill-refiner: surface per-component score breakdowns in iteration and final report templates",
+        "lint-skills.sh: scan references/*.md for private-skill mentions",
+        "validate-spec.sh: validate description from extracted frontmatter only",
+        "skill-creator/references/conventions.md: add backend-api inventory entry and align description limits"
+      ]
+    },
     "sources_verified": [
       "PyPI fastapi",
       "npm express",

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -19,12 +19,15 @@ PRIVATE_SKILLS=(cluster-health)
 
 # ── Private skill reference check ──────────────────────────────────────
 check_private_refs() {
-  local file="$1" name="$2"
+  local dir="$1" name="$2"
   for priv in "${PRIVATE_SKILLS[@]}"; do
     [[ "$name" == "$priv" ]] && continue  # private skill can reference itself
-    if grep -q "\\b${priv}\\b" "$file" 2>/dev/null; then
-      error "$name: references private skill '$priv' (public skills must not reference private skills)"
-    fi
+    for f in "$dir"/SKILL.md "$dir"/references/*.md; do
+      [[ -f "$f" ]] || continue
+      if grep -q "\\b${priv}\\b" "$f" 2>/dev/null; then
+        error "$name: references private skill '$priv' in $(basename "$f") (public skills must not reference private skills)"
+      fi
+    done
   done
 }
 
@@ -207,7 +210,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   check_ascii "$skill_file" "$name"
   check_length "$skill_file" "$name"
   check_references "$skill_file" "$name" "$skill_dir"
-  check_private_refs "$skill_file" "$name"
+  check_private_refs "$skill_dir" "$name"
   check_ai_self_check "$skill_file" "$name"
   check_banned_words "$skill_dir" "$name"
   (( skill_count++ )) || true

--- a/scripts/validate-spec.sh
+++ b/scripts/validate-spec.sh
@@ -34,10 +34,10 @@ validate_name() {
 }
 
 validate_description() {
-  local file="$1" name="$2"
+  local fm="$1" name="$2"
   # Extract description value (handles multiline YAML)
   local desc
-  desc=$(sed -n '/^description:/,/^[a-z_-]*:/{ /^description:/{ s/^description: *//; p; }; /^  /p; }' "$file" | tr -d '\n' | sed 's/^ *//')
+  desc=$(printf '%s\n' "$fm" | sed -n '/^description:/,/^[a-z_-]*:/{ /^description:/{ s/^description: *//; p; }; /^  /p; }' | tr -d '\n' | sed 's/^ *//')
   if [[ -z "$desc" ]]; then
     error "$name: description is empty"
     return
@@ -110,7 +110,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   fi
 
   # Spec: field constraints
-  validate_description "$skill_file" "$name"
+  validate_description "$fm" "$name"
   validate_compatibility "$skill_file" "$name"
 
   # Spec: SKILL.md body recommended under 500 lines (soft target, 600 hard max)

--- a/skills/backend-api/SKILL.md
+++ b/skills/backend-api/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: backend-api
+description: >
+  · Design, review, or implement HTTP backend APIs for FastAPI, Express, and NestJS. Covers
+  REST/OpenAPI contracts, versioning, pagination, idempotency, problem details, sessions,
+  bearer tokens, OAuth/OIDC, and BFF patterns. Triggers: 'fastapi', 'express', 'nestjs',
+  'openapi', 'api versioning', 'pagination', 'idempotency', 'oauth', 'oidc', 'jwt', 'bff'.
+  Not for GraphQL/gRPC, database design (use databases), bug review (use code-review), or
+  security audits (use security-audit).
+license: MIT
+compatibility: "Optional: Python or Node.js framework context. Optional: OpenAPI-capable framework/docs tooling"
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-04-06"
+  effort: high
+  argument_hint: "[framework-or-api-task]"
+---
+
+# Backend APIs: HTTP Service Design and Implementation
+
+Design and review HTTP APIs that stay coherent as they grow. Focus on contracts, auth
+boundaries, error models, and framework structure for Python and Node.js services.
+
+**Target versions** (April 2026):
+- FastAPI **0.135.3** (released 2026-04-01)
+- Express **5.2.1** (published 2025-12-01)
+- NestJS **11.1.18** (published 2026-04-03)
+- OpenAPI Specification **3.2.0** (published 2025-09-19)
+- HTTP Semantics: **RFC 9110** (June 2022)
+- Problem Details for HTTP APIs: **RFC 9457** (July 2023)
+- OAuth 2.0 Security Best Current Practice: **RFC 9700** (January 2025)
+
+This skill works across five concerns:
+- **Contract design** -- resources, methods, status codes, schemas, versioning
+- **API ergonomics** -- pagination, filtering, sorting, idempotency, error format
+- **Framework structure** -- FastAPI dependencies, Express middleware, NestJS modules and guards
+- **Authentication** -- sessions, bearer tokens, OAuth/OIDC, BFF and token mediation
+- **Review** -- unstable contracts, DTO leakage, auth confusion, and HTTP misuse
+
+## When to use
+
+- Designing a new REST or HTTP API
+- Reviewing an existing FastAPI, Express, or NestJS service
+- Writing or fixing OpenAPI specifications and generated docs
+- Choosing status codes, error formats, pagination, filtering, or versioning strategy
+- Designing auth flows for browser, mobile, machine-to-machine, or third-party clients
+- Refactoring route or controller structure that has become hard to reason about
+- Planning backward-compatible API evolution
+- Defining idempotency and retry behavior for write endpoints
+
+## When NOT to use
+
+- GraphQL schema, resolvers, federation, or persisted query work -- out of scope for this skill
+- gRPC, protobuf schema evolution, or streaming RPCs -- out of scope for this skill
+- Database schema, indexing, replication, or query tuning -- use **databases**
+- General bug-finding, race-condition hunting, or correctness review outside the API boundary -- use **code-review**
+- Security auditing for auth bypasses, injection, secrets, or OWASP findings -- use **security-audit**
+- Writing or debugging automated tests -- use **testing**
+- Deployment, containers, gateways, ingress, or cluster config -- use **docker**, **kubernetes**, or **networking**
+- CI/CD pipeline design for API delivery -- use **ci-cd**
+- MCP-specific HTTP servers and tool handlers -- use **mcp**
+
+---
+
+## AI Self-Check
+
+Before returning API code, route design, or OpenAPI output, verify:
+
+- [ ] Resource names are nouns and URL shape is stable (`/users/{userId}/sessions`, not `/doUserSessionThing`)
+- [ ] Method semantics follow RFC 9110 -- no "GET that mutates", no PATCH used as a vague catch-all
+- [ ] `401` vs `403` is correct: unauthenticated vs authenticated-but-forbidden
+- [ ] Ownership-hiding behavior is deliberate and consistent: decide when out-of-scope resources return `404` vs `403`
+- [ ] Error responses use one consistent format, preferably RFC 9457 problem details
+- [ ] Request and response DTOs are explicit and separate from ORM or database models
+- [ ] Input validation happens server-side even if clients or SDKs also validate
+- [ ] Offset pagination is not used blindly on large or high-churn collections where cursor pagination is the safer default
+- [ ] Write endpoints that may be retried (`POST /payments`, webhook receivers, order creation) define idempotency behavior
+- [ ] OpenAPI docs match real handler behavior, examples, status codes, and auth requirements
+- [ ] First-party browser apps do not get long-lived bearer tokens stored in browser storage by default
+- [ ] Cookie-based browser auth accounts for cookie scope and CSRF behavior instead of assuming cookies are automatically safe
+- [ ] OAuth guidance is current: authorization code + PKCE, no implicit flow, no resource owner password credentials
+- [ ] Sensitive defaults are explicit: cookie flags, token TTLs, scope boundaries, and rate limits are not hand-waved
+
+---
+
+## Workflow
+
+**Build vs. Review:** when reviewing an existing service, still walk the same steps. Determine the API boundary, audit the contract, trace auth, then compare the implementation against the published behavior instead of jumping straight into handler code.
+
+### Step 1: Determine the boundary
+
+Clarify the API before picking framework patterns:
+- **Who calls it?** Browser app, mobile app, third-party integrator, internal service, webhook sender
+- **What kind of API is it?** Public API, private app backend, internal service, admin API
+- **Is the task greenfield or review?** New design, incremental change, migration, or bug fix
+- **What stability promise exists?** Internal-only, versioned public API, or "best effort"
+- **What auth model already exists?** Session cookies, JWT bearer, API keys, OAuth/OIDC, or none yet
+- **What house style already exists?** Error format, pagination shape, versioning scheme, auth boundary, DTO naming
+
+If the user asks to "just add an endpoint", inspect the surrounding service first. Most bad API
+work happens when one route lands with a different error model, auth rule, pagination shape, or
+DTO style than the rest of the service.
+
+### Step 2: Choose the framework pattern
+
+Pick the framework that matches the codebase and team constraints. Do not switch frameworks for fashion.
+
+| Framework | Best fit | Watch for |
+|-----------|----------|-----------|
+| **FastAPI** | Python services with typed request/response models and strong OpenAPI output | Leaking ORM models directly, async confusion, piling business logic into route functions |
+| **Express** | Thin Node.js services, custom middleware stacks, existing mature codebases | No built-in structure, validation scattered across middleware, inconsistent error handling |
+| **NestJS** | Larger TypeScript services that benefit from modules, guards, pipes, interceptors, and DI | Over-abstraction, decorator-heavy indirection, hiding simple flows behind too many layers |
+
+Framework rules:
+- **FastAPI** -- keep dependencies explicit, use response models, and centralize exception handling
+- **Express** -- keep routing, validation, auth, and business logic separated; add one error middleware path
+- **NestJS** -- keep controllers thin, move auth into guards, validation into pipes, and cross-cutting behavior into interceptors or filters
+
+### Step 3: Design the contract first
+
+Define the API contract before writing handlers:
+
+For changes to an existing service, match the current URL, error, pagination, and auth house
+style unless the task explicitly includes a migration.
+
+1. Pick resource shapes and URIs
+2. Choose methods and status codes
+3. Define request and response schemas
+4. Define error shapes
+5. Decide pagination, filtering, sorting, and versioning rules
+6. Only then wire the framework implementation
+
+Prefer:
+- Noun-based resources: `/users/{userId}/sessions`
+- Predictable list endpoints: `GET /orders?cursor=...&limit=...&status=paid`
+- Explicit write semantics: `POST` for create/commands, `PUT` for full replacement, `PATCH` for partial update, `DELETE` for delete
+- Explicit retry semantics for command endpoints like `POST /orders/{orderId}/cancel`
+- One canonical error model across the whole service
+
+Read `references/http-api-patterns.md` for method semantics, pagination, idempotency, and versioning rules.
+
+### Step 4: Design auth around the client, not around JWT hype
+
+Start from the client type:
+
+| Client | Default choice | Why |
+|--------|----------------|-----|
+| **First-party browser app** | Session cookie or BFF/token-mediating backend | Keeps tokens off the browser as much as possible |
+| **Native/mobile app** | OAuth/OIDC authorization code + PKCE | Current standard path for public clients |
+| **Third-party integrator** | OAuth/OIDC or scoped API keys if OAuth is overkill | Explicit delegation and revocation story |
+| **Internal service-to-service** | Platform identity or short-lived service credentials | Avoid user-style auth flows between services |
+
+Auth rules:
+- Use sessions by default for first-party web apps unless there is a clear reason not to
+- Use bearer tokens when the client really is a token-holding client
+- Treat API keys as machine credentials, not as a universal auth shortcut
+- Define scope or role boundaries at the API boundary, not ad hoc inside random handlers
+- If the browser app talks to third-party identity providers, follow authorization code + PKCE and current browser-app guidance rather than resurrecting implicit flow patterns
+
+Read `references/auth-and-session-patterns.md` for sessions, bearer tokens, OAuth, BFF, refresh tokens, and machine auth.
+
+### Step 5: Implement the framework surface
+
+Convert the contract into framework code without letting the framework dictate the contract.
+
+**FastAPI**
+- Define Pydantic models for requests and responses
+- Use dependency injection for auth, DB/session acquisition, and shared request context
+- Register exception handlers for consistent RFC 9457 output
+- Keep route handlers thin; move business rules into services or domain modules
+
+**Express**
+- Validate inputs before controller logic
+- Attach auth and request context in middleware
+- Use one shared error-handling middleware path
+- Keep controllers as transport adapters, not the place where every rule in the system lives
+
+**NestJS**
+- Use DTO classes for transport boundaries
+- Put validation in pipes and auth in guards
+- Use exception filters or interceptors to normalize response and error behavior
+- Keep module boundaries meaningful; one module per vague concept is not architecture
+
+### Step 6: Validate behavior and docs
+
+Before returning the result:
+- Compare OpenAPI docs against the real routes
+- Verify auth requirements per endpoint
+- Check all non-2xx responses, not just the happy path
+- Verify list endpoints under empty, partial, and end-of-cursor states
+- Check retries and duplicate submissions for create/payment/webhook paths
+- Check repeat-call behavior for command endpoints (`cancel`, `resend`, `approve`) instead of leaving retries implicit
+- Compare new endpoints with neighboring endpoints for naming, DTO shape, pagination params, and error consistency
+- Route follow-up testing work to **testing** and follow-up security review to **security-audit**
+
+---
+
+## Contract Guardrails
+
+### Versioning
+
+- Prefer additive change over version churn
+- Version only when you need a breaking change
+- Keep one versioning scheme for the service: path versioning (`/v1/...`) is the clearest default for public APIs
+- Do not mix path versioning, header versioning, and ad hoc `?version=` query params in one API
+
+### OpenAPI authoring
+
+- OpenAPI `3.2.0` is the current spec, but much of the framework and Swagger ecosystem still centers on `3.1.x`
+- Default to authoring for `3.1` compatibility unless the actual toolchain in the project proves `3.2` support end-to-end
+- Do not advertise `3.2` features in generated specs just because the top-level standard moved
+
+### Error model
+
+- Prefer RFC 9457 problem details with stable `type`, `title`, `status`, and domain-specific extension fields
+- Do not return one error shape from validation, another from auth, and a third from business rules
+- Never leak raw stack traces or ORM internals to clients
+
+### Pagination and filtering
+
+- Offset pagination is fine for small, stable backoffice lists
+- Cursor pagination is the default for user-facing or high-write collections
+- Sort order must be stable and documented
+- Filter names should reflect resource fields or clear domain concepts, not internal SQL column names
+
+### Idempotency and retries
+
+- Define idempotency for writes that clients or gateways may retry
+- Use explicit idempotency keys for payment-like or request-replay-prone operations
+- Distinguish "request accepted" from "side effect completed" when async workflows exist
+
+## What NOT to Force
+
+- Do not force cursor pagination onto every small internal list or backoffice table
+- Do not cut `/v2` just because a new field got added
+- Do not insist on OAuth for every internal automation path if scoped API keys or platform identity fit better
+- Do not push first-party browser apps toward bearer-token-in-local-storage patterns because "JWT auth" sounds modern
+- Do not turn simple Express services into pseudo-enterprise architectures with needless layers and decorators
+
+---
+
+## Reference Files
+
+- `references/http-api-patterns.md` -- resource design, method semantics, status codes, versioning, pagination, filtering, idempotency
+- `references/auth-and-session-patterns.md` -- sessions vs bearer tokens, OAuth/OIDC, BFF, refresh tokens, machine clients
+
+## Related Skills
+
+- **databases** -- schema design, query tuning, migrations, and persistence concerns behind the API
+- **code-review** -- correctness bugs, logic errors, and non-API-specific review findings
+- **security-audit** -- auth bypasses, OWASP findings, secrets, and security review after the API design exists
+- **testing** -- route, integration, contract, and end-to-end verification
+- **docker** -- containerizing API services
+- **kubernetes** -- deploying API services on clusters
+- **networking** -- reverse proxies, TLS termination, CORS-adjacent network boundaries, and gateway behavior
+- **ci-cd** -- delivery pipelines for API services
+- **mcp** -- MCP-specific HTTP servers and auth patterns
+
+## Rules
+
+1. **Contract before handlers.** Design the resource model, schemas, errors, and auth boundary before writing route code.
+2. **Do not let transport leak persistence.** Database tables, ORM entities, and internal enums are not public API contracts.
+3. **Pick one error format.** Prefer RFC 9457 and apply it consistently.
+4. **Use current auth guidance.** Authorization code + PKCE for public OAuth clients, sessions or BFF patterns for first-party browser apps, no implicit flow, no password grant.
+5. **Keep framework structure boring.** Thin controllers or routes, explicit validation, explicit auth, centralized error handling.
+6. **Backward compatibility is a feature.** New fields are cheap; breaking clients is expensive.
+7. **Write for real retries.** Assume clients, proxies, and job runners will replay requests.
+8. **Keep scope on HTTP APIs.** When the problem is GraphQL or gRPC-specific, say so and stop pretending the same rules apply.
+9. **Match service conventions unless migrating them.** A one-off endpoint with a different error, auth, or pagination model is usually a contract bug.

--- a/skills/backend-api/references/auth-and-session-patterns.md
+++ b/skills/backend-api/references/auth-and-session-patterns.md
@@ -1,0 +1,121 @@
+# Auth and Session Patterns
+
+Use this file when the main skill needs current HTTP API auth guidance.
+
+## Start From the Client Type
+
+| Client | Default | Avoid by default |
+|--------|---------|------------------|
+| First-party browser SPA or web app | Session cookie or BFF/token-mediating backend | Long-lived bearer tokens in browser storage |
+| Native/mobile app | OAuth/OIDC authorization code + PKCE | Implicit flow |
+| Third-party server integration | OAuth 2.0 client credentials or scoped API keys | Reusing user tokens for machine work |
+| Internal service | Platform workload identity, mTLS, or short-lived service credentials | User login flows between services |
+
+## Sessions vs Bearer Tokens
+
+### Prefer sessions when:
+- The client is a first-party browser app
+- The backend can hold server-side session state or issue tightly scoped session cookies
+- You want the browser to act like a browser instead of a token vault
+
+Cookie baseline:
+- `HttpOnly`
+- `Secure`
+- `SameSite=Lax` or `SameSite=Strict` unless the flow truly needs cross-site behavior
+- CSRF defenses that match the app's cookie and cross-site behavior, not just "SameSite should handle it"
+- Short idle and absolute lifetimes
+
+### Prefer bearer tokens when:
+- The client is native, mobile, CLI, or third-party server software
+- The client legitimately needs to call multiple resource servers
+- Delegated authorization matters more than server-side session control
+
+Bearer token rules:
+- Keep access tokens short-lived
+- Rotate or sender-constrain refresh tokens where the platform supports it
+- Scope tokens narrowly
+- Never assume JWT means "safe" or "stateless enough"
+
+## OAuth/OIDC Rules
+
+Current baseline:
+- Use authorization code + PKCE for public clients
+- Do not use the implicit flow
+- Do not use the resource owner password credentials grant
+
+OIDC note:
+- Use OIDC when the client needs verified user identity claims, not as a synonym for every OAuth-protected API
+
+Important nuance:
+- "OAuth 2.1" is still draft territory; anchor guidance on RFC 9700 and current browser-app BCP work instead of pretending a final OAuth 2.1 RFC already exists
+
+If the request says "JWT auth", do not stop at the token format. Determine:
+- Who issues the token?
+- Who stores it?
+- How is it refreshed?
+- What revokes it?
+- What audience and scopes are enforced?
+
+## BFF / Token-Mediating Backend
+
+For first-party browser apps that rely on OAuth/OIDC with an external IdP, the BFF or
+token-mediating backend pattern is often the safest default.
+
+Why:
+- Tokens stay on the server side or are minimized in the browser
+- Sensitive token exchange logic moves out of browser JavaScript
+- Session cookies can represent the browser-facing auth state
+
+Good fit:
+- React, Vue, or other SPAs that talk mostly to one backend
+- Admin apps
+- Internal business apps
+
+Tradeoff:
+- More backend coordination
+- Extra network hop if every request is fully proxied
+
+## API Keys
+
+API keys are machine credentials, not universal auth.
+
+Reasonable uses:
+- Internal automation
+- Server-to-server integrations
+- Simple third-party integrations with low delegation needs
+
+Rules:
+- Scope keys to an account or integration
+- Store only hashed keys server-side when possible
+- Allow rotation and revocation
+- Rate limit by key
+- Do not overload one key with human and machine privileges
+- Do not issue browser-facing API keys to first-party web apps as a lazy substitute for sessions or OAuth
+
+## Refresh Tokens
+
+Refresh tokens need stricter handling than access tokens.
+
+Rules:
+- Issue them only when the client type and session model justify them
+- Rotate them for public clients where supported
+- Detect replay where the identity platform allows it
+- Revoke on logout, credential change, or high-risk events
+
+## Authorization Boundaries
+
+Authentication answers "who are you?"
+Authorization answers "can you do this?"
+
+Check authorization at the right boundary:
+- Route or guard level for coarse access
+- Service or domain layer for object-level rules
+- Never trust client-supplied tenant IDs, roles, or ownership hints
+- Decide whether out-of-scope resources are hidden with `404` or exposed with `403`, then keep that rule consistent across the boundary
+
+Common mistake:
+- Valid token present
+- Resource ownership never checked
+- Result: authenticated users can access the wrong tenant's data
+
+That is not a design nit. That is a security bug. Route follow-up review to **security-audit**.

--- a/skills/backend-api/references/http-api-patterns.md
+++ b/skills/backend-api/references/http-api-patterns.md
@@ -1,0 +1,162 @@
+# HTTP API Patterns
+
+Use this file when the main skill needs concrete API design rules without turning `SKILL.md`
+into a full HTTP textbook.
+
+## Resource Modeling
+
+Prefer nouns and relationships:
+
+| Goal | Prefer | Avoid |
+|------|--------|-------|
+| List users | `GET /users` | `GET /getUsers` |
+| One user | `GET /users/{userId}` | `GET /user?id=123` |
+| User sessions | `GET /users/{userId}/sessions` | `GET /sessions?userId=123` when nesting is clearer |
+| Start workflow | `POST /orders/{orderId}/cancel` for explicit domain commands | Smuggling commands into vague updates |
+
+Two decent patterns for commands:
+- Treat the command as a subresource: `POST /orders/{orderId}/cancel`
+- Model the resulting resource explicitly: `POST /refunds`
+
+Pick one pattern and stay consistent.
+
+## Method Semantics
+
+| Method | Use for | Notes |
+|--------|---------|-------|
+| `GET` | Read | Safe and cacheable by default; no side effects |
+| `POST` | Create or non-idempotent command | Use idempotency keys when retries matter |
+| `PUT` | Full replacement | The client sends the full target state |
+| `PATCH` | Partial update | Define patch semantics clearly; do not use as "misc update" |
+| `DELETE` | Delete | Decide whether response is `204`, `200`, or async `202` |
+
+Common status codes:
+
+| Situation | Status |
+|-----------|--------|
+| Read success | `200` |
+| Create success | `201` |
+| Async accepted | `202` |
+| Delete with no body | `204` |
+| Validation failure | `400` or `422`, but pick one house style |
+| Unauthenticated | `401` |
+| Forbidden | `403` |
+| Missing resource | `404` |
+| Version or state conflict | `409` |
+| Precondition failed | `412` |
+| Too many requests | `429` |
+
+Do not return `200` for everything because the framework made it easy.
+If the service already chose `400` or `422` for validation errors, keep that convention unless
+the task explicitly includes a broader migration.
+
+## Versioning
+
+Default rule: avoid breaking changes; version only when needed.
+
+Path versioning is the clearest default for public APIs:
+
+```text
+/v1/users
+/v1/orders/{orderId}
+```
+
+Use a new version when you must:
+- Remove or rename fields clients depend on
+- Change a field type or semantic meaning
+- Rework auth or permission boundaries in a breaking way
+
+Do not cut a new version for:
+- Adding optional response fields
+- Adding new endpoints
+- Adding new enum values when the contract already documents extensibility
+
+## OpenAPI Version Choice
+
+The current OpenAPI Specification is `3.2.0`, but many framework-integrated docs and Swagger
+toolchains still target `3.1.x` most comfortably.
+
+Practical rule:
+- Prefer `3.1` as the default authoring target unless the project's generators, validators,
+  docs renderer, and gateway tooling are all confirmed to handle `3.2`
+- Treat `3.2` as an opt-in upgrade, not as an automatic edit every time you touch an API spec
+
+## Pagination
+
+Use offset pagination only when all of these are true:
+- The list is small or internal
+- Stable ordering is easy
+- Duplicate or skipped rows under concurrent writes are acceptable
+
+Use cursor pagination when:
+- The list can grow large
+- New rows arrive often
+- Users page through results in order
+
+Cursor shape:
+
+```text
+GET /events?cursor=eyJjcmVhdGVkQXQiOiIyMDI2LTA0LTA2VDEwOjAwOjAwWiIsImlkIjoiZXZ0XzEyMyJ9&limit=50
+```
+
+Rules:
+- Keep sort order stable
+- Include tie-breakers in the cursor (`createdAt` + `id`, not just `createdAt`)
+- Return pagination metadata that is consistent across list endpoints
+- Keep list parameter names consistent across the service (`cursor`/`limit` or `page`/`perPage`, not both without a migration plan)
+
+## Filtering and Sorting
+
+Filters should map to domain language:
+
+```text
+GET /orders?status=paid&customerId=cus_123&createdAfter=2026-04-01T00:00:00Z
+```
+
+Sorting rules:
+- Allow only documented sort fields
+- Document default sort order
+- Reject invalid sort fields instead of silently ignoring them
+
+## Idempotency
+
+Use explicit idempotency keys for operations that create external side effects:
+- Payments
+- Checkout or order creation
+- Webhook handling
+- Email or SMS sends
+- Any endpoint likely to be retried by clients, workers, or proxies
+
+Typical pattern:
+
+```http
+POST /payments
+Idempotency-Key: 77a5e517-0b63-42c2-8fb7-d4df0f1e30e6
+```
+
+Rules:
+- Scope the key to the caller and operation
+- Store enough request fingerprint data to detect key reuse with different payloads
+- Return the same semantic result for safe replays
+- Expire old keys deliberately, not accidentally
+
+## Problem Details
+
+RFC 9457 gives a standard error shape:
+
+```json
+{
+  "type": "https://api.example.com/problems/insufficient-balance",
+  "title": "Insufficient balance",
+  "status": 409,
+  "detail": "Account acc_123 cannot fund order ord_456.",
+  "instance": "/orders/ord_456/payments/pay_789"
+}
+```
+
+Add stable extension fields when helpful:
+- `code`
+- `requestId`
+- `fieldErrors`
+
+Do not invent a new top-level error envelope for every layer of the service.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -53,7 +53,7 @@ Before returning any generated or modified skill, verify against this list:
 - [ ] **Name spec-valid**: lowercase alphanumeric + hyphens only, no leading/trailing/consecutive
   hyphens, no reserved words (`anthropic`, `claude`), matches directory name
 - [ ] **No XML tags** in `name` or `description` fields (Anthropic platform restriction)
-- [ ] **Description is trigger-optimized**: starts with action verbs, includes trigger keywords, mentions related contexts, stays under 1024 chars
+- [ ] **Description is trigger-optimized**: starts with action verbs, includes trigger keywords, mentions related contexts, stays under 500 chars for the collection (600 hard max in `validate-spec.sh`; platform truncation happens later)
 - [ ] **Compatibility field present** (when skill requires specific tools/platforms): quotes values containing colons
 - [ ] **Scope sections present**: "When to use" with concrete scenarios, "When NOT to use"
   cross-referencing related skills by **bold** name (e.g., `use **skill-name**`)
@@ -281,9 +281,12 @@ first -- don't guess. Do not modify `date_added` (it records when the skill was 
 for historical tracking). If the skill needs a freshness marker, the `date_added` field serves
 that purpose for the initial creation; substantial refreshes are tracked via git history.
 
-#### Step 6: Forward-test (optional)
+#### Step 6: Forward-test
 
-After substantial changes, forward-test the skill (see Mode 1, Step 6). Especially valuable when:
+After substantial changes, forward-test the skill (see Mode 1, Step 6). Required for
+high-effort skills after workflow restructuring, reordered steps, or new references.
+Optional for narrow edits like version refreshes, wording cleanup, or metadata-only fixes.
+Especially valuable when:
 - The workflow was restructured or steps were reordered
 - New reference files were added and need discovery testing
 - Trigger description was rewritten (test activation, not just content)
@@ -391,7 +394,8 @@ Follow these patterns from high-performing custom skill descriptions:
 - **Include specific trigger keywords**: list them inline, e.g., "Triggers: 'keyword1', 'keyword2'"
 - **Mention adjacent skills to avoid**: "Not for X (use Y instead)"
 - **Be slightly pushy**: many tools undertrigger skills by default. Include edge cases.
-- **Stay under 1024 characters**: the system truncates beyond this
+- **Stay under 500 characters**: the collection warns above 500 and errors above 600
+- **Treat 1024 as the platform ceiling, not the collection target**: truncation happens there, but the repo convention is stricter
 
 #### Step 4: Validate
 

--- a/skills/skill-creator/references/conventions.md
+++ b/skills/skill-creator/references/conventions.md
@@ -85,7 +85,7 @@ succeeded" invites the agent to invent checks with wrong paths and service names
 ```yaml
 ---
 name: skill-name              # lowercase a-z, 0-9, hyphens; no leading/trailing/consecutive hyphens; max 64 chars; must match directory name; no reserved words (anthropic, claude)
-description: >                # max 1024 chars, trigger-optimized
+description: >                # target <500 chars, 600 hard max in this collection; platform truncates later
   Use when... Also use for... Triggers: '...', '...'.
 license: MIT                  # Agent Skills spec field
 metadata:
@@ -130,7 +130,7 @@ user confirmation in steps that could run unattended.
 | Field | Values | Purpose |
 |-------|--------|---------|
 | `name` | `a-z`, `0-9`, hyphens; no leading/trailing/consecutive hyphens; max 64 chars; no reserved words (`anthropic`, `claude`) | identifier, must match directory name |
-| `description` | free text, <1024 chars, no XML tags | primary trigger mechanism -- the agent scans this |
+| `description` | free text, target <500 chars, 600 hard max in this collection, no XML tags | primary trigger mechanism -- the agent scans this |
 | `license` | license name (e.g., `MIT`) | Agent Skills spec field |
 | `compatibility` | free text, <500 chars | environment requirements (optional) |
 | `metadata.source` | `owner/repo` or `custom` | identifies the publishing collection or an unpublished local skill |
@@ -495,13 +495,13 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 - **Too vague**: "Use for Docker stuff" -- no specific triggers
 - **Too narrow**: "Use only when the user says 'write a Dockerfile'" -- misses most use cases
 - **No differentiation**: shares all keywords with another skill, no routing guidance
-- **Over 1024 chars**: gets truncated by the system
+- **Over 600 chars**: fails collection validation; platform truncation at 1024 is not the operative repo limit
 
 ---
 
 ## 9. Skill Inventory (April 2026)
 
-### Published skills (26)
+### Published skills (27)
 
 | Skill | Effort | Date Added | Domain |
 |-------|--------|-----------|--------|
@@ -509,6 +509,7 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 | ansible | high | 2026-03-24 | Configuration management |
 | anti-slop | medium | 2026-03-25 | Code quality audit |
 | arch-btw | high | 2026-03-26 | Arch Linux / CachyOS administration |
+| backend-api | high | 2026-04-06 | HTTP API design and implementation |
 | browse | medium | 2026-04-04 | Web browsing, scraping, token-efficient extraction |
 | ci-cd | high | 2026-03-24 | CI/CD pipelines |
 | code-review | high | 2026-03-25 | Correctness audit |

--- a/skills/skill-refiner/SKILL.md
+++ b/skills/skill-refiner/SKILL.md
@@ -120,9 +120,9 @@ contested major flags (non-configurable).
 12. **Log iteration summary**:
     ```
     --- iteration N / max -------------------------------------------
-    improved:  skill1 (72 > 80), skill2 (68 > 73)
+    improved:  skill1 (72 > 80 | S:100 A:76 B:78 X:90), skill2 (68 > 73 | S:95 A:70 B:72 X:100)
     skipped:   M skills above threshold
-    reverted:  skill3 (proposed change scored -2, rolled back)
+    reverted:  skill3 (proposed change scored -2, rolled back | S:100 A:74 B:69 X:100)
     contested: skill4 (secondary flagged major, primary disagreed)
     plateau:   yes/no (max delta: +X)
     -----------------------------------------------------------------
@@ -173,11 +173,11 @@ contested major flags (non-configurable).
     Terminated: plateau / threshold / cap / user
 
     Score changes:
-      skill1:  62 > 88 (+26)
-      skill2:  71 > 85 (+14)
+      skill1:  62 > 88 (+26)  [S:100 A:84 B:86 X:90]
+      skill2:  71 > 85 (+14)  [S:95 A:82 B:79 X:100]
       ...
-      skill-creator: 80 > 84 (+4)  [meta]
-      skill-refiner: 78 > 83 (+5)  [meta]
+      skill-creator: 80 > 84 (+4)  [S:100 A:82 B:81 X:100] [meta]
+      skill-refiner: 78 > 83 (+5)  [S:100 A:80 B:79 X:100] [meta]
 
     Aggregate:  avg X.X | min X.X | max X.X
     Reverted:   X changes across Y iterations
@@ -187,7 +187,9 @@ contested major flags (non-configurable).
 23. **Write run history**: append this run's metadata to `.refiner-runs.json` in the
     collection root. Include: run_id, branch, date, primary/secondary harness+model+effort,
     config, pool size, termination reason, cross-model flag counts, before/after per-skill
-    scores, and a changes summary. Commit with the phase 3 summary.
+    scores (component breakdown + composite, or clearly labeled estimates if the run used a
+    targeted manual rubric instead of the full automated sweep), and a changes summary.
+    Commit with the phase 3 summary.
 24. **Announce branch**: remind user to review and merge when ready
 
 ## AI Self-Check


### PR DESCRIPTION
## Summary
- add the new `backend-api` skill and its HTTP/auth reference files
- refine the new skill through a recorded 6-iteration `skill-refiner` run
- apply approved phase-2 meta improvements to `skill-creator`, `skill-refiner`, lint scripts, and the conventions inventory

## Test Plan
- [x] `scripts/lint-skills.sh skills`
- [x] `scripts/validate-spec.sh skills`
- [x] `bash -n install.sh`
- [x] `shellcheck scripts/lint-skills.sh scripts/validate-spec.sh install.sh`
