### PR TITLE
feat(skills): add dev-cycle start-to-finish workflow orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-**29 production-tested skills** - Kubernetes, Terraform, Docker, Ansible, CI/CD, HTTP APIs, databases, AI/ML, testing, virtualization, Arch Linux, networking, MCP servers, security audits, pentesting, code review, prose audits, and more.
+**32 production-tested skills** - Kubernetes, Terraform, Docker, Ansible, CI/CD, HTTP APIs, databases, AI/ML, testing, virtualization, Arch Linux, networking, MCP servers, security audits, pentesting, code review, prose audits, dev workflow orchestration, and more.
 
 Built on the [Agent Skills open standard](https://agentskills.io/specification). Works with any tool that supports it.
 

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -78,7 +78,7 @@ Before declaring finish-mode complete:
 
 - [ ] `$FORGE` detected from `git remote get-url origin` before any push/PR/merge step
 - [ ] All lint/type/test suites green - output inspected, not inferred from "exit code 0". If no toolchain was detectable, user was asked explicitly (not silently skipped)
-- [ ] `update-docs` ran and its findings were addressed (or explicitly deferred with a note)
+- [ ] `update-docs` ran over tracked AND gitignored context files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.claude/`, `.codex/`, `.opencode/`, `.planning/`); findings addressed or deferred with a note. Only tracked files were staged for commit; gitignored edits remain local
 - [ ] Current version sourced from primary manifest (or user confirmation) before proposing bumps
 - [ ] Version-bump sites checked: Dockerfile, K8s manifests, Helm Chart.yaml/values, package.json/pyproject.toml/Cargo.toml, CHANGELOG
 - [ ] `git fetch --tags origin` run before release-signal detection (local-only tag check misses remote history)
@@ -222,9 +222,11 @@ Inspect the actual output. "Exit 0" is not verification - tests that didn't run 
 
 ### Step B3: Sync docs and versions
 
-This is the gap you noticed - docs and versions get left behind. Address in two parts:
+Docs and versions get left behind. Address in two parts:
 
 **Part 1 - Delegate to `update-docs`** for README, CHANGELOG, roadmap, instruction files, companion-file drift. Invoke as a review-and-fix pass, not read-only.
+
+**Important: refresh gitignored docs too**, not just tracked ones. Files like `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.claude/`, `.codex/`, `.opencode/`, and private `.planning/` directories are commonly gitignored but are still primary context for the developer and for future AI sessions. Stale gitignored docs cause just as much confusion as stale tracked ones. Only the tracked subset gets staged for commit; gitignored updates stay local but still get made. Ask `update-docs` to sweep both sets.
 
 **Part 2 - Version-bump sites**. First read the current version from the primary source (see `references/version-bump-sites.md` for the detection script - it checks `package.json`, `pyproject.toml`, `Cargo.toml`, then falls back to the latest semver tag). If no primary source exists, ask the user what the current version is before proceeding.
 

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: dev-cycle
+description: >
+  · Start-to-finish workflow. Start: pull, branch, size-detect, spec or
+  dive in. Finish: lint/test, review, sync docs/versions, push, PR, watch
+  CI, merge, release (auto-skip if none). Forge-agnostic: GitHub, GitLab,
+  Forgejo/Gitea, Bitbucket, plain git. Delegates to git, testing,
+  code-review, update-docs, brainstorming. Triggers: 'start working',
+  'kick off', 'new branch', 'wrap up', 'ship this', 'finish and merge',
+  'ready to ship', 'close out'. Not for milestones or single git ops.
+license: MIT
+compatibility: "Requires git. Optional forge CLIs by host: gh (GitHub), glab (GitLab), tea (Forgejo/Gitea). Bitbucket uses web UI or REST API. Bare git (no remote) works via format-patch/bundle. Delegates to git, testing, code-review, update-docs, and a brainstorming skill if installed."
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-04-14"
+  effort: high
+  argument_hint: "[start|finish] [description]"
+---
+
+# Dev Cycle: Start-to-Finish Workflow
+
+Orchestrates a unit of work from branch creation to merge and release. Runs in
+two modes that typically span different sessions:
+
+- **Start mode**: pull latest, size-detect, create feature branch, brainstorm
+  spec for large work or hand off to coding for small work.
+- **Finish mode**: verify green, sync docs/versions, review, push, open PR,
+  watch CI, merge, cut release when conventions exist.
+
+Each mode delegates to purpose-built skills (`git`, `testing`, `code-review`,
+`update-docs`, brainstorming skills) rather than reimplementing them. This
+skill is the glue, not the engine.
+
+## When to use
+
+- User signals the start of a unit of work: "start working on X", "let's add Y",
+  "kick off the Z refactor", "new feature branch for ..."
+- User signals the end of a unit of work: "wrap this up", "ship this", "ready
+  to merge", "finish and release", "close out", "finalize"
+- Branch is clearly a feature branch and the user is about to stop touching code
+- A PR is about to be opened, or CI just went green on one
+
+## When NOT to use
+
+- Heavyweight, planned milestones with phases and formal requirements - use a dedicated milestone/phase skill if your environment has one (e.g., the GSD family `gsd-new-milestone` / `gsd-plan-phase` / `gsd-execute-phase`). Skip this skill entirely for multi-week coordinated initiatives with stakeholders.
+- Single git operations (just commit, just push, just cut a release) - use **git**
+- Roadmap idea capture without starting code - use **roadmap**
+- Pure brainstorming without any start-of-work intent - use a brainstorming skill directly
+- Post-merge retrospective or documentation cleanup alone - use **update-docs**
+- Full repo audits (security, bugs, slop) - use **full-review** or **deep-audit**
+
+## Related Skills
+
+- **git** - branch creation, commits, push, PR/MR. This skill calls git for the mechanical steps; git knows the forge conventions.
+- **testing** - runs lint/type/unit/integration suites. Finish mode invokes it before review.
+- **code-review** - final correctness pass before push. Finish mode invokes it after tests are green.
+- **update-docs** - sweeps README/CHANGELOG/roadmap/instruction files for drift. Finish mode invokes it to close the doc-gap you've noticed.
+- **docker** - when the unit of work touches `Dockerfile`, `docker-compose*.yml`, or container images. Finish mode's version-bump step updates image tags here.
+- **kubernetes** - when the work touches K8s manifests, Kustomize overlays, or Helm charts. Version-bump step touches `Chart.yaml` and image references.
+- **ci-cd** - when the change modifies pipeline config. The CI-watch step in finish mode depends on working pipelines; if CI itself changed, exercise caution.
+- **roadmap** - if the repo has a gitignored ROADMAP.md, finish mode checks off shipped items.
+- **superpowers:brainstorming** (optional, external to this collection) - start mode uses it for large work if installed. Falls back to other brainstorming skills (e.g., `gsd-explore`), then inline Socratic questioning. See start.md Step A4 for the full fallback chain.
+
+---
+
+## AI Self-Check
+
+Before declaring start-mode complete:
+
+- [ ] Ran `git status` and `git pull --ff-only` (or equivalent) - working tree is clean and up to date
+- [ ] New branch created from the base branch (not from another feature branch); branch name follows repo convention
+- [ ] Size classification stated explicitly (small/medium/large) with the signals that drove it
+- [ ] For large work: a spec file was produced, or a brainstorming skill was invoked and its output captured
+- [ ] Handoff line told the user what skill(s) to reach for next (e.g., "this touches Postgres - use **databases** when modifying migrations")
+- [ ] No code was written in start mode unless the task was explicitly small
+
+Before declaring finish-mode complete:
+
+- [ ] `$FORGE` detected from `git remote get-url origin` before any push/PR/merge step
+- [ ] All lint/type/test suites green - output inspected, not inferred from "exit code 0". If no toolchain was detectable, user was asked explicitly (not silently skipped)
+- [ ] `update-docs` ran and its findings were addressed (or explicitly deferred with a note)
+- [ ] Current version sourced from primary manifest (or user confirmation) before proposing bumps
+- [ ] Version-bump sites checked: Dockerfile, K8s manifests, Helm Chart.yaml/values, package.json/pyproject.toml/Cargo.toml, CHANGELOG
+- [ ] `git fetch --tags origin` run before release-signal detection (local-only tag check misses remote history)
+- [ ] Release convention detected via 2+ independent signals before attempting a release
+- [ ] `code-review` ran on the diff against base, not against HEAD alone
+- [ ] PR/MR body includes summary + test plan; no AI attribution trailers
+- [ ] CI watched to completion with forge-appropriate verification (e.g., `gh pr view --json statusCheckRollup`, `glab ci status --output json`, manual confirmation for Bitbucket/bare) - not merged on "probably fine"
+- [ ] For releases: tag matches the bumped version; CHANGELOG has a new section dated today; release-workflow watch used forge-appropriate exit-status flag (`gh run watch --exit-status` etc.)
+- [ ] No `--no-verify`, no `--force-push`, no destructive reset - if blocked, fix the root cause
+
+---
+
+## Workflow
+
+### Step 0: Detect mode
+
+Pick the mode from user intent + repo state. Do not assume.
+
+| Signal | Likely mode |
+|--------|-------------|
+| "start", "kick off", "new branch for", "let's build", no feature branch yet | **start** |
+| "ship", "wrap up", "merge this", "release", "finalize", feature branch active with commits ahead of base | **finish** |
+| Branch clean + no explicit signal | ask the user which mode |
+| User ran the skill with `start` or `finish` as an argument | honor the argument |
+
+If in doubt, determine the base branch first (`git symbolic-ref --quiet refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||'`), then:
+
+```bash
+git branch --show-current
+git log --oneline @{u}.. 2>/dev/null || git log --oneline "$BASE_BRANCH"..HEAD
+```
+
+A feature branch with commits ahead of base strongly signals finish mode.
+
+---
+
+## Mode A: Start
+
+Detailed steps live in `references/start.md`. Summary:
+
+### Step A1: Verify clean state and pull
+
+Run these, stopping on any failure:
+
+```bash
+git rev-parse --is-inside-work-tree  # must be inside a git repo
+git status --porcelain               # must be empty; if not, stash or commit first
+git fetch origin --prune
+git checkout "$BASE_BRANCH"          # usually main or master
+git pull --ff-only                   # refuse non-fast-forward
+```
+
+If `BASE_BRANCH` is unknown, read it from `git symbolic-ref refs/remotes/origin/HEAD` or ask the user. Never guess between `main` and `master` - wrong base means a botched branch.
+
+### Step A2: Size-detect
+
+Read `references/size-heuristics.md` for the full table. Fast path:
+
+- **Small** (dive in): typo, rename, dep bump, single-file fix, <20 LOC estimated, user said "quick"/"tiny"
+- **Large** (brainstorm): new feature, refactor, new dependency, public API change, multi-module, user said "properly" or "design"
+- **Ambiguous**: ask 1-2 disambiguating questions; default to large if uncertain
+
+State the classification and the signals: "Classifying this as **large** because it adds a new public endpoint and touches the auth module."
+
+### Step A3: Create the feature branch
+
+Delegate branch naming and creation to the **git** skill. If it isn't available, use the repo's convention (grep recent branches for pattern) or a sensible default like `type/short-description` (e.g., `feat/oauth-login`, `fix/token-refresh-race`).
+
+```bash
+git checkout -b "$BRANCH_NAME"
+```
+
+### Step A4: For large work, brainstorm or spec
+
+Try skills in this order, stopping at the first that succeeds:
+
+1. `superpowers:brainstorming` (the superpowers brainstorming skill)
+2. Any other installed brainstorming skill (e.g., `brainstorm`, `brainstorming`, `gsd-explore`)
+3. **Inline Socratic fallback** - ask the user these questions one at a time, then write a spec file:
+   - What's the goal in one sentence?
+   - What does success look like (measurable outcome)?
+   - What's explicitly out of scope?
+   - What are the hardest constraints (performance, compatibility, deadlines)?
+   - What could go wrong or surprise us?
+   - Any existing code/skills/patterns to reuse?
+
+**Headless/non-interactive contexts** (Claude Code `--bare`, Codex `exec`, Cursor Automations) cannot prompt the user. If a brainstorming skill is unavailable AND the environment is non-interactive, write a minimal `SPEC.md` with Goal/Constraints/Risks populated from available context (issue body, branch name, git log), mark unknowns with `TODO:` so they're easy to find later, and continue to handoff. Do not block waiting for answers that can't come.
+
+Write the spec to `SPEC.md` at the repo root (or `specs/<branch-name>.md` if the repo already has a `specs/` dir). Commit it as the first commit on the new branch so the start point is recorded. Spec file format in `references/start.md`.
+
+### Step A5: Hand off
+
+End start mode with a clear handoff:
+
+- State the branch name
+- State the classification
+- Point the user at skills that fit the domain ("touches Dockerfile - use **docker** when editing", "adds K8s manifests - use **kubernetes**")
+- Remind the user to invoke **dev-cycle** in finish mode when ready to ship
+
+Do not continue into implementation - that's the user's next session.
+
+---
+
+## Mode B: Finish
+
+Detailed steps live in `references/finish.md`. Summary:
+
+### Step B1: Pre-close audit and forge detection
+
+First, detect the forge - every later step (push, PR, CI watch, merge, release) dispatches on it. See `references/finish.md` Step B1 for the full detection block. Short version: read `git remote get-url origin`, pattern-match on host, set `$FORGE` to one of `github | gitlab | forgejo | bitbucket | unknown | bare`. Forgejo and Gitea share a CLI (`tea`) and are collapsed into the single value `forgejo`.
+
+Then sanity-check the branch:
+
+```bash
+# Staged or modified files block closing. Untracked files are fine (not part of HEAD).
+git diff --cached --stat; git diff --stat
+git log --oneline "$BASE_BRANCH"..HEAD   # commits exist on this branch
+git diff "$BASE_BRANCH"..HEAD --stat     # scope sanity check
+```
+
+If the branch has no commits or the diff is empty, stop - there's nothing to ship.
+
+### Step B2: Run lint, type, and tests
+
+Delegate to the **testing** skill with instruction "run lint, type checks, and tests; surface any failures".
+
+If the testing skill isn't installed, detect the toolchain. Check in order - first match wins. If no language manifest matches, **continue** to task runners and custom scripts; don't give up:
+
+- **Language manifests**: `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `Gemfile`, `composer.json`, `pom.xml`, `build.gradle*`, `mix.exs`, `Package.swift`
+- **Task runners**: `Makefile` with `lint`/`test`/`check` targets, `justfile`, `Taskfile.yml`
+- **Custom scripts**: executable files in `scripts/` or `bin/` whose names match `lint|test|check|ci|validate|verify`
+- **Documented commands**: grep `README.md` / `CONTRIBUTING.md` for script invocations
+
+Full detection table and the quick-scan commands live in `references/finish.md`.
+
+**If nothing detectable**: stop and ask the user how to verify. Do NOT silently skip - a finish-mode report with no verification run is a false green. Offer: (a) run a command they'll provide, (b) skip with explicit acknowledgement, (c) abort.
+
+Inspect the actual output. "Exit 0" is not verification - tests that didn't run also return 0. Confirm the suite was exercised.
+
+**If anything is red, stop.** Do not proceed. Fix the root cause (or ask the user to), then re-run. Never use `--no-verify` or skip failing tests.
+
+### Step B3: Sync docs and versions
+
+This is the gap you noticed - docs and versions get left behind. Address in two parts:
+
+**Part 1 - Delegate to `update-docs`** for README, CHANGELOG, roadmap, instruction files, companion-file drift. Invoke as a review-and-fix pass, not read-only.
+
+**Part 2 - Version-bump sites**. First read the current version from the primary source (see `references/version-bump-sites.md` for the detection script - it checks `package.json`, `pyproject.toml`, `Cargo.toml`, then falls back to the latest semver tag). If no primary source exists, ask the user what the current version is before proceeding.
+
+Then find and update version strings. Common sites:
+
+- `Dockerfile` (LABEL version, image tags, default ARGs)
+- `docker-compose*.yml` (image tags)
+- `k8s/**/*.yaml` and `kustomize/**/*.yaml` (`image:` fields)
+- `helm/**/Chart.yaml` (`version` and `appVersion`) and `values.yaml` (image tag)
+- `package.json` (`version`)
+- `pyproject.toml` (`version` under `[project]` or `[tool.poetry]`)
+- `Cargo.toml` (`version`)
+- `CHANGELOG.md` (new section with today's date)
+- Version badges in `README.md`
+
+Propose a diff. Do not silently edit. The user confirms the version bump scope.
+
+**Part 3 - Tests reflect new version**. If tests reference version strings (snapshots, integration tests pulling images by tag, fixtures hardcoding versions), update them and rerun the suite.
+
+### Step B4: Final code review
+
+Delegate to the **code-review** skill with the diff scope: `BASE_BRANCH..HEAD`. The review covers the full change, not just the last commit.
+
+If the review surfaces blocking issues, fix them and loop back to Step B2 (tests may now be affected).
+
+### Step B5: Push and open PR
+
+Delegate to the **git** skill - it handles forge routing. If unavailable, dispatch on `$FORGE` from Step B1. Full per-forge commands in `references/finish.md`.
+
+| `$FORGE` | Push + PR |
+|----------|-----------|
+| `github` | `git push -u origin <branch>` + `gh pr create` |
+| `gitlab` | same push + `glab mr create --target-branch` |
+| `forgejo` | same push + `tea pulls create --base --head` |
+| `bitbucket` | push + announce web-UI URL (no official CLI) |
+| `unknown` (self-hosted) | push + announce branch URL; ask user what forge this is |
+| `bare` (no remote) | `git format-patch` or `git bundle` - share file with reviewer |
+
+No AI attribution trailers. No "Generated with Claude Code" lines. Strip them from any commit-helper template before committing.
+
+### Step B6: Watch CI
+
+Dispatch on `$FORGE`. Every tool has a watch trap - default exit code may not reflect failure.
+
+| `$FORGE` | Command | Trap |
+|----------|---------|------|
+| `github` | `gh pr checks --watch --fail-fast` then verify via `gh pr view --json statusCheckRollup` | exits 0/1/8; treat anything non-zero as not-ready |
+| `gitlab` | `glab ci status --live` then `glab mr view --output json` | `--live` doesn't always exit non-zero on failure; verify explicitly |
+| `forgejo` | `tea pulls status <pr>` or `tea actions list` (varies by instance) | Actions API is newer; fall back to web UI if command missing |
+| `bitbucket` | No CLI - watch web UI or poll Pipelines REST API | Manual confirmation before merge |
+| `unknown` | Ask user which CI is wired (Jenkins, Drone, Woodpecker, Buildkite, Teamcity) and point them at the URL | Assume nothing |
+| `bare` | No remote CI; rely on B2 local output | N/A |
+
+If CI fails, fix the root cause - don't retry hoping for flakiness to resolve. If genuinely flaky (rerunning the identical commit passes), rerun and note it in the PR body.
+
+### Step B7: Merge
+
+Once CI is green, dispatch on `$FORGE`:
+
+| `$FORGE` | Merge command | Delete-branch flag |
+|----------|---------------|--------------------|
+| `github` | `gh pr merge --squash` / `--rebase` / `--merge` | `--delete-branch` |
+| `gitlab` | `glab mr merge --squash` / `--rebase` / (default = merge commit) | `--remove-source-branch` |
+| `forgejo` | `tea pulls merge <pr> --style squash\|merge\|rebase\|rebase-merge` | Delete via web UI or follow-up `git push origin --delete <branch>` |
+| `bitbucket` | Web UI or REST API with `"merge_strategy": "squash"` | `"close_source_branch": true` |
+| `unknown`/`bare` | Local: `git merge --no-ff` (or `--ff-only` after rebase) on base, push, `git branch -d` | N/A |
+
+Check the repo's merge convention before picking a style. If multiple are allowed, match recent merge history: `git log --merges --oneline "$BASE_BRANCH" | head -5`.
+
+### Step B8: Release (conditional)
+
+**First, `git fetch --tags origin` if a remote exists** - local-only tag checks miss remote release history and cause false-negative skips. Then:
+
+**Auto-skip unless at least 2 independent release signals are present.** A single stale tag or lonely CHANGELOG is not a convention. Signal catalog and detection commands live in `references/finish.md` Step B8. Summary:
+
+- Semver tags (`git tag -l 'v[0-9]*'` after `git fetch --tags`)
+- CHANGELOG / CHANGES / HISTORY file
+- Release workflow file (GitHub Actions, GitLab CI, Forgejo/Gitea Actions, Woodpecker, Drone)
+- Forge-native release history (`gh`/`glab`/`tea` release list)
+- Published package (non-private `package.json`, `[project]` in `pyproject.toml`, `[package]` in `Cargo.toml`)
+
+**Hard skips**: `package.json` has `"private": true`, or `$FORGE=bare` with no local-tag-only intent (ask user).
+
+If release-capable:
+
+1. Determine bump type (breaking -> major, feature -> minor, fix -> patch). Ask if unclear.
+2. Guard against existing tag via `git rev-parse --verify --quiet "refs/tags/v$NEW_VERSION"` (note: `git tag -l` always exits 0 so it cannot be used as a guard).
+3. Tag the merge commit on `$BASE_BRANCH` and push.
+4. Create a forge-native release object (`gh release create`, `glab release create`, `tea releases create`) - Bitbucket and bare have no platform release object; the tag itself IS the release.
+5. Watch the release workflow with the forge-appropriate exit-status flag. **Every forge has a default-exit trap** (see Rule 6 and `references/finish.md` for per-forge commands).
+
+Full procedures, extract-changelog function, and per-forge release-watch commands in `references/finish.md`.
+
+---
+
+## Rules
+
+1. **Read before edit.** Always read files you're about to modify in the current session. No exceptions.
+2. **Never force-push, never `--no-verify`, never skip failing tests.** If a hook or test is in the way, fix the underlying issue. Destructive shortcuts are a red flag, not a convenience.
+3. **Delegate, don't reimplement.** `git`, `testing`, `code-review`, `update-docs`, and brainstorming skills know their domains better than this skill does. Call them.
+4. **No AI attribution in git artifacts.** No `Co-Authored-By` trailers, no "Generated with Claude Code" lines, no robot emoji in commit messages, PR titles/bodies, or release notes. Strip from any commit-helper templates before committing.
+5. **Confirm before release.** Release cutting is a forge-visible action. Announce the version, bump sites, and plan to the user; get explicit confirmation before pushing the tag.
+6. **Inspect CI output, don't infer it.** Every forge's watch command has a default-exit trap: `gh run watch` exits 0 on workflow failure without `--exit-status`; `gh pr checks --watch` returns when done, not only when green; `glab ci status --live` prints but doesn't always exit non-zero on pipeline failure. After any watch, verify with an explicit status query (`gh pr view --json statusCheckRollup`, `glab ci status --output json`, or web-UI confirmation for forges without a CLI). Confirm every check actually passed.
+7. **Release detection is conservative.** If no convention signals are present, skip. A missing `CHANGELOG.md` plus no tags means this isn't a release-cut situation - don't create one.
+8. **Don't bundle unrelated work.** If mid-finish you notice a bug outside the branch's scope, file it (roadmap skill or an issue) - don't sneak it into the PR.
+9. **Plain ASCII only.** No em-dashes, no `--` substitutes, no curly quotes, no decorative emoji. Functional status markers (`[OK]`, `[FAIL]`, severity emoji in reports from delegated skills) are fine.
+10. **Mode boundaries are sacred.** Start mode ends with a handoff, not implementation. Finish mode starts with verification, not committing new code. Don't blur them.
+
+## Reference Files
+
+- `references/start.md` - detailed start-mode workflow, branch naming conventions, spec file template, brainstorming fallback chain (including headless-mode behavior)
+- `references/finish.md` - detailed finish-mode workflow with per-forge commands (GitHub/GitLab/Forgejo/Gitea/Bitbucket) and bare-git paths (format-patch, bundle, local merge). Covers forge detection, toolchain detection with custom-script fallback, CI watch traps, release cutting, and rollback
+- `references/size-heuristics.md` - complete size-classification table with concrete signals, edge cases, and the ambiguity-resolution questions
+- `references/version-bump-sites.md` - grep patterns and locations for version strings across common ecosystems (Docker, K8s, Helm, package managers)

--- a/skills/dev-cycle/references/finish.md
+++ b/skills/dev-cycle/references/finish.md
@@ -165,9 +165,25 @@ This is where quality slips. Address it in three parts.
 
 ### Part 1: Delegate to update-docs
 
-> "Invoke the **update-docs** skill via the Skill tool. Run in update mode (not read-only). Sweep README, CHANGELOG, roadmap, instruction files, and companion files. Address drift caused by the current branch's changes."
+> "Invoke the **update-docs** skill via the Skill tool. Run in update mode (not read-only). Sweep README, CHANGELOG, roadmap, instruction files, companion files, **AND gitignored context files** (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, files under `.claude/`, `.codex/`, `.opencode/`, and private `.planning/` directories). Address drift caused by the current branch's changes in all of them."
 
-Review its findings. Accept, modify, or defer each. Defer only with a note in the PR body ("docs for X tracked in #Y, not blocking this merge").
+**Why gitignored files still need updating**: these files are often agent instruction files, developer context notes, or per-AI-tool config. They're gitignored because they're local or personal, not because they're disposable. Stale instruction files mislead the next session just as badly as stale READMEs. Keep them current even though they won't be staged.
+
+**Staging discipline**: after update-docs runs, classify each modified file:
+
+```bash
+# Tracked docs (stage for commit)
+git diff --name-only                              # modified, tracked
+
+# Gitignored docs (leave unstaged; verify they ARE gitignored, not new-untracked)
+git ls-files --others --exclude-standard          # untracked (new files - review before ignoring)
+comm -12 <(git ls-files --others | sort) <(git status --short | awk '{print $2}' | sort)
+# Or simply: for each ??-marked file in `git status`, check with `git check-ignore <file>`
+```
+
+Only `git add` the tracked set. Gitignored edits land locally but are intentionally out of the PR.
+
+Review update-docs findings. Accept, modify, or defer each. Defer only with a note in the PR body ("docs for X tracked in #Y, not blocking this merge").
 
 ### Part 2: Version bumps
 

--- a/skills/dev-cycle/references/finish.md
+++ b/skills/dev-cycle/references/finish.md
@@ -1,0 +1,748 @@
+# Dev Cycle: Finish Mode Reference
+
+Detailed procedures for finishing a unit of work - from verification through merge and release.
+
+## When this reference loads
+
+Load when the user invokes **dev-cycle** in finish mode (see SKILL.md Step 0). Not needed in start mode.
+
+---
+
+## Step B1 details: Pre-close audit and forge detection
+
+Before running expensive checks, sanity-check the branch **and identify the forge**. Every subsequent step that touches a remote (push, PR, CI watch, merge, release) dispatches on `$FORGE`.
+
+### Detect the forge
+
+```bash
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+FORGE=""
+case "$REMOTE_URL" in
+  "")                           FORGE=bare ;;         # no remote at all, purely local
+  *github.com[:/]*)             FORGE=github ;;
+  *gitlab.com[:/]*|*gitlab.*)   FORGE=gitlab ;;       # gitlab.com or self-hosted gitlab
+  *codeberg.org[:/]*)           FORGE=forgejo ;;      # Codeberg runs Forgejo
+  *gitea.*|*forgejo.*)          FORGE=forgejo ;;      # self-hosted Forgejo/Gitea
+  *bitbucket.org[:/]*)          FORGE=bitbucket ;;
+  *)                            FORGE=unknown ;;      # self-hosted; CLI tool may not exist
+esac
+
+# Pick the CLI (empty if none available)
+FORGE_CLI=""
+case "$FORGE" in
+  github)                 command -v gh  >/dev/null && FORGE_CLI=gh  ;;
+  gitlab)                 command -v glab >/dev/null && FORGE_CLI=glab ;;
+  forgejo)                command -v tea  >/dev/null && FORGE_CLI=tea ;;
+  bitbucket|unknown|bare) FORGE_CLI="" ;;
+esac
+
+echo "Forge: $FORGE | CLI: ${FORGE_CLI:-none}"
+```
+
+**What each value means for later steps**:
+
+| `$FORGE` | `$FORGE_CLI` | Push/PR/merge path |
+|----------|--------------|--------------------|
+| `github` | `gh` | Standard PR flow via `gh` |
+| `gitlab` | `glab` | MR flow via `glab` |
+| `forgejo` | `tea` | PR flow via `tea` (Codeberg, self-hosted Forgejo/Gitea) |
+| `bitbucket` | (none - no official CLI) | Manual push + create PR in web UI; skill provides the URL |
+| `unknown` | (none) | Self-hosted. Ask user: is this a Gitea/GitLab/other? If unclear, treat as bare. |
+| `bare` | n/a | No remote; share via format-patch or direct ref-push. Manual integration. |
+
+If `$FORGE_CLI` is empty for a forge that normally has one, install it (`brew install gh` etc.) or fall through to the manual web-UI path. Don't silently skip the step.
+
+### Sanity-check the branch
+
+```bash
+# Staged or modified files? (untracked files are fine - they're not part of HEAD)
+git diff --cached --stat; git diff --stat
+# If either is non-empty: commit, stash, or abort. Untracked files in `git status` output
+# are NOT a reason to stop - only staged/modified matter here.
+
+# Commits ahead of base?
+git log --oneline "$BASE_BRANCH"..HEAD
+# If empty: branch has no unique commits. Nothing to ship.
+
+# Diff scope sanity check
+git diff "$BASE_BRANCH"..HEAD --stat
+
+# Remote sync (skip if $FORGE is bare)
+if [[ "$FORGE" != "bare" ]]; then
+  git fetch origin
+  git rev-list --left-right --count "origin/$BRANCH_NAME...HEAD" 2>/dev/null
+  # left=0 right=N: N local commits not yet pushed (normal)
+  # left=N right=0: N remote commits not yet pulled (pull first)
+  # left=N right=M: diverged (ask user)
+fi
+```
+
+Determine the base branch from the PR target if one exists, else from `origin/HEAD`. For `$FORGE=bare`, ask the user - there's no remote HEAD to read.
+
+---
+
+## Step B2 details: Lint, type, test
+
+### Delegate to the testing skill
+
+Prefer this over a hand-rolled invocation:
+
+> "Invoke the **testing** skill via the Skill tool. Run the repo's full lint, type, and test suites. Report pass/fail with evidence. Do not silence failures or rerun with exclusions."
+
+If the testing skill isn't available, detect the toolchain and run manually.
+
+### Toolchain detection + commands
+
+Check in order - first match wins. If no language manifest matches, **keep going** to the task-runner and custom-script rows. Many repos (infrastructure, skill collections, dotfiles, mixed-language monorepos) have no language manifest at all.
+
+| Signal | Commands |
+|--------|----------|
+| `package.json` with `"lint"`/`"typecheck"`/`"test"` scripts | `bun run lint && bun run typecheck && bun test` (or npm/pnpm/yarn) |
+| `package.json` without lint/test scripts | Check for `eslint`, `tsc`, `jest`/`vitest` in devDependencies; run directly |
+| `pyproject.toml` + `ruff` config | `ruff check . && ruff format --check . && mypy . && pytest` |
+| `pyproject.toml` without ruff | `flake8 \|\| pylint` + `mypy` + `pytest` |
+| `go.mod` | `gofmt -l . && go vet ./... && go test ./...` |
+| `Cargo.toml` | `cargo fmt --check && cargo clippy -- -D warnings && cargo test` |
+| `Gemfile` | `bundle exec rubocop && bundle exec rspec` |
+| `composer.json` (PHP) | `composer run-script lint && composer test` (check scripts block) |
+| `pom.xml` / `build.gradle*` | `mvn verify` / `./gradlew check` |
+| `mix.exs` | `mix credo && mix test` |
+| `Package.swift` | `swift build && swift test` |
+| `Makefile` with `lint`/`test`/`check` targets | `make lint test` (or whichever targets exist - grep for target names) |
+| `justfile` | `just --list` to discover; run obvious candidates like `just lint test` |
+| `Taskfile.yml` | `task --list` then run discovered tasks |
+| `scripts/` dir with executable bash/python | Look for `lint`, `test`, `check`, `ci`, `validate`, `verify` in filenames. Run found scripts. |
+| `bin/` dir with executable scripts | Same pattern as `scripts/` |
+| Nx / Turbo monorepo | `nx run-many -t lint test` or `turbo run lint test` |
+| **No detectable toolchain** | **Stop and ask the user**: "I can't detect a lint/test convention in this repo. How should I verify the change? Options: (a) run a specific command you'll provide, (b) skip verification with explicit acknowledgement, (c) abort finish-mode." Do NOT silently proceed - a finish report with no actual verification is a false green. |
+
+### Detection heuristic
+
+```bash
+# Quick scan for custom entry points when no manifest matches
+find . -maxdepth 2 -type f \( -name Makefile -o -name justfile -o -name Taskfile.yml -o -name Taskfile.yaml \) 2>/dev/null
+find scripts bin -maxdepth 2 -type f -executable 2>/dev/null | \
+  grep -Ei '(lint|test|check|ci|validate|verify)' | head -20
+# Also check README/CONTRIBUTING for documented commands
+grep -Ei '^\s*(\$ )?(bash |sh )?\./?(scripts|bin)/[a-z-]+\.sh' README.md CONTRIBUTING.md 2>/dev/null
+```
+
+If this returns nothing useful AND no language manifest matched, hit the "No detectable toolchain" row - ask the user, don't guess.
+
+### Inspect output, don't infer
+
+```bash
+# WRONG - trusting exit code alone
+bun test && echo "ok"
+
+# RIGHT - capture output, verify tests actually ran
+bun test 2>&1 | tee /tmp/test-output.log
+grep -E "(passed|failed|skipped|tests)" /tmp/test-output.log
+```
+
+Common traps:
+
+- Exit 0 with "no tests found" - the runner couldn't locate tests. Fix config.
+- Exit 0 with skipped suites - check what was skipped and why.
+- Flaky tests - rerun identical commit to confirm. Don't retry until green.
+
+### Red = stop
+
+If anything is red, stop the workflow. Fix the root cause. Do not:
+
+- Use `--no-verify`
+- Add `skip` / `xit` / `pytest.mark.skip` to make tests pass
+- Commit with "will fix later"
+- Merge and file a follow-up ticket
+
+If the failure is outside the branch's scope (pre-existing breakage), stop and ask the user how to proceed.
+
+---
+
+## Step B3 details: Doc and version sync
+
+This is where quality slips. Address it in three parts.
+
+### Part 1: Delegate to update-docs
+
+> "Invoke the **update-docs** skill via the Skill tool. Run in update mode (not read-only). Sweep README, CHANGELOG, roadmap, instruction files, and companion files. Address drift caused by the current branch's changes."
+
+Review its findings. Accept, modify, or defer each. Defer only with a note in the PR body ("docs for X tracked in #Y, not blocking this merge").
+
+### Part 2: Version bumps
+
+See `version-bump-sites.md` for grep patterns and locations. Walk the list:
+
+1. Identify all version strings in the repo
+2. Determine the new version from the change scope (major/minor/patch)
+3. Propose a diff to the user - **do not auto-edit**
+4. Apply after confirmation
+5. Re-run tests if version strings appear in fixtures
+
+### Part 3: CHANGELOG entry
+
+If a CHANGELOG exists (usually `CHANGELOG.md`):
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- {new features from this branch}
+
+### Changed
+- {behavior changes}
+
+### Fixed
+- {bug fixes}
+
+### Removed
+- {deprecations/removals}
+```
+
+Match the existing style. Some repos use Keep a Changelog, some use emoji prefixes, some conventional-commits-derived. Preserve their format.
+
+### Part 4: Tests referencing version
+
+Grep for the old version string across tests:
+
+```bash
+rg --fixed-strings "$OLD_VERSION" test/ tests/ spec/ __tests__/
+rg --fixed-strings "$OLD_VERSION" '*.snap'
+```
+
+Update or regenerate snapshots. Rerun tests.
+
+---
+
+## Step B4 details: Final code review
+
+### Delegate to code-review
+
+> "Invoke the **code-review** skill via the Skill tool. Review the diff `{BASE_BRANCH}..HEAD`. Focus on correctness, edge cases, and convention violations. Return blocking issues separately from suggestions."
+
+Pass the base branch, not HEAD alone. The reviewer needs to see the full change set.
+
+### Triage
+
+- **Blocking**: fix before push. Loop back to Step B2 after fixing.
+- **Should-fix**: fix in this PR if quick, else file a follow-up.
+- **Nit**: ignore or fix at your discretion.
+
+Document the triage in the PR body if the review found issues.
+
+---
+
+## Step B5 details: Push and PR
+
+The **git** skill handles this for every forge. Prefer delegation:
+
+> "Invoke the **git** skill via the Skill tool. Push the current branch to origin (with upstream tracking) and open a PR/MR against `{BASE_BRANCH}`. Conventional-commit title, summary + test plan in body. No AI attribution trailers."
+
+If the git skill isn't available, dispatch on `$FORGE` from Step B1. Skip to "No forge CLI" if `$FORGE_CLI` is empty.
+
+### GitHub (`$FORGE=github`, `gh`)
+
+```bash
+git push -u origin "$BRANCH_NAME"
+
+gh pr create \
+  --base "$BASE_BRANCH" \
+  --title "feat(scope): short description" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Bullet 1
+- Bullet 2
+
+## Test plan
+
+- [x] Lint clean
+- [x] Type checks pass
+- [x] Unit tests green
+- [x] update-docs run; drift addressed
+- [x] code-review run; issues resolved
+
+Closes #123
+EOF
+)"
+```
+
+Recent-PR style check: `gh pr list --state merged --limit 10 --json title --jq '.[].title'`
+
+### GitLab (`$FORGE=gitlab`, `glab`)
+
+```bash
+git push -u origin "$BRANCH_NAME"
+
+glab mr create \
+  --target-branch "$BASE_BRANCH" \
+  --title "feat(scope): short description" \
+  --description "$(cat <<'EOF'
+## Summary
+- Bullet 1
+
+## Test plan
+- [x] Lint/type/tests green
+- [x] Docs + versions synced
+EOF
+)"
+
+# Capture the MR number for later steps (B6 watch, B7 merge).
+# glab auto-detects from the current branch for most commands, but being explicit avoids surprises.
+MR_IID=$(glab mr view --output json 2>/dev/null | jq -r '.iid // empty')
+echo "MR IID: ${MR_IID:-unknown}"
+```
+
+Recent-MR style: `glab mr list --state merged --per-page 10 --output json | jq -r '.[].title'`
+
+### Forgejo / Gitea / Codeberg (`$FORGE=forgejo`, `tea`)
+
+```bash
+git push -u origin "$BRANCH_NAME"
+
+tea pulls create \
+  --base "$BASE_BRANCH" \
+  --head "$BRANCH_NAME" \
+  --title "feat(scope): short description" \
+  --description "$(cat <<'EOF'
+## Summary
+...
+## Test plan
+...
+EOF
+)"
+```
+
+### Bitbucket (`$FORGE=bitbucket`, no official CLI)
+
+Push the branch, then open the PR in the web UI:
+
+```bash
+git push -u origin "$BRANCH_NAME"
+
+# Compose the create-PR URL (Bitbucket Cloud)
+WORKSPACE_REPO=$(git remote get-url origin | sed -E 's|.*bitbucket.org[:/]([^.]+)(\.git)?|\1|')
+echo "Open: https://bitbucket.org/$WORKSPACE_REPO/pull-requests/new?source=$BRANCH_NAME&dest=$BASE_BRANCH"
+```
+
+Announce the URL to the user. Cannot auto-create the PR without the CLI or the Bitbucket API (which requires auth setup). If the user has scripted the API, delegate via the **git** skill.
+
+### No forge CLI available (`$FORGE=unknown` or tool missing)
+
+Push the branch. Produce a shareable reference for manual review. **Let push errors surface** - auth failures, hook rejections, and permission errors are fixable; silencing them wastes time:
+
+```bash
+# Push will fail loudly on auth/hook/permission issues - that's correct.
+# Only fall through to bare-git path if there is genuinely no remote.
+if git remote get-url origin >/dev/null 2>&1; then
+  git push -u origin "$BRANCH_NAME"   # surface the real error if it fails
+  REMOTE_URL=$(git remote get-url origin | sed 's|\.git$||')
+  echo "Branch pushed to: $REMOTE_URL (branch: $BRANCH_NAME)"
+  echo "Review via the forge's web UI - skill doesn't know the PR URL pattern for self-hosted $FORGE."
+else
+  echo "No remote configured. Fall through to the Bare git (\$FORGE=bare) path below."
+fi
+```
+
+Tell the user what self-hosted forge this is so the skill can route correctly next time. Once identified, `$FORGE` can be set manually.
+
+### Bare git (`$FORGE=bare`, no remote at all)
+
+No push, no PR. Two share options:
+
+```bash
+# Option A: format-patch - email-friendly, works with `git am` to apply
+mkdir -p /tmp/dev-cycle-patches
+git format-patch "$BASE_BRANCH..HEAD" -o "/tmp/dev-cycle-patches/$BRANCH_NAME"
+echo "Patches in /tmp/dev-cycle-patches/$BRANCH_NAME - share via email/chat. Reviewer applies with: git am <files>"
+
+# Option B: bundle - portable single-file format, preserves history
+git bundle create "/tmp/$BRANCH_NAME.bundle" "$BASE_BRANCH..HEAD"
+echo "Bundle: /tmp/$BRANCH_NAME.bundle - share with reviewer. They apply with: git pull /path/to/bundle $BRANCH_NAME"
+```
+
+CI and merge are entirely manual. Skip B6 (no CI to watch unless locally configured). Merge happens via Step B7 bare-git path.
+
+### PR title conventions
+
+Match the repo's existing style. Common patterns:
+
+- Conventional commits: `feat(auth): add OAuth login`
+- Brief imperative: `Add OAuth login`
+- Issue-prefixed: `[#123] Add OAuth login`
+
+### Strip AI attribution
+
+Per the global rule: no `Co-Authored-By`, no "Generated with Claude Code", no robot emoji, no AI markers anywhere. Commit-helper templates inject these - strip before commit/PR/MR.
+
+If you notice the trailer in the final preview, delete it before confirming. Merged PRs preserve trailers forever.
+
+---
+
+## Step B6 details: Watch CI
+
+Dispatch on `$FORGE`. If no CI is configured (no workflow files, no `.gitlab-ci.yml`, etc.), skip this step and note it to the user.
+
+### GitHub (`$FORGE=github`)
+
+```bash
+# Blocks until all checks complete, exits non-zero if any fail
+gh pr checks --watch --fail-fast
+
+# After it returns, confirm no non-SUCCESS conclusions remain
+gh pr view --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | select(.conclusion != "SUCCESS" and .conclusion != null)'
+```
+
+`gh pr checks` exit codes: `0` = all green, `1` = at least one failure, `8` = some checks still pending. Treat anything non-zero as "not ready to merge." Never infer success from "the command returned" alone - iterate the `statusCheckRollup` array.
+
+### GitLab (`$FORGE=gitlab`)
+
+```bash
+# Live pipeline view (blocking, prints updates as jobs progress)
+glab ci status --live
+
+# Programmatic status - inspect the pipeline state of the MR
+glab mr view --output json | jq '.pipeline | {status: .status, web_url: .web_url}'
+```
+
+`glab ci status --live` does not emit JSON. For scripted checks, poll `glab mr view` until `.pipeline.status` reaches `success` / `failed` / `canceled`. Treat anything other than `success` as not ready to merge.
+
+### Forgejo / Gitea / Codeberg (`$FORGE=forgejo`)
+
+```bash
+# Check status of a PR by number (from the create-PR output)
+tea pulls status "$PR_NUMBER"
+
+# Or list runs for the branch (Actions-enabled instances)
+tea actions list --repo "$(git remote get-url origin | sed -E 's|.*[:/]([^/]+/[^/]+)\.git$|\1|')"
+```
+
+Forgejo/Gitea Actions API is newer and less uniform than GitHub's. If `tea actions` is unavailable on the instance's version, fall through to web-UI confirmation.
+
+### Bitbucket (`$FORGE=bitbucket`)
+
+No official CLI. Options:
+- Watch in the web UI (Pull Request view shows Pipeline status)
+- Poll the REST API if scripted: `curl -u "$USER:$APP_PASSWORD" "https://api.bitbucket.org/2.0/repositories/$WORKSPACE_REPO/pipelines/?sort=-created_on&pagelen=5"`
+
+Announce the Pipelines URL to the user and wait for their confirmation. Do not merge until they confirm green.
+
+### Self-hosted / unknown (`$FORGE=unknown`)
+
+Ask the user: "What CI is this repo wired to? (Jenkins, Drone, Woodpecker, Buildkite, Teamcity, in-repo Actions, other)". Give them the branch URL to watch. Do not assume green.
+
+### Bare git (`$FORGE=bare`)
+
+No CI to watch. If the user has a local CI harness (pre-push hook, cron, `act`, `nektos/act`), they ran it before this step. Otherwise, verification relies on Step B2 local runs. Announce: "No remote CI - relying on local lint/test/review output from Step B2."
+
+### If CI fails (any forge)
+
+1. Read the failing job's logs. Don't guess.
+2. Identify root cause: flaky test, real bug, env drift, timeout, missing secret.
+3. For real bugs: fix locally, push, re-watch.
+4. For flakiness: confirm by rerunning identical commit. If confirmed flaky, rerun the job and note it in the PR. Do not fix a real bug by calling it "flaky".
+5. For env drift (CI has different versions than local): update lockfiles or CI config.
+
+Never merge with failing checks. Never bypass branch protection.
+
+---
+
+## Step B7 details: Merge
+
+Dispatch on `$FORGE`. Three merge patterns exist everywhere:
+
+- **Squash + merge** - most common; squashes all branch commits into one on base
+- **Rebase + merge** - preserves commit history linearly
+- **Merge commit** - preserves full branch history with a merge commit
+
+To pick between them when multiple are allowed, check recent merge commits:
+
+```bash
+git log --merges --oneline "$BASE_BRANCH" | head -5
+# If merges exist: project uses merge commits. If none: squash or rebase - check forge config.
+```
+
+### GitHub (`$FORGE=github`)
+
+```bash
+# Detect what the repo allows
+gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed
+
+# Pick one
+gh pr merge --squash  --delete-branch   # most common
+gh pr merge --rebase  --delete-branch
+gh pr merge --merge   --delete-branch   # merge commit
+```
+
+### GitLab (`$FORGE=gitlab`)
+
+```bash
+# Note: --delete-branch in gh is --remove-source-branch in glab
+glab mr merge --squash --remove-source-branch
+glab mr merge --rebase --remove-source-branch
+# GitLab's default is "merge commit" if no flag is passed
+glab mr merge --remove-source-branch
+```
+
+Check project settings for allowed merge methods: `glab repo view --output json | jq '{merge_method, squash_option}'`
+
+### Forgejo / Gitea (`$FORGE=forgejo`)
+
+```bash
+tea pulls merge "$PR_NUMBER" --style squash   # or: merge, rebase, rebase-merge, squash
+```
+
+Available styles depend on the repo's settings. If the style isn't allowed, the command errors - adjust and retry.
+
+### Bitbucket (`$FORGE=bitbucket`)
+
+Merge in the web UI (no official CLI). Or via REST API if scripted:
+
+```bash
+curl -X POST -u "$USER:$APP_PASSWORD" \
+  "https://api.bitbucket.org/2.0/repositories/$WORKSPACE_REPO/pullrequests/$PR_ID/merge" \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"pullrequest","close_source_branch":true,"merge_strategy":"squash"}'
+```
+
+### Self-hosted / unknown (`$FORGE=unknown`)
+
+Use whatever merge UI/API the host provides. If none, fall through to the bare-git path.
+
+### Bare git (`$FORGE=bare`)
+
+No forge, no PR to merge. Integrate locally. Detect whether a remote exists before pulling/pushing:
+
+```bash
+git checkout "$BASE_BRANCH"
+
+HAS_REMOTE=false
+git remote get-url origin >/dev/null 2>&1 && HAS_REMOTE=true
+$HAS_REMOTE && git pull --ff-only   # fail loud if remote exists and base diverged
+
+# Pick one based on the repo's convention:
+git merge --no-ff "$BRANCH_NAME"          # preserves branch history (merge commit)
+# or
+git merge --ff-only "$BRANCH_NAME"        # linear, if base hasn't moved
+# or rebase first, then fast-forward:
+# git checkout "$BRANCH_NAME" && git rebase "$BASE_BRANCH" && git checkout "$BASE_BRANCH" && git merge --ff-only "$BRANCH_NAME"
+
+# Push if a remote exists (common for self-hosted bare repos over SSH)
+$HAS_REMOTE && git push origin "$BASE_BRANCH"
+
+# Safe delete only; escalate manually if unmerged
+git branch -d "$BRANCH_NAME"
+```
+
+### After merge (all forges)
+
+Sync the local base branch. **Don't blanket-silence errors** - a failed pull or a refused branch-delete is information, not noise.
+
+```bash
+git checkout "$BASE_BRANCH"
+
+if [[ "$FORGE" != "bare" ]]; then
+  git pull --ff-only   # fail loud if base diverged
+fi
+
+# Safe delete only (-d). Do NOT escalate to -D automatically - unmerged commits
+# indicate either incomplete merge or wrong branch; stop and investigate.
+if ! git branch -d "$BRANCH_NAME" 2>/dev/null; then
+  echo "branch $BRANCH_NAME not fully merged into $BASE_BRANCH; investigate before deleting"
+fi
+```
+
+---
+
+## Step B8 details: Release
+
+### Detection - is this repo release-capable?
+
+**First, fetch remote tags.** Local-only `git tag -l` can miss tags that exist on the remote but haven't been pulled - false-negative release detection is the worst outcome of this step. Do this before any tag-based signal check:
+
+```bash
+# Fetch tags if a remote exists; let errors print but don't block on offline/auth failure
+if git remote get-url origin >/dev/null 2>&1; then
+  git fetch --tags origin 2>&1 | grep -vE '^(From |$)' || true
+fi
+```
+
+Check all signals. **Require at least 2 independent positive signals** before treating the repo as release-capable. A single stale tag on a scratch repo is not a convention. Signals below are forge-agnostic where possible; forge-specific signals only count on the matching forge.
+
+| Signal | Applies when | Command |
+|--------|--------------|---------|
+| Semver tags exist | any forge | `git tag -l 'v[0-9]*' \| head -1` (after `git fetch --tags`; match `v` + digit, not arbitrary `v*`) |
+| CHANGELOG exists | any forge | `[[ -f CHANGELOG.md ]] \|\| [[ -f CHANGES.md ]] \|\| [[ -f HISTORY.md ]]` |
+| Release workflow file | any forge | `find .github/workflows .gitlab-ci.yml .forgejo/workflows .gitea/workflows .woodpecker.yml .drone.yml 2>/dev/null \| xargs grep -lE "(release\|publish)" 2>/dev/null \| head -1` |
+| Published releases (forge-specific) | depends on `$FORGE` | see below |
+| Published package | any forge | `jq -e '.private != true and .version' package.json 2>/dev/null` or `grep -q '^\[project\]' pyproject.toml 2>/dev/null` or a non-empty `[package]` block in `Cargo.toml` |
+
+**Forge-specific "published releases" check**:
+
+```bash
+case "$FORGE" in
+  github)  [[ -n "$(gh release list --limit 1 2>/dev/null)" ]] && echo "has releases" ;;
+  gitlab)  [[ -n "$(glab release list --per-page 1 2>/dev/null)" ]] && echo "has releases" ;;
+  forgejo) tea releases list 2>/dev/null | head -n 1 | grep -q . && echo "has releases" ;;
+  *)       echo "forge-specific release history not checkable; rely on tags" ;;
+esac
+```
+
+**Hard skips** (stop, do not release):
+- `jq -e '.private == true' package.json` returns 0 - the package opted out of publication
+- No tags AND no CHANGELOG AND no release workflow - this repo has never released
+- `$FORGE=bare` AND no intention of local-only tags. Ask the user this exact question:
+  > "This repo has no remote, so there's no platform release to cut. Do you want me to (a) create a local semver tag anyway (e.g., for local versioning or a bundle distribution), (b) skip release entirely, or (c) push the tag to a specific remote I should add first?"
+
+**Ambiguous single-signal cases** (ask the user):
+- Only one tag exists and it's >6 months old - might be abandoned, might be stable. Ask.
+- CHANGELOG exists but has never had a release section populated - new repo, ask.
+
+If neither threshold met: announce "No release convention detected (signals: N of 5) - skipping release cut. Version-bump work from Step B3 still applies."
+
+### Determine bump type
+
+From conventional commits in the merged branch:
+
+- `feat:` or `feat!:` → minor (or major if breaking)
+- `fix:` → patch
+- `perf:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:` → patch (usually)
+- `BREAKING CHANGE:` footer anywhere → major
+
+If unclear, ask the user. Offer the three options with the current version shown.
+
+### Cut the release
+
+```bash
+git checkout "$BASE_BRANCH"
+git pull --ff-only  # merge commit is here now
+
+NEW_VERSION="X.Y.Z"
+# git tag -l always exits 0 - check for non-empty output instead
+if git rev-parse --verify --quiet "refs/tags/v$NEW_VERSION" >/dev/null; then
+  echo "tag v$NEW_VERSION already exists; stop and investigate"; exit 1
+fi
+
+# Annotated, signed if the repo requires it
+git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
+# Or signed
+git tag -s "v$NEW_VERSION" -m "Release v$NEW_VERSION"
+
+git push origin "v$NEW_VERSION"
+```
+
+### Create the release (forge-specific)
+
+```bash
+# Extract the new version's CHANGELOG section (portable - no head -n -1).
+# Prints lines between "## [NEW_VERSION]" and the next "## [" header, exclusive.
+extract_changelog() {
+  awk -v v="$1" '
+    $0 ~ "^## \\["v"\\]" { in_section=1; next }
+    in_section && /^## \[/ { exit }
+    in_section { print }
+  ' CHANGELOG.md
+}
+```
+
+### GitHub (`$FORGE=github`)
+
+```bash
+gh release create "v$NEW_VERSION" \
+  --title "v$NEW_VERSION" \
+  --notes-file <(extract_changelog "$NEW_VERSION")
+
+# Or auto-generate from commits
+gh release create "v$NEW_VERSION" --generate-notes
+```
+
+### GitLab (`$FORGE=gitlab`)
+
+```bash
+glab release create "v$NEW_VERSION" \
+  --name "v$NEW_VERSION" \
+  --notes "$(extract_changelog "$NEW_VERSION")"
+```
+
+### Forgejo / Gitea (`$FORGE=forgejo`)
+
+```bash
+tea releases create \
+  --tag "v$NEW_VERSION" \
+  --title "v$NEW_VERSION" \
+  --note "$(extract_changelog "$NEW_VERSION")"
+```
+
+### Bitbucket (`$FORGE=bitbucket`)
+
+Bitbucket doesn't have GitHub-style Releases. The tag push IS the release. If you publish artifacts via Pipelines, they're already produced by the tag push. Announce the tag URL to the user.
+
+### Bare git / unknown (`$FORGE=bare|unknown`)
+
+The pushed tag (or locally-tagged commit) is the release. No platform-level release object exists. Release notes, if needed, live only in `CHANGELOG.md`. If artifacts need to be published (e.g., to an internal Artifactory/Nexus), delegate to the user's known pipeline.
+
+### Watch the release workflow
+
+Dispatch on `$FORGE`. Every forge's "watch" command has the same class of trap: default exit code may not reflect workflow failure. Always use the explicit-exit flag or parse status after the watch.
+
+**GitHub (`$FORGE=github`)** - `gh run watch` needs an explicit run ID in non-interactive mode AND it exits `0` by default even on failure. MUST pass `--exit-status`:
+
+```bash
+LATEST_RUN=$(gh run list --limit 1 --json databaseId,name,status \
+  --jq '.[0] | "\(.databaseId) \(.name) \(.status)"')
+echo "About to watch: $LATEST_RUN"
+RUN_ID=$(echo "$LATEST_RUN" | cut -d' ' -f1)
+gh run watch "$RUN_ID" --exit-status
+```
+
+**GitLab (`$FORGE=gitlab`)**:
+
+```bash
+# Live view blocks until the pipeline finishes, but doesn't reliably exit non-zero on failure
+glab ci status --live
+# Verify after
+glab ci status --output json | jq -e '.status == "success"'
+```
+
+**Forgejo/Gitea (`$FORGE=forgejo`)**:
+
+```bash
+# Actions support varies by instance. If available:
+tea actions list --repo "$REPO" --limit 1
+# Otherwise, watch in web UI
+```
+
+**Others**: announce the release URL/tag and rely on the user to confirm pipeline success. Do not assume green.
+
+If the watch exits non-zero, the release workflow failed. The tag is already pushed - debug the workflow, do NOT re-cut the release. See the "Release workflow fails at B8" row in the recovery table below.
+
+---
+
+## Rollback playbook
+
+If the release breaks production after merge:
+
+1. **Don't panic-delete the tag.** Deleted tags leave artifacts orphaned.
+2. **Revert the merge commit**:
+   ```bash
+   git revert -m 1 "$MERGE_SHA"
+   git push origin "$BASE_BRANCH"
+   ```
+3. **Cut a new patch release** with the revert, don't try to replace the broken tag.
+4. **File a post-mortem item** (roadmap skill) about what CI missed.
+
+Never force-push to the base branch. Never delete a published tag.
+
+---
+
+## Failure modes and recovery
+
+| Failure | Recovery |
+|---------|----------|
+| Tests red after Step B2 | Fix root cause, return to B2. Do not proceed. |
+| CI red in Step B6 | Read logs, fix, push. Return to B6. |
+| PR feedback requires refactor | Loop back to B2 (tests), B4 (review) after changes. |
+| Merge conflict at B7 | Rebase onto latest base, resolve, push, return to B6 (CI rerun). |
+| Tag already exists at B8 | Investigate - is this a retry of a completed release? If so, stop (already released). If a mistake, discuss with user before any destructive action. |
+| Release workflow fails at B8 | Release is cut (tag exists) but artifacts didn't publish. Debug workflow; do not re-tag. |

--- a/skills/dev-cycle/references/size-heuristics.md
+++ b/skills/dev-cycle/references/size-heuristics.md
@@ -1,0 +1,129 @@
+# Dev Cycle: Size Classification Heuristics
+
+How to decide whether a unit of work is small (dive in), medium (judgment call), or large (brainstorm/spec).
+
+## When this reference loads
+
+Load in start mode (Step A2 in SKILL.md). Not needed in finish mode.
+
+---
+
+## Philosophy
+
+The classification is a cost/benefit call:
+
+- **Small**: the cost of writing a spec exceeds the task itself. Just do it.
+- **Large**: the cost of NOT writing a spec - rework, scope creep, disagreement mid-flight - exceeds the spec cost. Spec first.
+- **Medium**: either route works. Default to large if the user isn't time-pressured, small if they are.
+
+Bias toward large when in doubt. The 5 minutes spent writing a spec is cheap insurance; 2 weeks of rework is not.
+
+---
+
+## The table
+
+| Signal | Small | Large |
+|--------|-------|-------|
+| **Expected LOC** | <20 | >100 |
+| **Files touched** | 1-2 | 5+ |
+| **Modules touched** | 1 | 2+ |
+| **New dependencies** | no | yes |
+| **Public API change** | no | yes |
+| **Database schema change** | no | yes |
+| **Behavior change** | localized | cross-cutting |
+| **Architectural decision** | no | yes |
+| **User language** | "quick", "tiny", "just", "simple", "bump" | "properly", "design", "figure out", "how should we" |
+| **Issue description** | one sentence | multi-paragraph |
+| **Test changes needed** | minimal or none | substantial |
+| **Rollback complexity** | trivial revert | multi-step |
+| **Review cycles expected** | 1 | 2+ |
+
+Match 3+ small signals without large signals → **small**.
+Match 3+ large signals → **large**.
+Mixed signals → **medium/ambiguous** → ask the user.
+
+---
+
+## Examples
+
+### Clearly small
+
+- "Fix the typo in the README" - 1 file, <5 LOC, no API change
+- "Bump the ruff version to 0.7.0" - tooling only, lockfile update
+- "Rename `getUserData` to `getUser`" - mechanical rename, search/replace
+- "Add `ignore` entry for `.env.local` to gitignore" - single-line config
+- "The error message says 'user' instead of 'username', fix it" - one string
+
+### Clearly large
+
+- "Add OAuth login" - new dependency, new endpoints, auth flow changes, DB migration
+- "Migrate from Express to Fastify" - framework swap, all middleware refactored
+- "Add multi-tenant support" - schema change, query rewrite, access control
+- "Implement audit logging" - new infrastructure, cross-cutting concern
+- "Rewrite the build system from webpack to vite" - tooling overhaul, CI changes
+
+### Ambiguous (ask)
+
+- "Clean up the user service" - could be slop cleanup (small) or architectural refactor (large)
+- "Improve performance of the dashboard" - one query fix vs full rearchitecture
+- "Modernize the auth code" - bump dep vs rewrite
+- "Update the API" - one new field vs versioned breaking change
+- "Fix the flaky tests" - one test (small) or deep infra issue (large)
+
+---
+
+## Ambiguity resolution questions
+
+Ask at most two. Default to large if still unclear.
+
+1. **Scope size**: "How many files or modules do you expect this to touch?"
+2. **Public surface**: "Does this change behavior users or API consumers will notice?"
+3. **Reversibility**: "If we ship this and need to back it out, is that a trivial revert or a coordinated rollback?"
+
+One large answer is enough to tip ambiguous → large.
+
+---
+
+## Edge cases
+
+### Small task inside a large context
+
+Example: "Add a field to the user table" sounds small (one migration), but if the field propagates through API response schemas, serializers, tests, and frontend types, it's actually large.
+
+Probe: "Does this field need to surface anywhere else (API, UI, admin)?"
+
+### Large task with small implementation
+
+Example: "Add retry logic to the HTTP client" might be 30 lines of code but has cross-cutting behavior implications (idempotency, backoff, circuit breaking, observability).
+
+Treat as large when the *decisions* are complex, even if the *code* is short.
+
+### "Just a config change"
+
+Config changes can be one line or an architecture pivot. Probe: "Which config, and what behavior does it control?" A feature flag toggle is small. Changing the database connection pooling mode is large.
+
+### Refactors with no behavior change
+
+"Extract this into a module" - if it's mechanical, small. If it involves interface redesign, large.
+
+Probe: "Does the external interface stay identical?"
+
+### "Just update the dependency"
+
+Minor/patch bump with no API change - small. Major version bump or deprecated-API migration - large.
+
+Probe: "Is this a major version bump, and does it deprecate APIs we use?"
+
+---
+
+## What to do with the classification
+
+- **Small**: skip Step A4 (spec/brainstorm). Go straight to handoff. Suggest which skill fits the domain.
+- **Medium**: offer the user both paths. "We could spec this (maybe 10 min) or dive in. Which?"
+- **Large**: run Step A4. Don't skip it just because the user is eager - the spec pays for itself.
+
+State the classification and the signals explicitly so the user can correct:
+
+> "Classifying this as **large**. Signals: new public endpoint, new dependency (oauth library), requires migration, user said 'think this through properly'."
+
+If the user overrides ("no, it's smaller than that"), accept with one probe: "What am I overweighting?" The answer either reveals a missing signal or confirms the user has context you don't.

--- a/skills/dev-cycle/references/start.md
+++ b/skills/dev-cycle/references/start.md
@@ -1,0 +1,278 @@
+# Dev Cycle: Start Mode Reference
+
+Detailed procedures for starting a unit of work. Referenced from the main SKILL.md.
+
+## When this reference loads
+
+Load when the user invokes **dev-cycle** and the mode resolves to `start` (see SKILL.md Step 0). Not needed in finish mode.
+
+---
+
+## Step A1 details: Clean state + pull latest
+
+The goal is to branch from an up-to-date base. Do not branch from stale local refs or from a dirty working tree.
+
+### Pre-flight
+
+```bash
+# Must be inside a git work tree (not a submodule, not a worktree of another repo without intent)
+git rev-parse --is-inside-work-tree
+
+# Submodule guard: if inside a submodule, stop. Branching here requires the parent repo to
+# update its pinned commit - that's a coordinated change, not a plain feature branch.
+if git rev-parse --show-superproject-working-tree 2>/dev/null | grep -q .; then
+  echo "Inside a submodule. Branch in the submodule only if that's intentional and"
+  echo "you will coordinate the parent repo pin update. Otherwise cd to the parent."
+  exit 1
+fi
+
+# Working tree must be clean (untracked files are fine; staged/modified are not).
+git diff --cached --stat; git diff --stat
+# Non-empty output means: commit, stash, or abort.
+
+# If dirty, options:
+#   a) commit the work on the current branch
+#   b) stash it (git stash push -m "wip: pre-dev-cycle")
+#   c) abort and ask the user what the leftover work is
+```
+
+Never silently stash - the user might have important uncommitted work. Ask.
+
+### Determine the base branch
+
+In order of reliability:
+
+```bash
+# 1. Explicit remote HEAD (most reliable)
+git symbolic-ref --quiet refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||'
+
+# 2. Default branch from the forge
+gh   repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null
+glab repo view --output json 2>/dev/null | jq -r '.default_branch'
+tea  repos show --output simple 2>/dev/null | awk '/^Default Branch:/ {print $3}'
+
+# 3. Heuristic: main or master
+git show-ref --verify --quiet refs/heads/main && echo main || echo master
+```
+
+If all three disagree, ask the user. Do not guess.
+
+### Pull with fast-forward only
+
+```bash
+git fetch origin --prune
+git checkout "$BASE_BRANCH"
+git pull --ff-only
+```
+
+`--ff-only` refuses to create a merge commit on the base branch. If it fails, the local base has diverged - investigate (don't just `reset --hard`).
+
+---
+
+## Step A2 details: Size classification
+
+Full table in `size-heuristics.md`. Apply the table, state the classification, and list the signals that drove it.
+
+Good: "Classifying as **large** - adds a new public API endpoint, requires DB schema migration, and user said 'proper design needed'."
+
+Bad: "This is large." (no signals shown)
+
+When ambiguous, ask up to 2 disambiguating questions:
+1. "How many files do you expect to touch?"
+2. "Is this adding new public API/behavior or just modifying existing logic?"
+
+Default to large on uncertainty. Spending 5 minutes on a spec for a 20-line fix wastes less than skipping a spec for a 2-week refactor.
+
+---
+
+## Step A3 details: Branch naming
+
+### Forge-specific conventions
+
+Check recent branches for patterns:
+
+```bash
+git branch -a --sort=-committerdate | head -20 | sed 's|remotes/origin/||' | sort -u
+```
+
+Common patterns:
+
+| Pattern | Example |
+|---------|---------|
+| `type/description` | `feat/oauth-login`, `fix/token-race`, `chore/bump-deps` |
+| `issue-number/description` | `123/oauth-login`, `456/token-race` |
+| `user/description` | `alice/oauth-login` |
+| `type/issue-description` | `feat/123-oauth-login` |
+
+If no clear pattern, use `type/short-description` (conventional-commit-aligned).
+
+### Type prefixes (aligned with conventional commits)
+
+- `feat/` - new feature
+- `fix/` - bug fix
+- `refactor/` - code restructuring, no behavior change
+- `perf/` - performance improvement
+- `docs/` - documentation only
+- `test/` - test additions/fixes
+- `chore/` - build, tooling, deps
+- `ci/` - CI config changes
+- `revert/` - revert a previous change
+
+### Create the branch
+
+```bash
+# Start point = current HEAD on the base branch (fresh pull)
+git checkout -b "$BRANCH_NAME"
+```
+
+Verify: `git branch --show-current` and `git log -1 --oneline` should show the latest base commit.
+
+---
+
+## Step A4 details: Brainstorming fallback chain
+
+### Order of preference
+
+1. **`superpowers:brainstorming`** - the superpowers skill. Structured ideation with user-intent exploration.
+2. **Other installed brainstorming skills** - try these names via the Skill tool:
+   - `brainstorm`
+   - `brainstorming`
+   - `gsd-explore`
+   - `ideate`
+3. **Inline Socratic fallback** - when no brainstorming skill is available.
+
+If the Skill tool reports "skill not found" for a name, move to the next. Don't retry the same name.
+
+### Inline Socratic template
+
+When no skill is installed AND the session is interactive, ask these questions one at a time. Wait for each answer before the next - do not batch them.
+
+**If the session is non-interactive** (`--bare`, Codex `exec`, automations): skip the Q&A. Extract what you can from available context - issue body, branch name, conventional-commit scope, diff base, recent git log - and write a minimal spec. Mark each field that had no source with a `TODO:` prefix so a human can fill it in later. Do not block waiting for answers that cannot arrive.
+
+```
+1. Goal: "In one sentence, what should this work accomplish?"
+
+2. Success: "How will we know it's done? What's the measurable or observable outcome?"
+
+3. Out of scope: "What are we explicitly NOT doing here?"
+
+4. Constraints: "What's the hardest constraint? (performance target, compatibility, deadline, team coordination, etc.)"
+
+5. Risks: "What could go wrong or surprise us? Where are the unknowns?"
+
+6. Reuse: "What existing code, patterns, or skills should we lean on?"
+```
+
+After the answers, compose the spec.
+
+### Spec file template
+
+Write to `SPEC.md` at repo root, or `specs/<branch-name>.md` if a `specs/` dir already exists.
+
+```markdown
+# Spec: {one-line title}
+
+**Branch**: `{branch-name}`
+**Date**: {YYYY-MM-DD}
+**Size**: {small|medium|large}
+
+## Goal
+
+{one sentence}
+
+## Success criteria
+
+- {measurable outcome 1}
+- {measurable outcome 2}
+
+## Out of scope
+
+- {explicit non-goal}
+
+## Constraints
+
+- {hard constraint}
+
+## Risks and unknowns
+
+- {risk 1 - what could go wrong}
+- {unknown 1 - what to research}
+
+## Approach sketch
+
+{bullet points or short paragraphs - not a full design}
+
+## Skills likely to engage
+
+- {e.g., databases for migrations, docker for image updates}
+```
+
+Commit the spec as the first commit on the branch:
+
+```bash
+git add SPEC.md
+git commit -m "docs: add spec for {title}"
+```
+
+### When NOT to write a spec
+
+- Small work (typo, bump, single-file fix). Spec overhead exceeds task scope.
+- User explicitly said "skip the spec, I've already scoped this in my head". Honor it, but note classification.
+- A clear issue/ticket already exists and covers the spec content. Link to it in the PR body instead.
+
+---
+
+## Step A5 details: Handoff
+
+End start mode cleanly. The next session will pick up in finish mode or continue implementation. Output should include:
+
+```markdown
+## Start Mode Complete
+
+**Branch**: `{branch-name}` (from `{base-branch}` @ `{short-sha}`)
+**Classification**: {small|medium|large} - {signals}
+**Spec**: {path, if written, or "skipped - small"}
+
+### Next steps
+
+- Implement the change. Suggested skills based on what you'll touch:
+  - {e.g., **databases** for the migration}
+  - {e.g., **docker** when updating the image}
+  - {e.g., **testing** when writing tests}
+
+- When ready to ship, invoke **dev-cycle** in finish mode.
+
+### Reminders
+
+- Commit early, commit often. Keep commits atomic.
+- Rebase against base periodically if the branch is long-lived.
+- Do NOT add AI attribution to commits.
+```
+
+Do not start editing source files in start mode. If the user immediately asks you to begin implementation in the same session, that's fine - but the mode has ended. Switch to whatever implementation skill fits the task.
+
+---
+
+## Edge cases
+
+### Already on a feature branch
+
+If the current branch isn't the base branch when start mode runs:
+
+- If it's a new branch with no commits (fresh checkout): safe to switch away
+- If it has unpushed commits: ask the user. Options:
+  - Finish that branch first (switch to finish mode)
+  - Stash the branch and start fresh (`git stash` or `git worktree add` for parallel work)
+  - Resume it later (leave alone, warn the user)
+
+### Detached HEAD
+
+Stop. Detached HEAD is almost always a mistake in this context. Ask the user to check out a named branch first.
+
+### Submodules / monorepos
+
+Run the pull/branch commands at the repo root. Submodules update via `git submodule update --init --recursive` after the pull. Monorepo subtrees may have different base branches - ask.
+
+### No remote
+
+Local-only repo. Skip the `fetch` and `pull` but still branch off the base. Warn the user that push/PR steps in finish mode won't work without a remote.

--- a/skills/dev-cycle/references/version-bump-sites.md
+++ b/skills/dev-cycle/references/version-bump-sites.md
@@ -1,0 +1,228 @@
+# Dev Cycle: Version-Bump Sites
+
+Where versions live across common ecosystems, and how to find them. Referenced from Step B3 in SKILL.md.
+
+## When this reference loads
+
+Load in finish mode during the doc/version sync step. Not needed in start mode.
+
+---
+
+## Philosophy
+
+Versions drift because nobody owns the full list. This skill owns the list.
+
+Two rules:
+
+1. **Grep, don't remember.** The locations below are common, but every repo has quirks. Always grep for the current version string.
+2. **Propose, don't auto-edit.** Show the user the diff. They confirm the scope.
+
+---
+
+## Detection script
+
+Run this at repo root to find all version strings:
+
+```bash
+# Get the current version from the primary manifest
+CURRENT_VERSION=""
+[[ -f package.json ]] && CURRENT_VERSION=$(jq -r '.version' package.json 2>/dev/null)
+[[ -z "$CURRENT_VERSION" && -f pyproject.toml ]] && CURRENT_VERSION=$(grep -E '^version\s*=' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+[[ -z "$CURRENT_VERSION" && -f Cargo.toml ]] && CURRENT_VERSION=$(grep -E '^version\s*=' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+[[ -z "$CURRENT_VERSION" ]] && CURRENT_VERSION=$(git tag -l 'v*' --sort=-v:refname | head -1 | sed 's/^v//')
+
+echo "Current version: $CURRENT_VERSION"
+
+# Find all occurrences across the repo
+rg --fixed-strings "$CURRENT_VERSION" --hidden --no-ignore \
+  --glob '!.git' --glob '!node_modules' --glob '!*.lock' --glob '!*.sum'
+```
+
+Review each match. Not all are version strings - some may be coincidental (e.g., a test fixture with `"version": "1.2.3"` that's documenting a different system).
+
+---
+
+## Site catalog
+
+### Language / package manifests
+
+| Ecosystem | File | Field | Notes |
+|-----------|------|-------|-------|
+| Node.js | `package.json` | `"version"` | Root. Sub-packages in monorepos (`packages/*/package.json`). |
+| Python (modern) | `pyproject.toml` | `[project] version` or `[tool.poetry] version` | Single source of truth for new projects. |
+| Python (legacy) | `setup.py`, `setup.cfg` | `version=` | Still seen in older projects. |
+| Python (dynamic) | `__init__.py` | `__version__` | When pyproject uses `dynamic = ["version"]`. |
+| Rust | `Cargo.toml` | `[package] version` | Workspace members may inherit via `workspace.package`. |
+| Go | `go.mod` | no direct version; tags drive it | Module version = latest git tag. |
+| Java (Maven) | `pom.xml` | `<version>` | Parent POM may define it; check inheritance. |
+| Java (Gradle) | `build.gradle` / `build.gradle.kts` | `version =` | May be in `gradle.properties`. |
+| Ruby | `Gemfile.lock`, `*.gemspec` | `spec.version` | Primary in gemspec. |
+| PHP | `composer.json` | `"version"` | Often omitted; packagist uses tags. |
+| .NET | `*.csproj`, `Directory.Build.props` | `<Version>` | Can be centralized in Directory.Build.props. |
+| Elixir | `mix.exs` | `version: "x.y.z"` | Inside project/0 function. |
+| Dart/Flutter | `pubspec.yaml` | `version:` | `x.y.z+build` format is common. |
+| Swift | `Package.swift` | No direct version; tags drive it | Like Go. |
+
+### Container / orchestration
+
+| File | Patterns to check |
+|------|-------------------|
+| `Dockerfile` | `LABEL version=`, `LABEL org.opencontainers.image.version=`, base image tags (`FROM image:TAG`), `ARG VERSION=` |
+| `Dockerfile.*` | Same, multiple Dockerfiles common in monorepos |
+| `docker-compose.yml`, `docker-compose.*.yml`, `compose.yaml` | `image: ORG/APP:TAG` |
+| `docker-bake.hcl` | `tags = ["..."]` |
+| `.dockerignore` | n/a - no versions |
+
+### Kubernetes
+
+| File | Patterns to check |
+|------|-------------------|
+| `k8s/**/*.yaml`, `manifests/**/*.yaml` | `image: ORG/APP:TAG` in Deployment/StatefulSet/DaemonSet/CronJob specs |
+| `kustomization.yaml` | `images:` block with `newTag:` |
+| `base/` and `overlays/` (Kustomize) | Same patterns per overlay |
+| Helm charts | see below |
+
+### Helm
+
+| File | Field | Notes |
+|------|-------|-------|
+| `Chart.yaml` | `version:` | The chart's own version. Bump on chart changes. |
+| `Chart.yaml` | `appVersion:` | The application version the chart deploys. Bump on app release. |
+| `values.yaml` | `image.tag` (or similar) | Default image tag for the chart's deployments. |
+| `values-*.yaml` | Same | Environment-specific overrides. |
+| `templates/` | Rarely contain hardcoded versions | Should reference `.Values.image.tag`. |
+
+Both `version` and `appVersion` need thought. Rule of thumb:
+- `appVersion` tracks the app it deploys (bump when the app releases)
+- `version` tracks the chart itself (bump when templates or values change)
+- A release can bump appVersion without bumping version if the chart is unchanged - but most CI gates require version to also bump (to force-refresh installed releases)
+
+### CI / workflows
+
+| File | Check |
+|------|-------|
+| `.github/workflows/*.yml` | Action pins (`uses: owner/repo@vX.Y.Z`), tool-version env vars |
+| `.gitlab-ci.yml`, `.gitlab/*.yml` | `image:` tags, versioned job includes |
+| `.circleci/config.yml` | `orb` versions, Docker executor tags |
+| `.drone.yml`, `.woodpecker.yml` | Same image-tag pattern |
+| `.pre-commit-config.yaml` | `rev:` pins for hook repos |
+
+### Docs and metadata
+
+| File | Check |
+|------|-------|
+| `README.md` | Version badges (shields.io), installation commands with pinned versions, changelog link headers |
+| `CHANGELOG.md` | Add a new section; do not edit historical sections |
+| `CHANGES`, `HISTORY.md`, `NEWS.md` | Same |
+| `docs/` | Versioned install snippets, compatibility matrices |
+| `mkdocs.yml`, `docs/conf.py`, `docusaurus.config.*` | Site version strings |
+| `CITATION.cff`, `.zenodo.json` | Academic metadata |
+
+### Installers and bootstrap scripts
+
+| File | Check |
+|------|-------|
+| `install.sh`, `bootstrap.sh`, `setup.sh` | Hardcoded version pins |
+| `Makefile`, `justfile`, `Taskfile.yaml` | Version variables in recipes |
+| Homebrew formula (if maintained in-repo) | `version "x.y.z"`, `url`, `sha256` |
+| Scoop manifests | `version`, `url`, `hash` |
+| `.releaserc`, `release-please-config.json` | Release automation config - don't edit the version, let the tool set it |
+
+### Build outputs and constants
+
+| File | Check |
+|------|-------|
+| Source files with `VERSION` constants | `const VERSION = "..."`, `__version__`, etc. |
+| Generated files (dist/, build/) | Usually ignored - regenerated on build |
+| CLI `--version` output | Verify the change surfaces here too |
+
+---
+
+## Strategy by change type
+
+### Patch release (bug fix)
+
+Bump the main manifest. Update:
+- Primary package manifest
+- Helm `appVersion` (if helm)
+- Dockerfile LABEL version (if set)
+- CHANGELOG
+- Keep chart `version`, image tags, etc. unless they need to propagate for deployment
+
+### Minor release (feature)
+
+Same as patch, plus:
+- Helm chart `version` (chart templates may have new capabilities)
+- README if installation steps or compatibility changed
+
+### Major release (breaking)
+
+Everything patches cover, plus:
+- Breaking-change notes in CHANGELOG
+- Migration guide (often `MIGRATION.md` or `UPGRADE.md`)
+- README install command if major is pinned differently (e.g., npm `@latest` vs `@1`)
+- CI compatibility matrix if languages/runtimes were dropped
+
+### Tooling-only version (dependency bump, no public change)
+
+Usually no public version bump needed. But:
+- If the tool is re-exported (e.g., lib in `node_modules` whose types you export), that may be a minor/major of your library
+- Lockfiles update automatically; commit them
+
+---
+
+## Confirming the diff
+
+Before editing, show the user something like:
+
+```
+Version bump: 1.4.2 → 1.5.0 (minor)
+
+Proposed edits:
+  package.json                  "version": "1.4.2" → "1.5.0"
+  Dockerfile                    LABEL version="1.4.2" → "1.5.0"
+  helm/myapp/Chart.yaml         appVersion: 1.4.2 → 1.5.0
+  helm/myapp/values.yaml        image.tag: 1.4.2 → 1.5.0
+  CHANGELOG.md                  + new section: ## [1.5.0] - 2026-04-14
+
+Not touching (confirm):
+  docs/install.md               shows "install@1" - major-line pin, leave as-is
+  test/fixtures/old_response.json   contains "version": "1.0.0" - unrelated fixture
+```
+
+Apply after user confirms. If they want changes to the plan, redo the proposal - don't partially apply.
+
+---
+
+## Gotchas
+
+### Generated files
+
+Some files regenerate on build (e.g., `dist/package.json` in some Node setups). Don't edit by hand - they'll be overwritten. Edit the source and rebuild, or commit the regenerated output after a build.
+
+### Monorepo version coordination
+
+Packages in a monorepo may version independently (Lerna/changesets style) or in lockstep. Check the repo's release tooling:
+- `changeset/` directory → changesets, bump per package
+- `lerna.json` with `"version": "independent"` → per-package
+- `lerna.json` with a fixed version → lockstep
+- Nx: check `release.yml` or `nx.json`
+
+Don't manually bump every `package.json` in a changesets repo - the tool does it on release.
+
+### SemVer pre-releases
+
+Pre-release tags like `1.5.0-rc.1`, `1.5.0-beta.2` sort before `1.5.0`. Bumping from `1.5.0-rc.1` → `1.5.0` is a release-out-of-prerelease, not a new minor.
+
+### Calendar versioning
+
+Some projects use CalVer (`2026.04.0`, `26.04`) instead of SemVer. Don't silently convert. Match the existing format.
+
+### Language-specific tag prefixes
+
+- Go requires `v` prefix: `v1.2.3`
+- npm strips `v` if present
+- PyPI does not use `v` prefix
+- Docker tags are arbitrary
+
+Match the repo's existing convention. `git tag -l | head -5` usually tells you.


### PR DESCRIPTION
## Summary

New skill: **dev-cycle** - a two-mode orchestrator for the full arc of a unit of work.

- **Start mode**: pull latest, detect forge, create feature branch, classify size (small/large), brainstorm-or-dive-in, hand off
- **Finish mode**: lint/test, sync docs/versions, code review, push + PR, watch CI, merge, cut release (auto-skip when no convention)
- **Forge-agnostic**: GitHub (`gh`), GitLab (`glab`), Forgejo/Gitea (`tea`), Bitbucket (web UI / REST), bare git (format-patch/bundle, local merge)
- **Delegates, not reimplements**: calls into `git`, `testing`, `code-review`, `update-docs`, and a brainstorming skill if installed. Falls back to inline Socratic questioning or toolchain-detection + ask-the-user when delegates are missing.

Built and refined through three `skill-creator` review iterations plus one `skill-refiner` quality-sweep pass (composite score 89.8 -> 97.0, plateau-terminated).

## Changes

- `skills/dev-cycle/SKILL.md` (340 lines)
- `skills/dev-cycle/references/start.md` - branch naming, brainstorm fallback chain, spec template, submodule guard
- `skills/dev-cycle/references/finish.md` - per-forge push/PR/merge/CI-watch/release commands, bare-git integration, rollback playbook
- `skills/dev-cycle/references/size-heuristics.md` - classification table and ambiguity resolution
- `skills/dev-cycle/references/version-bump-sites.md` - grep patterns for Docker, K8s, Helm, package managers
- `README.md` - skill count bumped (29 -> 32)

## Test plan

- [x] `./scripts/lint-skills.sh skills` - 32 skills, 0 errors, 0 warnings
- [x] `./scripts/validate-spec.sh skills` - 32 skills, 0 violations, 0 warnings
- [x] Three skill-creator Mode 2 review iterations applied and verified
- [x] Three forward-test scenarios (gitlab finish, bare finish, forgejo start) passed
- [x] Adversarial fresh-context review (`|| true` masking eliminated, auth errors surface)
- [x] Release detection bug fixed: `git fetch --tags` now runs before tag checks (would have false-skipped release on this very PR)

## Follow-up

Release `v1.20.0` to cut after merge, matching the per-skill minor-bump pattern (`v1.19.0` = deep-audit, `v1.17.0` = localize).