### PR TITLE
refactor(anti-ai-prose): polish 4 follow-up tells

### DIFF
--- a/skills/roadmap/references/trigger-integration.md
+++ b/skills/roadmap/references/trigger-integration.md
@@ -79,7 +79,7 @@ jobs:
 ```
 
 Creates a GitHub issue as a reminder. Requires a `roadmap` label to exist (create it
-manually or add a step). The issue serves as the trigger - close it after updating
+manually or add a step). The issue is the trigger - close it after updating
 ROADMAP.md.
 
 Event data is passed through environment variables (not inline `${{ }}` interpolation)

--- a/skills/skill-creator/references/conventions.md
+++ b/skills/skill-creator/references/conventions.md
@@ -534,7 +534,7 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 | virtualization | high | 2026-03-25 | Proxmox, libvirt, VM operations |
 | zero-day | high | 2026-04-03 | Vulnerability research and discovery |
 
-This inventory is a snapshot of the upstream iuliandita/skills collection. It serves as a
+This inventory is a snapshot of the upstream iuliandita/skills collection. Treat it as a
 reference example for convention compliance, not as an authoritative list for other repos.
 When auditing a different collection, build the inventory from that collection's actual contents.
 `date_added` reflects local creation date, which may predate or postdate the first commit

--- a/skills/zero-day/references/binary-analysis.md
+++ b/skills/zero-day/references/binary-analysis.md
@@ -89,7 +89,7 @@ rizin -A TARGET
 
 ### Windows PE Analysis
 
-Windows binaries (PE/PE32+) have a different toolchain and mitigation landscape.
+Windows binaries (PE/PE32+) use a different toolchain and a different set of mitigations.
 
 **Initial assessment:**
 

--- a/skills/zero-day/references/vulnerability-classes.md
+++ b/skills/zero-day/references/vulnerability-classes.md
@@ -609,7 +609,7 @@ These are increasingly common as package ecosystems grow.
 RDS, Cloud SQL), managed streaming (MSK, Confluent, Aiven Kafka)
 
 Cloud-native applications have attack surfaces that don't exist in traditional deployments.
-The infrastructure itself becomes part of the vulnerability landscape - IAM policies, metadata
+The infrastructure itself becomes part of the attack surface - IAM policies, metadata
 services, cross-tenant isolation, and managed service APIs all introduce novel bug classes.
 
 ### Instance Metadata / IMDS Abuse


### PR DESCRIPTION
## Summary

- Fix two metaphorical `landscape` uses in `zero-day` references (binary-analysis, vulnerability-classes)
- Fix two `serves as` copula-avoidance constructions in `skill-creator/conventions` and `roadmap/trigger-integration`
- Follow-up audit after v1.16.0; all 4 findings were Low severity

## Test plan

- [ ] `scripts/lint-skills.sh` passes
- [ ] `scripts/validate-spec.sh` passes
- [ ] CI green