### PR TITLE
ci(repo): expand quality gates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,25 +1,35 @@
-name: Lint Skills
+name: Quality Gates
 
 on:
   push:
     branches: [main]
     paths:
-      - 'skills/**'
-      - 'scripts/**'
-      - 'install.sh'
-      - '.github/workflows/lint.yml'
+      - "skills/**"
+      - "scripts/**"
+      - "install.sh"
+      - "README.md"
+      - "SECURITY.md"
+      - "docs/**"
+      - ".markdownlint-cli2.jsonc"
+      - "lychee.toml"
+      - ".github/workflows/**"
   pull_request:
     paths:
-      - 'skills/**'
-      - 'scripts/**'
-      - 'install.sh'
-      - '.github/workflows/lint.yml'
+      - "skills/**"
+      - "scripts/**"
+      - "install.sh"
+      - "README.md"
+      - "SECURITY.md"
+      - "docs/**"
+      - ".markdownlint-cli2.jsonc"
+      - "lychee.toml"
+      - ".github/workflows/**"
 
 permissions:
   contents: read
 
 jobs:
-  lint:
+  collection:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -30,11 +40,92 @@ jobs:
       - name: Validate Agent Skills spec compliance
         run: ./scripts/validate-spec.sh
 
-      - name: Check installer syntax
-        run: bash -n install.sh
+      - name: Check whitespace and merge markers
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git fetch origin "$BASE_REF" --depth=1
+            git diff --check "origin/$BASE_REF"...HEAD
+          else
+            git diff-tree --check --no-commit-id -r HEAD
+          fi
+
+  shell-and-python:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check shell syntax
+        run: |
+          bash -n install.sh
+          bash -n scripts/lint-skills.sh
+          bash -n scripts/validate-spec.sh
 
       - name: Shellcheck scripts
-        run: shellcheck scripts/lint-skills.sh scripts/validate-spec.sh install.sh
+        run: shellcheck install.sh scripts/lint-skills.sh scripts/validate-spec.sh scripts/skill-lib.sh
+
+      - name: Check Python helper syntax
+        run: python3 -m py_compile scripts/skill-frontmatter.py
+
+  markdown:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install markdownlint-cli2
+        run: |
+          npm install --prefix "$RUNNER_TEMP/markdownlint-cli2" markdownlint-cli2@0.22.0
+          echo "$RUNNER_TEMP/markdownlint-cli2/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Lint Markdown
+        run: markdownlint-cli2
+
+  links:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install lychee
+        env:
+          LYCHEE_VERSION: "0.23.0"
+          LYCHEE_SHA256: "1fcb6ccf10d04c22b8c5873c5b9cb7be32ee7423e12169d6f1a79a6f1962ef81"
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSLo /tmp/lychee.tar.gz "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${LYCHEE_SHA256}  /tmp/lychee.tar.gz" | sha256sum --check
+          tar -xzf /tmp/lychee.tar.gz -C "$HOME/.local/bin" lychee
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Check links
+        run: |
+          mapfile -t markdown_files < <(
+            {
+              printf '%s\n' README.md SECURITY.md
+              find skills docs -type f -name '*.md' 2>/dev/null
+            } | sort -u
+          )
+          lychee --config lychee.toml "${markdown_files[@]}"
+
+  workflow:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSLo /tmp/actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum --check
+          tar -xzf /tmp/actionlint.tar.gz -C "$HOME/.local/bin" actionlint
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Lint GitHub Actions workflows
+        run: actionlint -color
 
   security:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             git fetch origin "$BASE_REF" --depth=1
-            git diff --check "origin/$BASE_REF"...HEAD
+            git diff --check "origin/$BASE_REF"..HEAD
           else
             git diff-tree --check --no-commit-id -r HEAD
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ skills/cluster-health/
 docs/superpowers/
 SECURITY-AUDIT.md
 .codex
+__pycache__/

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "default": false,
+    "code-block-style": {
+      "style": "fenced"
+    },
+    "code-fence-style": {
+      "style": "backtick"
+    },
+    "no-duplicate-heading": {
+      "siblings_only": true
+    }
+  },
+  "globs": [
+    "README.md",
+    "SECURITY.md",
+    "skills/**/*.md",
+    "docs/**/*.md"
+  ]
+}

--- a/docs/superpowers/specs/2026-04-14-ci-quality-gates-design.md
+++ b/docs/superpowers/specs/2026-04-14-ci-quality-gates-design.md
@@ -1,0 +1,297 @@
+# CI Quality Gates - Design Spec
+
+**Date:** 2026-04-14
+**Status:** Draft
+**Author:** iuliandita + Codex
+
+Expand the existing GitHub Actions workflow into a fuller but still practical PR gate for a Markdown-heavy repo. The repo already has useful shell and security checks. The goal is to add the missing "big boys" checks without turning a small skills repo into a slow, noisy enterprise parody.
+
+---
+
+## 1. Goals
+
+- Keep the existing shell, security, and collection-validation coverage
+- Add first-class Markdown and workflow validation
+- Catch broken links and low-grade git hygiene issues early
+- Keep the workflow understandable from the YAML alone
+- Avoid adding tools that require a long tuning phase before they become useful
+
+## 2. Non-Goals
+
+- No prose-style enforcement with Vale, cSpell, or grammar bots in this pass
+- No package-manager-based build setup for the empty `package.json`
+- No broad Semgrep scan over the Markdown corpus
+- No separate release workflow in this pass
+
+---
+
+## 3. Current State
+
+The repo already has one GitHub Actions workflow at `.github/workflows/lint.yml` with two jobs:
+
+- `lint`
+  - `./scripts/lint-skills.sh`
+  - `./scripts/validate-spec.sh`
+  - `bash -n install.sh`
+  - `shellcheck scripts/lint-skills.sh scripts/validate-spec.sh install.sh`
+- `security`
+  - `gitleaks`
+  - `semgrep` over `install.sh`, `scripts`, and `.github/workflows`
+
+This is a good base, but it is missing:
+
+- Markdown linting for the repo's main content surface
+- Broken-link checks
+- GitHub Actions workflow validation
+- Verification for the new Python helper under `scripts/`
+- A low-cost git hygiene check for whitespace and merge-marker junk
+
+---
+
+## 4. Proposed Architecture
+
+Keep a single workflow file, but split it into focused jobs so failures are readable:
+
+1. `collection`
+2. `shell-and-python`
+3. `markdown`
+4. `links`
+5. `workflow`
+6. `security`
+
+All jobs run on:
+
+- `pull_request`
+- `push` to `main`
+
+All jobs use path filtering so unrelated pushes do not trigger them. The workflow should include:
+
+- `skills/**`
+- `scripts/**`
+- `install.sh`
+- `README.md`
+- `SECURITY.md`
+- `.github/workflows/**`
+- `docs/**`
+
+The existing security job remains independent so doc-only failures do not hide security results.
+
+---
+
+## 5. Job Design
+
+### 5.1 `collection`
+
+Purpose: keep the existing repo-specific contract checks.
+
+Steps:
+
+- checkout
+- `./scripts/lint-skills.sh`
+- `./scripts/validate-spec.sh`
+- `git diff --check`
+
+Rationale:
+
+- These are the highest-signal checks in the repo
+- `git diff --check` is a cheap way to catch whitespace breakage and conflict markers
+
+### 5.2 `shell-and-python`
+
+Purpose: validate executable repo tooling.
+
+Steps:
+
+- checkout
+- `bash -n install.sh`
+- `bash -n scripts/lint-skills.sh`
+- `bash -n scripts/validate-spec.sh`
+- `shellcheck install.sh scripts/lint-skills.sh scripts/validate-spec.sh scripts/skill-lib.sh`
+- `python3 -m py_compile scripts/skill-frontmatter.py`
+
+Rationale:
+
+- The repo now has a small Python helper and it should be treated as first-class executable code
+- This keeps the CI signal grounded in the repo's actual non-Markdown surface
+
+### 5.3 `markdown`
+
+Purpose: enforce consistent Markdown structure and catch sloppy formatting drift.
+
+Tool:
+
+- `markdownlint-cli2`
+
+Scope:
+
+- `README.md`
+- `SECURITY.md`
+- `skills/**/*.md`
+- `docs/**/*.md`
+
+Configuration:
+
+- Prefer a repo-level `.markdownlint-cli2.jsonc`
+- Start with pragmatic rules only
+- Disable any rule that creates high churn for deliberate collection style
+
+Initial expected adjustments:
+
+- Heading increment/order
+- Blank lines around lists/code blocks
+- Line-length policy should be explicit instead of relying on defaults
+
+### 5.4 `links`
+
+Purpose: catch stale external links and broken internal anchors.
+
+Tool:
+
+- `lychee`
+
+Scope:
+
+- `README.md`
+- `SECURITY.md`
+- `skills/**/*.md`
+- `docs/**/*.md`
+
+Configuration:
+
+- Add a repo-level `lychee.toml`
+- Ignore obvious non-resolvable examples when justified
+- Keep retries and timeout sane to avoid flaky runs
+
+Expected ignores:
+
+- Example domains that are intentionally non-live
+- Possibly local-only paths or anchors if the tool cannot resolve them correctly
+
+### 5.5 `workflow`
+
+Purpose: validate GitHub Actions YAML and workflow usage.
+
+Tool:
+
+- `actionlint`
+
+Scope:
+
+- `.github/workflows/*.yml`
+
+Rationale:
+
+- The repo is adding more CI surface; the workflow itself should be linted like code
+
+### 5.6 `security`
+
+Purpose: preserve the current security signal.
+
+Keep:
+
+- `gitleaks`
+- `semgrep`
+
+Change:
+
+- No major scope expansion in this pass
+
+Rationale:
+
+- Current scope is sane for a Markdown-heavy repo
+- Expanding security scanning over doc content will mostly buy false positives
+
+---
+
+## 6. Configuration Files
+
+Add:
+
+- `.markdownlint-cli2.jsonc`
+- `lychee.toml`
+
+Do not add:
+
+- `vale.ini`
+- `.cspell.json`
+- package-manager tool config that implies a JS toolchain commitment
+
+Configuration should live in-repo so the rules are obvious to contributors and easy to tweak.
+
+---
+
+## 7. Failure Philosophy
+
+The workflow should be strict on structure and correctness, but conservative on style noise.
+
+Fail hard on:
+
+- invalid skill collection structure
+- invalid workflow YAML
+- shell/python syntax issues
+- broken links
+- security findings
+- merge markers / whitespace errors
+
+Be pragmatic on:
+
+- Markdown line length
+- style rules that fight the collection's intentional format
+
+If a rule creates broad churn without improving review quality, disable it instead of training contributors to ignore CI.
+
+---
+
+## 8. Implementation Plan
+
+1. Fix the in-flight frontmatter helper so it is dependency-free and CI-safe
+2. Add `.markdownlint-cli2.jsonc` with pragmatic defaults for this repo
+3. Add `lychee.toml` with minimal justified ignores
+4. Expand `.github/workflows/lint.yml` into the six-job layout
+5. Run the local equivalents of the new checks where possible
+6. Review the resulting CI runtime and trim any noisy or redundant rule
+
+---
+
+## 9. Risks and Mitigations
+
+### Risk: Markdown lint churn is too high
+
+Mitigation:
+
+- start with narrow scope and pragmatic rule config
+- disable rules that fight the repo's established style
+
+### Risk: Link checking is flaky
+
+Mitigation:
+
+- use conservative timeout/retry settings
+- explicitly ignore known example-only targets
+
+### Risk: New CI breaks because the Python helper adds hidden dependencies
+
+Mitigation:
+
+- keep the helper stdlib-only
+- compile-check it explicitly in CI
+
+### Risk: Workflow becomes hard to read
+
+Mitigation:
+
+- keep one workflow file
+- split by job responsibility, not by tool novelty
+
+---
+
+## 10. Success Criteria
+
+The design is successful if:
+
+- CI still feels lightweight relative to the repo size
+- Markdown regressions are caught automatically
+- broken links are surfaced in PRs
+- GitHub Actions changes are linted before merge
+- the Python helper is checked in CI without adding a package bootstrap step
+- contributors can understand the workflow without reading external docs

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./scripts/skill-lib.sh
+source "$SCRIPT_DIR/scripts/skill-lib.sh"
+
 SKILLS_SRC="$SCRIPT_DIR/skills"
 CANONICAL_DIR="${SKILLS_CANONICAL_DIR:-$HOME/.agents/skills}"
 
@@ -34,44 +37,60 @@ SUPPORTED_TOOLS=(
   portable
 )
 
+declare -A TOOL_PATHS=(
+  [claude]="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
+  [codex]="${CODEX_SKILLS_DIR:-$HOME/.codex/skills}"
+  [cursor]="${CURSOR_SKILLS_DIR:-$HOME/.cursor/skills}"
+  [windsurf]="${WINDSURF_SKILLS_DIR:-$HOME/.windsurf/skills}"
+  [opencode]="${OPENCODE_SKILLS_DIR:-$HOME/.config/opencode/skills}"
+  [copilot]="$HOME/.copilot/skills"
+  [gemini]="$HOME/.gemini/skills"
+  [roo]="$HOME/.roo/skills"
+  [goose]="$HOME/.config/goose/skills"
+  [amp]="$HOME/.amp/skills"
+  [continue]="$HOME/.continue/skills"
+  [kiro]="$HOME/.kiro/skills"
+  [cline]="$HOME/.cline/skills"
+  [warp]="$HOME/.warp/skills"
+  [portable]="${PORTABLE_SKILLS_DIR:-$HOME/.skills}"
+)
+
+supported_tools_text() {
+  local tool
+  local text=""
+  for tool in "${SUPPORTED_TOOLS[@]}"; do
+    if [[ -n "$text" ]]; then
+      text+=", "
+    fi
+    text+="$tool"
+  done
+  printf '%s' "$text"
+}
+
 # ── Agent path resolution ─────────────────────────────────────────────
 resolve_tool_path() {
-  case "$1" in
-    claude)   printf '%s\n' "${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}" ;;
-    codex)    printf '%s\n' "${CODEX_SKILLS_DIR:-$HOME/.codex/skills}" ;;
-    cursor)   printf '%s\n' "${CURSOR_SKILLS_DIR:-$HOME/.cursor/skills}" ;;
-    windsurf) printf '%s\n' "${WINDSURF_SKILLS_DIR:-$HOME/.windsurf/skills}" ;;
-    opencode) printf '%s\n' "${OPENCODE_SKILLS_DIR:-$HOME/.config/opencode/skills}" ;;
-    copilot)  printf '%s\n' "$HOME/.copilot/skills" ;;
-    gemini)   printf '%s\n' "$HOME/.gemini/skills" ;;
-    roo)      printf '%s\n' "$HOME/.roo/skills" ;;
-    goose)    printf '%s\n' "$HOME/.config/goose/skills" ;;
-    amp)      printf '%s\n' "$HOME/.amp/skills" ;;
-    continue) printf '%s\n' "$HOME/.continue/skills" ;;
-    kiro)     printf '%s\n' "$HOME/.kiro/skills" ;;
-    cline)    printf '%s\n' "$HOME/.cline/skills" ;;
-    warp)     printf '%s\n' "$HOME/.warp/skills" ;;
-    portable) printf '%s\n' "${PORTABLE_SKILLS_DIR:-$HOME/.skills}" ;;
-    *)
-      printf 'Unknown tool: %s\n' "$1" >&2
-      printf 'Supported: %s\n' "${SUPPORTED_TOOLS[*]}" >&2
-      exit 1
-      ;;
-  esac
+  local tool="$1"
+  local path="${TOOL_PATHS[$tool]:-}"
+
+  if [[ -z "$path" ]]; then
+    printf 'Unknown tool: %s\n' "$tool" >&2
+    printf 'Supported: %s\n' "$(supported_tools_text)" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$path"
 }
 
 # ── Usage ─────────────────────────────────────────────────────────────
 usage() {
-  cat <<'EOF'
+  cat <<EOF
 Usage: install.sh [OPTIONS] [SKILL...]
 
 Install skills for AI coding agents.
 
 Options:
   --tool TOOL         Target tool (repeatable, comma-separated)
-                      Supported: claude, codex, cursor, windsurf, opencode,
-                      copilot, gemini, roo, goose, amp, continue, kiro,
-                      cline, warp, portable
+                      Supported: $(supported_tools_text)
   --dest PATH         Override destination directory (single-tool mode only)
   --link              Symlink mode: install once to canonical dir, symlink per tool
   --list              List available skills and install status
@@ -123,8 +142,8 @@ skill_hash() {
 is_internal() {
   local skill_dir="$1"
   [[ -f "$skill_dir/SKILL.md" ]] || return 1
-  sed -n '2,/^---$/{ /^---$/d; p; }' "$skill_dir/SKILL.md" \
-    | grep -qE '^\s+internal:\s*(true|yes)$'
+  frontmatter_has "$skill_dir/SKILL.md" "metadata.internal" \
+    && [[ "$(frontmatter_get "$skill_dir/SKILL.md" "metadata.internal")" == "true" ]]
 }
 
 # ── Backup ────────────────────────────────────────────────────────────

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,16 @@
+verbose = "info"
+max_concurrency = 8
+max_retries = 2
+retry_wait_time = 2
+timeout = 20
+accept = ["200", "203", "204", "206", "429"]
+
+exclude = [
+  "^http://localhost",
+  "^http://127\\.0\\.0\\.1",
+  "^http://0\\.0\\.0\\.0",
+  "^http://169\\.254\\.169\\.254",
+  "^https?://(?:[A-Za-z0-9-]+\\.)?example\\.(?:com|org)",
+  "^https?://example-store\\.com",
+  "^https?://internal\\.example\\.com"
+]

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2016
+# shellcheck disable=SC2016,SC1091
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/skill-lib.sh"
 
 # Lint all skills in the collection for common issues.
 # Runs in CI and locally. Exit 0 = clean, exit 1 = issues found.
@@ -34,30 +37,30 @@ check_private_refs() {
 # ── Frontmatter checks ─────────────────────────────────────────────────
 check_frontmatter() {
   local file="$1" name="$2"
-
-  # Extract frontmatter block (between first --- and second ---)
-  local fm
-  fm=$(sed -n '2,/^---$/{ /^---$/d; p; }' "$file")
+  if ! frontmatter_valid "$file"; then
+    error "$name: invalid YAML frontmatter"
+    return
+  fi
 
   # Required top-level fields (Agent Skills spec)
   for field in name description license; do
-    if ! echo "$fm" | grep -q "^${field}:"; then
+    if ! frontmatter_has "$file" "$field"; then
       error "$name: missing frontmatter field '$field'"
     fi
   done
 
   # Required metadata fields (custom, nested under metadata:)
-  if ! echo "$fm" | grep -q '^metadata:'; then
+  if ! frontmatter_has "$file" "metadata"; then
     error "$name: missing 'metadata:' block"
   fi
   for field in source date_added effort; do
-    if ! echo "$fm" | grep -q "^  ${field}:"; then
+    if ! frontmatter_has "$file" "metadata.$field"; then
       error "$name: missing metadata field '$field'"
     fi
   done
 
   local src
-  src=$(echo "$fm" | grep -m1 '^  source:' 2>/dev/null | sed 's/.*source: *//' || true)
+  src="$(frontmatter_get "$file" "metadata.source" 2>/dev/null || true)"
   if [[ -z "$src" ]]; then
     error "$name: metadata.source is empty"
   elif [[ "$src" != "custom" && ! "$src" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
@@ -65,28 +68,28 @@ check_frontmatter() {
   fi
 
   local eff
-  eff=$(echo "$fm" | grep -m1 '^  effort:' 2>/dev/null | sed 's/.*effort: *//' || true)
+  eff="$(frontmatter_get "$file" "metadata.effort" 2>/dev/null || true)"
   if [[ "$eff" != "low" && "$eff" != "medium" && "$eff" != "high" ]]; then
     error "$name: metadata.effort must be low/medium/high, got '$eff'"
   fi
 
   # Optional: metadata.argument_hint (string, max 100 chars)
   local arg_hint
-  arg_hint=$(echo "$fm" | grep -m1 '^  argument_hint:' 2>/dev/null | sed 's/.*argument_hint: *//' || true)
+  arg_hint="$(frontmatter_get "$file" "metadata.argument_hint" 2>/dev/null || true)"
   if [[ -n "$arg_hint" && ${#arg_hint} -gt 100 ]]; then
     error "$name: metadata.argument_hint exceeds 100 characters"
   fi
 
   # Optional: metadata.internal (boolean)
   local internal
-  internal=$(echo "$fm" | grep -m1 '^  internal:' 2>/dev/null | sed 's/.*internal: *//' || true)
+  internal="$(frontmatter_get "$file" "metadata.internal" 2>/dev/null || true)"
   if [[ -n "$internal" && "$internal" != "true" && "$internal" != "false" ]]; then
     error "$name: metadata.internal must be true or false, got '$internal'"
   fi
 
   # Validate name matches directory (Agent Skills spec requirement)
   local fm_name
-  fm_name=$(echo "$fm" | grep -m1 '^name:' 2>/dev/null | sed 's/name: *//' || true)
+  fm_name="$(frontmatter_get "$file" "name" 2>/dev/null || true)"
   if [[ "$fm_name" != "$name" ]]; then
     error "$name: frontmatter name '$fm_name' does not match directory name"
   fi
@@ -183,7 +186,7 @@ check_banned_words() {
 check_ai_self_check() {
   local file="$1" name="$2"
   local effort
-  effort=$(sed -n '2,/^---$/p' "$file" | grep -m1 'effort:' | sed 's/.*effort: *//' || true)
+  effort="$(frontmatter_get "$file" "metadata.effort" 2>/dev/null || true)"
   if [[ "$effort" == "high" ]]; then
     if ! grep -qi '^## .*Self.Check' "$file"; then
       warn "$name: high-effort skill without 'AI Self-Check' section (recommended for skills that generate output)"

--- a/scripts/skill-frontmatter.py
+++ b/scripts/skill-frontmatter.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Parse and query skill frontmatter without external dependencies."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+def load_frontmatter(path_str: str) -> dict[str, Any]:
+    text = pathlib.Path(path_str).read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        raise ValueError("missing frontmatter start")
+
+    try:
+        end_index = lines[1:].index("---") + 1
+    except ValueError as exc:
+        raise ValueError("missing frontmatter end") from exc
+
+    data, next_index = parse_mapping(lines[1:end_index])
+    if next_index != end_index - 1:
+        raise ValueError("unexpected trailing content in frontmatter")
+
+    return data
+
+
+def get_value(data: dict[str, Any], path: str) -> Any:
+    current: Any = data
+    for segment in path.split("."):
+        if not isinstance(current, dict) or segment not in current:
+            raise KeyError(path)
+        current = current[segment]
+
+    if current is None:
+        raise KeyError(path)
+
+    return current
+
+
+def print_value(value: Any) -> None:
+    if isinstance(value, bool):
+        print("true" if value else "false")
+        return
+    if isinstance(value, (dict, list)):
+        print(json.dumps(value, sort_keys=True))
+        return
+    print(value)
+
+
+def parse_mapping(lines: list[str], start: int = 0, indent: int = 0) -> tuple[dict[str, Any], int]:
+    data: dict[str, Any] = {}
+    index = start
+
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            index += 1
+            continue
+
+        current_indent = len(line) - len(line.lstrip(" "))
+        if current_indent < indent:
+            break
+        if current_indent > indent:
+            raise ValueError(f"unexpected indentation: {line!r}")
+
+        stripped = line.strip()
+        if ":" not in stripped:
+            raise ValueError(f"expected key/value pair: {line!r}")
+
+        key, raw_value = stripped.split(":", 1)
+        raw_value = raw_value.lstrip()
+
+        if not raw_value:
+            value, index = parse_nested(lines, index + 1, indent + 2)
+            data[key] = value
+            continue
+
+        if raw_value in {">", "|"}:
+            value, index = parse_block(lines, index + 1, indent + 2, raw_value)
+            data[key] = value
+            continue
+
+        data[key] = parse_scalar(raw_value)
+        index += 1
+
+    return data, index
+
+
+def parse_nested(lines: list[str], start: int, indent: int) -> tuple[Any, int]:
+    index = start
+    while index < len(lines) and not lines[index].strip():
+        index += 1
+
+    if index >= len(lines):
+        raise ValueError("expected nested value")
+
+    current_indent = len(lines[index]) - len(lines[index].lstrip(" "))
+    if current_indent < indent:
+        raise ValueError("expected nested value")
+
+    if lines[index].strip().startswith("- "):
+        return parse_sequence(lines, index, indent)
+    return parse_mapping(lines, index, indent)
+
+
+def parse_sequence(lines: list[str], start: int, indent: int) -> tuple[list[Any], int]:
+    items: list[Any] = []
+    index = start
+
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            index += 1
+            continue
+
+        current_indent = len(line) - len(line.lstrip(" "))
+        if current_indent < indent:
+            break
+        if current_indent != indent:
+            raise ValueError(f"unexpected indentation in sequence: {line!r}")
+
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            break
+
+        item = stripped[2:].lstrip()
+        if not item:
+            raise ValueError(f"empty sequence item: {line!r}")
+
+        items.append(parse_scalar(item))
+        index += 1
+
+    return items, index
+
+
+def parse_block(lines: list[str], start: int, indent: int, style: str) -> tuple[str, int]:
+    block_lines: list[str] = []
+    index = start
+
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            block_lines.append("")
+            index += 1
+            continue
+
+        current_indent = len(line) - len(line.lstrip(" "))
+        if current_indent < indent:
+            break
+
+        block_lines.append(line[indent:])
+        index += 1
+
+    if style == "|":
+        return "\n".join(block_lines).rstrip(), index
+
+    paragraphs: list[str] = []
+    current: list[str] = []
+    for line in block_lines:
+        if line == "":
+            if current:
+                paragraphs.append(" ".join(current))
+                current = []
+            if not paragraphs or paragraphs[-1] != "":
+                paragraphs.append("")
+            continue
+        current.append(line.strip())
+
+    if current:
+        paragraphs.append(" ".join(current))
+
+    return "\n".join(part for part in paragraphs if part != "" or len(paragraphs) == 1).rstrip(), index
+
+
+def parse_scalar(raw_value: str) -> Any:
+    if len(raw_value) >= 2 and raw_value[0] == raw_value[-1] and raw_value[0] in {"'", '"'}:
+        return raw_value[1:-1]
+
+    lowered = raw_value.lower()
+    if lowered in {"true", "yes"}:
+        return True
+    if lowered in {"false", "no"}:
+        return False
+
+    return raw_value
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print("usage: skill-frontmatter.py {valid|get|has} <file> [path]", file=sys.stderr)
+        return 2
+
+    command = argv[1]
+    file_path = argv[2]
+
+    try:
+        data = load_frontmatter(file_path)
+        if command == "valid":
+            return 0
+        if len(argv) < 4:
+            print(f"{command}: missing path", file=sys.stderr)
+            return 2
+        value = get_value(data, argv[3])
+    except (OSError, ValueError, KeyError):
+        return 1
+
+    if command == "get":
+        print_value(value)
+        return 0
+    if command == "has":
+        return 0
+
+    print(f"unknown command: {command}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/skill-lib.sh
+++ b/scripts/skill-lib.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+SKILL_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTMATTER_PY="$SKILL_LIB_DIR/skill-frontmatter.py"
+
+frontmatter_valid() {
+  local file="$1"
+  python3 "$FRONTMATTER_PY" valid "$file"
+}
+
+frontmatter_get() {
+  local file="$1" path="$2"
+  python3 "$FRONTMATTER_PY" get "$file" "$path"
+}
+
+frontmatter_has() {
+  local file="$1" path="$2"
+  python3 "$FRONTMATTER_PY" has "$file" "$path"
+}

--- a/scripts/validate-spec.sh
+++ b/scripts/validate-spec.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2016
+# shellcheck disable=SC2016,SC1091
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/skill-lib.sh"
 
 # Validate skills against the Agent Skills open standard (agentskills.io/specification).
 # Checks naming conventions, required fields, and structural requirements.
@@ -34,19 +37,13 @@ validate_name() {
 }
 
 validate_description() {
-  local fm="$1" name="$2"
-  # Extract description value (handles multiline YAML)
+  local file="$1" name="$2"
   local desc
-  desc=$(printf '%s\n' "$fm" | sed -n '/^description:/,/^[a-z_-]*:/{ /^description:/{ s/^description: *//; p; }; /^  /p; }' | tr -d '\n' | sed 's/^ *//')
+  desc="$(frontmatter_get "$file" "description" 2>/dev/null || true)"
   if [[ -z "$desc" ]]; then
     error "$name: description is empty"
     return
   fi
-  # Strip YAML quoting for length check
-  desc="${desc#\"}"
-  desc="${desc%\"}"
-  desc="${desc#>}"
-  desc="${desc#"${desc%%[![:space:]]*}"}"
   if [[ ${#desc} -gt 600 ]]; then
     error "$name: description exceeds 600 characters (${#desc})"
   elif [[ ${#desc} -gt 500 ]]; then
@@ -57,13 +54,9 @@ validate_description() {
 validate_compatibility() {
   local file="$1" name="$2"
   local compat
-  compat=$(grep -m1 '^compatibility:' "$file" 2>/dev/null | sed 's/compatibility: *//' || true)
+  compat="$(frontmatter_get "$file" "compatibility" 2>/dev/null || true)"
   if [[ -n "$compat" && ${#compat} -gt 500 ]]; then
     error "$name: compatibility exceeds 500 characters (${#compat})"
-  fi
-  # Values containing colons must be quoted (strict YAML parsers choke otherwise)
-  if [[ -n "$compat" && "$compat" == *:* && "$compat" != \"*\" && "$compat" != \'*\' ]]; then
-    error "$name: compatibility value contains ':' but is not quoted (breaks strict YAML parsers)"
   fi
 }
 
@@ -90,27 +83,30 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     error "$name: SKILL.md must start with YAML frontmatter (---)"
   fi
 
-  # Extract frontmatter block (between first --- and second ---)
-  fm=$(sed -n '2,/^---$/{ /^---$/d; p; }' "$skill_file")
+  if ! frontmatter_valid "$skill_file"; then
+    error "$name: invalid YAML frontmatter"
+    (( skill_count++ )) || true
+    continue
+  fi
 
-  fm_name=$(echo "$fm" | grep -m1 '^name:' 2>/dev/null | sed 's/name: *//' || true)
+  fm_name="$(frontmatter_get "$skill_file" "name" 2>/dev/null || true)"
   if [[ "$fm_name" != "$name" ]]; then
     error "$name: frontmatter name '$fm_name' does not match directory name"
   fi
 
   # Spec: required fields
-  if ! echo "$fm" | grep -q '^name:'; then
+  if ! frontmatter_has "$skill_file" "name"; then
     error "$name: missing required field 'name'"
   fi
-  if ! echo "$fm" | grep -q '^description:'; then
+  if ! frontmatter_has "$skill_file" "description"; then
     error "$name: missing required field 'description'"
   fi
-  if ! echo "$fm" | grep -q '^license:'; then
+  if ! frontmatter_has "$skill_file" "license"; then
     error "$name: missing required field 'license'"
   fi
 
   # Spec: field constraints
-  validate_description "$fm" "$name"
+  validate_description "$skill_file" "$name"
   validate_compatibility "$skill_file" "$name"
 
   # Spec: SKILL.md body recommended under 500 lines (soft target, 600 hard max)


### PR DESCRIPTION
## Summary
- replace regex-style frontmatter scraping with a shared dependency-free Python helper plus shell wrappers
- expand the GitHub Actions workflow into focused collection, shell/python, markdown, links, workflow, and security jobs
- add pragmatic repo configs for markdownlint and lychee, plus ignore Python cache artifacts

## Test Plan
- shellcheck install.sh scripts/*.sh
- bash scripts/lint-skills.sh
- bash scripts/validate-spec.sh
- python3 -m py_compile scripts/skill-frontmatter.py
- bash -lc 'tmpdir=$(mktemp -d) && npm install --prefix "$tmpdir/markdownlint-cli2" markdownlint-cli2@0.22.0 >/tmp/markdownlint-install.log 2>&1 && PATH="$tmpdir/markdownlint-cli2/node_modules/.bin:$PATH" markdownlint-cli2'
- /tmp/ci-tools/actionlint -color
- bash -lc 'mkdir -p /tmp/ci-tools && curl -fsSLo /tmp/ci-tools/lychee.tar.gz https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-gnu.tar.gz && echo "1fcb6ccf10d04c22b8c5873c5b9cb7be32ee7423e12169d6f1a79a6f1962ef81  /tmp/ci-tools/lychee.tar.gz" | sha256sum --check && tar -xzf /tmp/ci-tools/lychee.tar.gz -C /tmp/ci-tools lychee && mapfile -t markdown_files < <({ printf "%s\n" README.md SECURITY.md; find skills docs -type f -name "*.md" 2>/dev/null; } | sort -u) && /tmp/ci-tools/lychee --config lychee.toml "${markdown_files[@]}"'
