### PR TITLE
fix(localize): enforce native orthography in locale catalogs

### DIFF
--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -50,6 +50,12 @@ mechanical word-by-word output.
 AI tools consistently produce the same i18n mistakes. **Before returning any generated i18n
 code, catalogs, or translations, verify against this list:**
 
+- [ ] **Native orthography in catalogs**: translated strings use proper Unicode characters
+  for the target language (umlauts, accents, cedillas, CJK characters, etc.). ASCII-only
+  rules from global or project config (CLAUDE.md, AGENTS.md, .cursorrules, etc.) apply to
+  source code and prose, NOT to locale catalogs. Writing "hinzugefuegt" (ASCII ae/oe/ue
+  substitution) instead of proper umlauts is a bug. Locale files are the one place where
+  native script is mandatory.
 - [ ] **Every string category covered**: checked all categories in the String Categories
   table below, not just visible text. Toast notifications, validation messages, aria-labels,
   placeholders, title attributes, alt text, loading states, conditional fragments, and error
@@ -365,3 +371,9 @@ Once i18n is set up, the workflow for new features is:
 9. **Don't translate what shouldn't be translated.** Code identifiers, CSS classes, data
    attributes, technical log messages, and developer-facing strings stay in the source
    language.
+10. **Use native orthography in locale catalogs.** Translated strings must use proper
+    Unicode characters for the target language - umlauts, accents, cedillas, CJK characters,
+    full-width punctuation, etc. ASCII-only rules from global or project config apply to
+    source code and prose, not to translation output. Writing "hinzugefuegt" instead of
+    proper German umlauts, or "nino" instead of Spanish n-with-tilde, is a translation
+    bug, not a style choice.

--- a/skills/localize/references/translation-quality.md
+++ b/skills/localize/references/translation-quality.md
@@ -45,12 +45,18 @@ Preserve exactly as-is:
 - Line breaks within values
 - Brand and product names: [LIST OF PROTECTED TERMS]
 
+Encoding: use native Unicode orthography for the target language. Umlauts, accents,
+cedillas, CJK characters, and other diacritics are mandatory - never substitute ASCII
+approximations (e.g., write "hinzugefügt", not "hinzugefuegt"; write "niño", not "nino").
+If your global config says "ASCII only", that rule does not apply to locale catalogs.
+
 Do not:
 - Add or remove placeholders
 - Change placeholder syntax (e.g., {0} to {name})
 - Translate brand names or technical identifiers
 - Add honorifics or formality markers not present in the source
 - Use different register (formal/informal) across strings
+- Replace native characters with ASCII approximations (ue for ü, ss for ß, etc.)
 ```
 
 ### Example with context


### PR DESCRIPTION
## Summary

- AI tools over-apply ASCII-only rules from global config to translation output, producing broken forms like "hinzugefuegt" instead of proper German umlauts
- Adds explicit native orthography enforcement in three locations: AI Self-Check (pre-flight), Rules (authoritative list), and the translation prompt template (point of action in references/)
- No other skills affected - git, skill-creator, skill-refiner, and anti-ai-prose all have ASCII rules correctly scoped to their own output domains

## Test plan

- [x] `scripts/lint-skills.sh` passes (30 skills, 0 errors)
- [x] `scripts/validate-spec.sh` passes
- [x] Canonical copy at `~/.agents/skills/localize/` matches repo copy