### PR TITLE
refactor(anti-slop): tighten AI-specific smell detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The loop: **Score -> Improve -> Verify -> Keep or Revert -> Repeat.**
 | Skill | What it does |
 |-------|-------------|
 | **code-review** | Bug hunting, logic errors, edge cases, race conditions, resource leaks, convention violations |
-| **anti-slop** | Detects and fixes AI-generated code patterns - over-abstraction, redundant comments, verbose defensive code |
+| **anti-slop** | Detects and fixes AI-generated code patterns - hallucinated APIs/flags/resources, test theater, over-abstraction, redundant comments, verbose defensive code |
 | **anti-ai-prose** | Audits writing for AI tells - vocabulary (delve, tapestry), syntax (negative parallelism, tricolons), tone (travel-guide voice, vague attribution), formatting (em-dash abuse). Covers docs, READMEs, wikis, PRs, emails, slides, creative writing |
 | **backend-api** | HTTP backend APIs - FastAPI, Express, NestJS, REST/OpenAPI contracts, auth flows, versioning, pagination, idempotency |
 | **testing** | Unit, integration, E2E, accessibility, and performance tests - Vitest, Jest, Playwright, pytest, Go testing, cargo test, TDD workflows, mocking strategies, CI test infrastructure |

--- a/skills/anti-slop/SKILL.md
+++ b/skills/anti-slop/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: anti-slop
 description: >
-  · Audit code for machine-generated patterns, over-abstraction, redundant comments, verbose
-  code, and dependency creep. Triggers: 'slop', 'code quality', 'simplify', 'modernize',
-  'code smell', 'clean up'. Not for prose review (use anti-ai-prose). Not for full repo
-  audit (use full-review).
+  · Audit code for machine-generated patterns, hallucinated APIs/flags/resources,
+  over-abstraction, test theater, redundant comments, verbose code, and dependency creep.
+  Triggers: 'slop', 'AI-generated code', 'hallucinated API', 'hallucinated flag',
+  'hallucinated resource', 'weird code pattern', 'cleanup', 'clean up',
+  'overengineered', 'mock-heavy tests', 'schema drift'. Not for prose review (use
+  anti-ai-prose). Not for full repo audit (use full-review).
 license: MIT
 compatibility: "None - works on any codebase"
 metadata:
@@ -16,7 +18,7 @@ metadata:
 
 # Anti-Slop: Polyglot Code Quality Audit
 
-Detect and fix patterns that make code look machine-generated, over-abstracted, or unnecessarily verbose. The goal is code that reads like a competent human wrote it - minimal, intentional, and clear.
+Detect and fix patterns that make code look machine-generated, over-abstracted, unnecessarily verbose, or fluently wrong. The goal is code that reads like a competent human wrote it - minimal, intentional, grounded, and clear.
 
 This skill covers: **TypeScript/JavaScript**, **Python**, **Bash/Shell**, **Rust**, **Docker/Containers**, and **Infrastructure as Code** (Terraform, Ansible, Helm, Kubernetes manifests). The universal patterns apply everywhere; language-specific sections add targeted checks.
 
@@ -26,6 +28,7 @@ This skill covers: **TypeScript/JavaScript**, **Python**, **Bash/Shell**, **Rust
 - Simplifying code after an AI-heavy implementation pass
 - Auditing comment noise, naming quality, over-abstraction, and dependency creep
 - Looking for "ugly but technically works" code that still hurts readability or maintainability
+- Looking for AI-native tells: hallucinated APIs, schema drift, fallback laundering, and tests that only ratify the implementation
 
 ## The Three Axes of Slop
 
@@ -53,6 +56,8 @@ Before returning any anti-slop audit, verify:
 - [ ] **Existing project conventions preserved**: the repo's naming style, comment density, and abstraction level take precedence over generic "clean code" preferences
 - [ ] **Severity is honest**: don't inflate Low findings to Medium to pad the report
 - [ ] **No hallucinated replacements**: verify that suggested modern alternatives actually exist in the target language version (e.g., `match` requires Python 3.10+, `LazyLock` requires Rust 1.80+)
+- [ ] **Grounding checked**: if flagging a hallucinated API, CLI flag, resource, chart value, or config key, verify it against local types/schema/tool help or official docs before claiming it is fake
+- [ ] **Test theater distinguished from correctness**: implementation-mirroring tests, mock-heavy ceremony, and snapshots with no semantic assertions belong here; actual failing behavior still belongs to code-review
 
 ---
 
@@ -82,6 +87,7 @@ Before scanning for slop, run standard linters to clear the low-hanging fruit:
 - **Python**: `ruff check` / `mypy`
 - **TypeScript**: `eslint` / `tsc --noEmit`
 - **Terraform**: `terraform validate` / `tflint`
+- **IaC schema tools**: `ansible-lint`, `helm lint`, `kubectl apply --dry-run=client`, `kubeconform` when available
 - **Structural patterns**: `ast-grep` (tree-sitter powered AST search - write rules to catch restating comments, dead code, hallucinated imports across languages. Install: `npm i -g @ast-grep/cli`. If your tool ecosystem provides `ast-grep` helper skills or templates, use them.)
 
 Linters handle syntax issues, unused imports, and known anti-patterns mechanically. This skill focuses on what linters can't catch: taste, over-abstraction, naming quality, unnecessary complexity, and stale idioms. Don't duplicate what a linter already covers.
@@ -100,7 +106,7 @@ Classify each finding by axis (Noise/Lies/Soul - see above), action, and severit
 - **Fine** - looks like slop but is justified (note why and move on)
 
 **Severity** (determines report ordering - high first):
-- **High** - security risk (silent error swallowing, `any` casts bypassing type safety, missing input validation at boundaries), correctness (stale/deprecated APIs, hallucinated patterns)
+- **High** - strongly suggests fabricated or ungrounded code (hallucinated APIs, schema drift, silent swallowing used to hide uncertainty, fallback laundering)
 - **Medium** - maintainability (over-abstraction, generic naming, missing error context, logic duplication)
 - **Low** - style (verbose patterns, comment noise, redundant annotations, barrel files)
 
@@ -260,6 +266,35 @@ AI models trained on multiple languages bleed idioms across boundaries. A reliab
 
 **Fix:** Replace with the target language's idiom. This is almost always an AI generation artifact - humans don't accidentally write `.push()` in Python.
 
+### 10. Plausible Hallucinations / Schema Drift (Lies)
+
+Code that looks locally plausible because the names sound right, but it is not grounded in the actual API, schema, CLI, provider, or framework version in use.
+
+**Detect:**
+- Functions, methods, imports, CLI flags, config keys, or resource arguments that look real but are not in local types, tool help, or docs
+- Mixing adjacent ecosystems: provider arguments from the wrong Terraform resource, Helm values keys that the chart never reads, Kubernetes fields from a different API version, Ansible params from the wrong module or collection
+- Compatibility blind spots: using a modern API without checking the repo's runtime/tool version
+- "Fixes" that paper over missing understanding with `try()`, optional chaining, default fallbacks, or broad catches instead of verifying the contract
+
+**Fix:** Check the actual contract first - local types, generated schema, `--help`, provider docs, chart values, API version docs. Delete invented surface area. Prefer loud failure for required config over fantasy defaults.
+
+**Exception:** Compatibility shims for multi-version support are fine when the codebase clearly supports multiple runtimes, provider versions, or API levels.
+
+### 11. Test Theater / Self-Confirming Tests (Lies + Soul)
+
+Tests can be slop too. A green test suite is not evidence if the tests were generated from the implementation and only mirror what already exists.
+
+**Detect:**
+- Tests written after implementation that assert the exact control flow, fixture data, or internal call graph of the current code
+- Mock-heavy tests where every dependency is stubbed and the only assertions are call counts, method names, or log messages
+- Snapshots or golden files used as a substitute for semantic assertions
+- "Happy path only" tests paired with broad catches, default fallbacks, or defensive code that never gets exercised
+- Generated tests with high coverage but no clear link to the spec, acceptance criteria, or boundary behavior
+
+**Fix:** Prefer spec-driven tests, behavior-level assertions, and a real RED phase. Keep mocks at the edges. If the test would still pass when the implementation is wrong in the same way, it is ceremony, not protection.
+
+**Exception:** Adapter tests, logging/metrics assertions, and contract tests may legitimately assert call shapes when that contract is the behavior under test.
+
 ---
 
 ## Language: TypeScript / JavaScript
@@ -270,6 +305,7 @@ Read `references/typescript.md` for the full TS/JS pattern catalog. Key highligh
 - **Stale patterns**: `require()` in ESM, `var`, `React.FC`, class components, `PropTypes` alongside TS, `.then()` chains, `namespace`
 - **Verbose**: `for` loops that should be `.filter().map()`, `Object.keys().forEach()` instead of `for...of`, classes for stateless logic
 - **Dependency creep**: `node-fetch` when `fetch` is global, `uuid` when `crypto.randomUUID()` exists, two libs for the same concern
+- **AI-native tells**: `try/catch` around deterministic local code, `new Promise(async ...)`, fallback defaults for required env/config, tests that only assert mocks or snapshots
 - **Barrel files**: `index.ts` re-exporting everything in small directories
 
 ## Language: Python
@@ -282,6 +318,7 @@ Read `references/python.md` for the full Python pattern catalog. Key highlights:
 - **Type hints**: `Any` used to bypass type errors, redundant hints on obvious assignments, overly complex `TypeVar` gymnastics
 - **Verbose**: manual dict/list building instead of comprehensions, nested `if` instead of early returns, `lambda` assigned to a variable (just use `def`), redundant docstrings restating the function signature
 - **Dependency creep**: `requests` for a single GET when `urllib` works, `python-dotenv` when `os.environ` is fine
+- **AI-native tells**: `dict.get(..., {})` chains laundering missing invariants, catch-log-reraise noise, mock-heavy tests with no behavioral assertion
 
 ## Language: Bash / Shell
 
@@ -292,15 +329,16 @@ Read `references/shell.md` for the full Shell pattern catalog. Key highlights:
 - **Stale patterns**: backticks instead of `$()`, `expr` instead of `$(())`, `[ ]` instead of `[[ ]]` in bash/zsh, parsing `ls` output
 - **Over-defensive**: `if command; then ... fi` on every line instead of `set -e`, manual `$?` checks
 - **Verbose**: `echo "$var" | grep` instead of `[[ "$var" == *pattern* ]]`, external tools for built-in operations
+- **AI-native tells**: hallucinated flags/subcommands copied from adjacent CLIs, `2>/dev/null || true` used to hide uncertainty, heredoc-heavy automation instead of checked files/templates
 
 ## Language: Infrastructure as Code
 
 Read `references/iac.md` for the full IaC pattern catalog covering Terraform, Ansible, Helm, and Kubernetes manifests. Key highlights:
 
-- **Terraform**: over-modularizing (module for a single resource), redundant `depends_on` when implicit deps exist, not using `locals` for repeated expressions, unpinned provider versions, `provisioner` blocks instead of proper config management
-- **Ansible**: `command`/`shell` when a module exists, `ignore_errors: true` everywhere, registering variables never used, not using handlers for service restarts, no YAML anchors for DRY
-- **Helm**: hardcoded values in templates, `tpl` for static strings, `.Values` spaghetti without defaults, chart version not pinned
-- **Kubernetes**: no resource requests/limits, `latest` tags, no namespace, imperative `kubectl run/create` in automation, no readiness/liveness probes
+- **Terraform**: over-modularizing, redundant `depends_on`, not using `locals`, unpinned provider versions, invented resource arguments, provider/version hallucinations
+- **Ansible**: `command`/`shell` when a module exists, `ignore_errors: true` everywhere, registering variables never used, not using handlers, invented module params or wrong collections
+- **Helm**: hardcoded values in templates, `tpl` for static strings, `.Values` spaghetti without defaults, chart version not pinned, values keys that the chart never consumes
+- **Kubernetes**: no resource requests/limits, `latest` tags, no namespace, imperative `kubectl run/create` in automation, no probes, mismatched `apiVersion`/field combinations
 
 ## Language: Rust
 
@@ -325,7 +363,7 @@ Read `references/docker.md` for Dockerfile and Compose pattern catalog. Key high
 
 ## Other Languages
 
-For Go and other languages without dedicated reference files: apply the universal patterns (sections 1-9) only. Note in the report that language-specific checks were skipped. Common cross-language tells still apply - over-abstraction, comment noise, cross-language leakage, and error handling anti-patterns look similar everywhere.
+For Go and other languages without dedicated reference files: apply the universal patterns (sections 1-11) only. Note in the report that language-specific checks were skipped. Common cross-language tells still apply - over-abstraction, comment noise, cross-language leakage, schema drift, and error handling anti-patterns look similar everywhere.
 
 ## Research & Citations
 
@@ -345,6 +383,8 @@ These look like slop but aren't:
 - **Shell verbosity for clarity**: complex pipelines benefit from intermediate variables and comments.
 - **Terraform `count`/`for_each` on single resources**: might be conditional (`count = var.enabled ? 1 : 0`).
 - **Ansible `when` conditions that seem obvious**: often guarding against cross-platform differences.
+- **Compatibility shims**: version- or provider-specific branches may look repetitive because they support multiple real targets.
+- **Contract-level tests**: asserting exact API payloads, SQL, CLI args, or emitted metrics is fine when that contract is the thing being tested.
 
 ---
 
@@ -407,7 +447,9 @@ Keep it concise. Show the diff, not a paragraph explaining it.
 ## Rules
 
 - **Keep correctness out of scope.** If it would actually break behavior, route it to code-review instead of padding this report.
+- **Flag AI-native lies even when they look polished.** Hallucinated APIs, schema drift, and self-confirming tests belong here when the problem is lack of grounding or taste rather than a demonstrated failing behavior.
 - **Keep security out of scope.** Defensive code often looks verbose on purpose. Do not flag it casually.
 - **Read before judging.** A pattern that looks generic in isolation may be justified by framework or project constraints.
+- **Ground hallucination claims.** Use local types, schema, lockfiles, generated docs, or tool help before saying a flag/resource/API is fake.
 - **Prefer concrete rewrites.** If you flag a pattern, show the simpler version.
 - **Run the AI Self-Check.** Verify findings against the checklist before returning the audit.

--- a/skills/anti-slop/references/iac.md
+++ b/skills/anti-slop/references/iac.md
@@ -47,6 +47,16 @@ Covers Terraform, Ansible, Helm, and Kubernetes manifests.
 - Nested `dynamic` blocks when a simple `for_each` on the resource would work
 - `data "template_file"` (deprecated) -> `templatefile()` function
 
+### Schema / Provider Hallucinations (Lies)
+
+**Detect:**
+- Resource arguments that are not in the provider schema for the version in `required_providers` or `.terraform.lock.hcl`
+- Resource names copied from the wrong provider or from a stale blog post
+- Defaulting required inputs with `try()` / `lookup()` to avoid understanding whether they are actually optional
+- Version-blind examples: using provider arguments introduced after the pinned version in the repo
+
+**Fix:** Check `terraform providers schema -json`, registry docs, or generated provider docs for the exact pinned version. Remove invented arguments and fail loudly on required inputs.
+
 ### Verbose (Noise)
 
 - Declaring variables with `type = string` and no `description`, `default`, or `validation` - the variable block is just noise
@@ -106,6 +116,16 @@ The #1 Ansible slop pattern. If there's a module for it, use the module.
 - `include:` -> `include_tasks:` or `import_tasks:`
 - No YAML anchors for repeated blocks (DRY violation)
 
+### Module / Collection Hallucinations (Lies)
+
+**Detect:**
+- Parameters that do not exist for the named module
+- Correct parameter names attached to the wrong module or collection
+- `community.*` modules used without the collection being declared or installed
+- Shell commands added because the model could not remember the module shape
+
+**Fix:** Check `ansible-doc`, collection docs, or local collection metadata before keeping module args. Prefer the real module when it exists; use `command`/`shell` only with a stated reason.
+
 ---
 
 ## Helm
@@ -136,6 +156,16 @@ The #1 Ansible slop pattern. If there's a module for it, use the module.
 - Subchart values overridden in parent `values.yaml` without documenting why
 - No `NOTES.txt` for post-install instructions
 - `.helmignore` missing, including test/ci files in the packaged chart
+
+### Values / Template Drift (Lies)
+
+**Detect:**
+- Keys in `values.yaml` that no template consumes
+- Template lookups for values that are never defined, documented, or defaulted
+- Copy-pasted Kubernetes fields stuffed into chart values with no matching template logic
+- Version-specific chart values copied from another chart or release line
+
+**Fix:** Grep templates and chart docs to confirm a value path is real. Delete dead values. Add defaults or documentation for optional ones.
 
 ---
 
@@ -173,6 +203,16 @@ The #1 Ansible slop pattern. If there's a module for it, use the module.
 - `emptyDir` for persistent data
 - Sidecar containers doing what an init container should
 - `nodeSelector` with a single node name (defeats scheduling)
+
+### API Version / Field Drift (Lies)
+
+**Detect:**
+- `apiVersion` and field combinations that do not belong together for the target cluster version
+- Fields copied from a blog, CRD, or older manifest into the wrong object kind
+- Probes, securityContext, or rollout fields nested at the wrong level but still looking plausible in YAML
+- `kubectl` flags in scripts or docs that do not exist for the actual client version in use
+
+**Fix:** Validate against cluster/OpenAPI schema or client-side validators (`kubectl apply --dry-run=client`, `kubeconform`, generated CRD schemas). Keep manifests version-aware instead of "YAML-shaped."
 
 ## Proxmox / LXC / VM IaC Patterns
 

--- a/skills/anti-slop/references/python.md
+++ b/skills/anti-slop/references/python.md
@@ -143,3 +143,15 @@ except ConnectionError:
 - `except: pass` - silent swallow with no comment
 - `logging.exception()` in every function instead of at boundaries
 - Re-raising as generic `RuntimeError` losing the original exception type
+
+## AI-Native Tells (Lies + Soul)
+
+**Detect:**
+- `dict.get("key", {})` or `obj.attr if obj else {}` chains used to hide a missing invariant instead of checking the real contract once
+- Broad `try/except` wrapped around its own explicit validation and raises
+- Catch-log-reraise blocks that add no context and make the function look "safe"
+- Dataclasses or tiny classes created only to hold one function and a logger
+- Mock-heavy tests using `MagicMock` everywhere, with assertions only on method calls instead of returned behavior or state
+- Library methods that sound Pythonic but are not real in the installed package or stdlib version
+
+**Fix:** Validate once at the boundary, then trust internal invariants. Use narrow exceptions. Prefer behavior assertions over interaction-only tests. When a method or module name looks suspicious, verify it in the local environment or docs before rewriting around it.

--- a/skills/anti-slop/references/research-sources.md
+++ b/skills/anti-slop/references/research-sources.md
@@ -29,6 +29,21 @@ Read this file for deeper context on specific findings or when the user wants ci
 - Sloplint: github.com/dannote/sloplint
 - Anti-slop (peakoss): github.com/peakoss/anti-slop
 
+## Community / Recent Signals
+
+- Medium: "The Illusion of Fluency and the Risk of Overtrust in AI-Assisted Coding" - medium.com/@rafaelperin/the-illusion-of-fluency-and-the-risk-of-overtrust-in-ai-assisted-coding-5ca8fca84907
+- Medium: "I Let AI Write Tests for 2 Months. 100% Coverage. 0% Useful." - medium.com/lets-code-future/i-let-ai-write-tests-for-2-months-100-coverage-0-useful-heres-what-broke-in-production-c088a5ecd030
+- DEV: "AI Writes Your Tests. Here's What It Systematically Misses." - dev.to/anhnguyensynctree/ai-writes-your-tests-heres-what-it-systematically-misses-3a38
+- Hacker News discussion: "Toward automated verification of unreviewed AI-generated code" - news.ycombinator.com/item?id=47397367
+- Lemmy discussion amplifying AI-vs-human code quality concerns - lemmy.world/post/40761686
+
+## Repeated Failure Themes
+
+- Fluent output gets over-trusted because it looks intentional even when it is not grounded.
+- Generated tests often mirror the implementation and validate the same wrong assumption.
+- Models use fallback defaults, broad catches, and extra wrappers to hide uncertainty.
+- Hallucinated APIs, flags, resource fields, and version mismatches are common in IaC and shell-heavy repos because the syntax is plausible enough to survive casual review.
+
 ## The "No Soul" Problem
 
 The hardest slop to detect programmatically. Code that compiles, passes tests, and follows conventions - but feels generic. Signs:

--- a/skills/anti-slop/references/shell.md
+++ b/skills/anti-slop/references/shell.md
@@ -104,3 +104,14 @@ cd "$(dirname "$0")"
 - Missing `readonly` on constants
 
 **Fix:** Use `main()` pattern for scripts >50 lines. Define functions before use. Use `readonly` for constants. Accept paths as arguments with sensible defaults.
+
+## AI-Native Tells (Lies + Soul)
+
+**Detect:**
+- Hallucinated flags or subcommands copied from adjacent CLIs (`--json`, `--force`, `--yes`, `config get`) without checking `--help`
+- `2>/dev/null || true` glued onto uncertain commands to make the script "robust"
+- Large inline heredocs used to generate YAML/JSON/config in automation when the repo already has templates or source files
+- Retry loops and sleeps around local deterministic commands instead of fixing ordering or preconditions
+- `command -v tool >/dev/null || install_tool` inside project scripts where tool installation should be explicit
+
+**Fix:** Check the real CLI help text before keeping a flag. Let failures surface unless the non-zero is expected and documented. Prefer checked-in files or templates over opaque heredocs for non-trivial config. Keep installation/bootstrap separate from normal task scripts.

--- a/skills/anti-slop/references/typescript.md
+++ b/skills/anti-slop/references/typescript.md
@@ -23,7 +23,7 @@ TypeScript's inference is good. Fighting it with redundant annotations is noise.
 - `const` type parameters (TS 5.0+) where applicable
 - Template literal types for string patterns
 - `using` / `Symbol.dispose` (TS 5.2+) for resource cleanup
-- `X | null` over `Optional<X>` for simple nullable types
+- Plain unions (`T | null`, `T | undefined`) over homegrown `Optional<T>` wrappers for simple nullable types
 
 ## Stale Patterns (Lies)
 
@@ -63,6 +63,20 @@ TypeScript's inference is good. Fighting it with redundant annotations is noise.
 - Two HTTP clients (e.g., `axios` + `node-fetch`)
 - Two date libraries
 - `dotenv` when the runtime supports `.env` natively (Bun, Deno, Node 20.6+)
+
+## AI-Native Tells (Lies + Soul)
+
+Patterns that often look polished enough to pass review unless someone asks, "Why does this exist?"
+
+**Detect:**
+- `try/catch` around deterministic local code (`console.*`, object spreads, pure transforms) where the catch only logs or returns a fallback
+- `new Promise(async (resolve, reject) => { ... })` or extra promise wrappers around already-async code
+- Required env/config read with a silent default: `process.env.API_URL ?? 'http://localhost:3000'` in production code
+- Internal helper calls guarded with `if (!response.ok)` or null checks even though the helper already normalizes failures
+- Tests that only assert `toHaveBeenCalledTimes`, exact mock arguments, or snapshots without checking returned behavior
+- Invented framework APIs, hook options, or config keys that are not present in local types or docs
+
+**Fix:** Delete defensive wrappers that add no recovery. Fail loudly on required config. Let the type system and real boundary checks do the work. For suspected hallucinations, check the project's installed types, generated docs, or framework docs before flagging.
 
 ## Barrel Files (Noise)
 


### PR DESCRIPTION
## Summary
- expand anti-slop to cover AI-native lies like hallucinated APIs, schema drift, and test theater
- add sharper TS, Python, Shell, and IaC reference examples for grounded review
- refresh the README summary to match the broader anti-slop scope

## Test Plan
- ./scripts/lint-skills.sh
- ./scripts/validate-spec.sh
- bash -n install.sh
- shellcheck scripts/lint-skills.sh scripts/validate-spec.sh install.sh