### PR TITLE
refactor(anti-slop): surface structural duplication findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The loop: **Score -> Improve -> Verify -> Keep or Revert -> Repeat.**
 | Skill | What it does |
 |-------|-------------|
 | **code-review** | Bug hunting, logic errors, edge cases, race conditions, resource leaks, convention violations |
-| **anti-slop** | Detects and fixes AI-generated code patterns - hallucinated APIs/flags/resources, test theater, over-abstraction, redundant comments, verbose defensive code |
+| **anti-slop** | Detects and fixes AI-generated code patterns - hallucinated APIs/flags/resources, duplicate code, test theater, over-abstraction, redundant comments, verbose defensive code |
 | **anti-ai-prose** | Audits writing for AI tells - vocabulary (delve, tapestry), syntax (negative parallelism, tricolons), tone (travel-guide voice, vague attribution), formatting (em-dash abuse). Covers docs, READMEs, wikis, PRs, emails, slides, creative writing |
 | **backend-api** | HTTP backend APIs - FastAPI, Express, NestJS, REST/OpenAPI contracts, auth flows, versioning, pagination, idempotency |
 | **testing** | Unit, integration, E2E, accessibility, and performance tests - Vitest, Jest, Playwright, pytest, Go testing, cargo test, TDD workflows, mocking strategies, CI test infrastructure |

--- a/skills/anti-slop/SKILL.md
+++ b/skills/anti-slop/SKILL.md
@@ -2,11 +2,11 @@
 name: anti-slop
 description: >
   · Audit code for machine-generated patterns, hallucinated APIs/flags/resources,
-  over-abstraction, test theater, redundant comments, verbose code, and dependency creep.
-  Triggers: 'slop', 'AI-generated code', 'hallucinated API', 'hallucinated flag',
-  'hallucinated resource', 'weird code pattern', 'cleanup', 'clean up',
-  'overengineered', 'mock-heavy tests', 'schema drift'. Not for prose review (use
-  anti-ai-prose). Not for full repo audit (use full-review).
+  over-abstraction, duplicate code, test theater, redundant comments, verbose code,
+  and dependency creep. Triggers: 'slop', 'AI-generated code', 'duplicate code',
+  'copy paste', 'hallucinated API', 'hallucinated flag', 'weird code pattern',
+  'cleanup', 'clean up', 'overengineered', 'mock-heavy tests', 'schema drift'. Not
+  for prose review (use anti-ai-prose). Not for full repo audit (use full-review).
 license: MIT
 compatibility: "None - works on any codebase"
 metadata:
@@ -58,6 +58,7 @@ Before returning any anti-slop audit, verify:
 - [ ] **No hallucinated replacements**: verify that suggested modern alternatives actually exist in the target language version (e.g., `match` requires Python 3.10+, `LazyLock` requires Rust 1.80+)
 - [ ] **Grounding checked**: if flagging a hallucinated API, CLI flag, resource, chart value, or config key, verify it against local types/schema/tool help or official docs before claiming it is fake
 - [ ] **Test theater distinguished from correctness**: implementation-mirroring tests, mock-heavy ceremony, and snapshots with no semantic assertions belong here; actual failing behavior still belongs to code-review
+- [ ] **Structural duplication sweep done**: compare same-role modules/classes across sibling dirs (`providers`, `targets`, `sources`, `clients`, `registry`) and either report near-twins or note why the duplication is intentional
 
 ---
 
@@ -97,6 +98,11 @@ Linters handle syntax issues, unused imports, and known anti-patterns mechanical
 ### Step 4: Scan for patterns
 
 Use Grep, Glob, and Read. Read files before flagging - context matters. A pattern that looks like slop in isolation might be justified.
+
+Before finalizing, do one explicit structural pass:
+- Compare same-role files across sibling directories (`foo/emby.ts` vs `foo/jellyfin.ts`, multiple `registry.ts` files, provider adapters, target wrappers)
+- Look for near-twin modules/classes with the same method set and only renamed nouns, IDs, or client types
+- If you find a repeated pattern across many files, report one representative example and mention the spread instead of silently dropping it
 
 Classify each finding by axis (Noise/Lies/Soul - see above), action, and severity:
 
@@ -227,12 +233,17 @@ Same logic written slightly differently in multiple places - a telltale sign of 
 
 **Detect:**
 - Near-identical helper functions in different files
+- Near-twin modules for adjacent integrations/providers where only names, IDs, or injected client types change
+- Registry classes with the same `Map` + `register/get/all|list/clear` shape repeated across domains
+- Thin wrappers/adapters that repeat the same mapping code for multiple backends
 - Same validation logic in multiple handlers/routes
 - Repeated inline formatting/parsing across modules
 - Terraform `locals` blocks computing the same thing in different modules
 - Ansible tasks doing the same thing with different variable names
 
-**Fix:** Consolidate into a single well-named function/local/variable. But only if truly the same - slight variations might be intentional.
+**Fix:** Consolidate into a shared helper/factory/base module or keep one representative implementation and parameterize the differences. But only if truly the same - slight variations might be intentional.
+
+**Exception:** Sometimes duplication is clearer than a contorted abstraction, especially when integrations are likely to diverge. Still surface it as a **Consider** finding if the files/classes are near-twins today.
 
 ### 7. Stale Patterns (Lies)
 
@@ -451,5 +462,6 @@ Keep it concise. Show the diff, not a paragraph explaining it.
 - **Keep security out of scope.** Defensive code often looks verbose on purpose. Do not flag it casually.
 - **Read before judging.** A pattern that looks generic in isolation may be justified by framework or project constraints.
 - **Ground hallucination claims.** Use local types, schema, lockfiles, generated docs, or tool help before saying a flag/resource/API is fake.
+- **Do not bury structural duplication.** If near-twin modules or repeated registry/wrapper shapes appear, surface at least one representative finding even when higher-severity hallucination findings dominate the report.
 - **Prefer concrete rewrites.** If you flag a pattern, show the simpler version.
 - **Run the AI Self-Check.** Verify findings against the checklist before returning the audit.

--- a/skills/anti-slop/references/typescript.md
+++ b/skills/anti-slop/references/typescript.md
@@ -54,6 +54,14 @@ TypeScript's inference is good. Fighting it with redundant annotations is noise.
 - `new Promise((resolve, reject) => { asyncFn().then(resolve).catch(reject) })` (the Promise constructor anti-pattern)
 - `Array.from(set).map(...)` when `[...set].map(...)` works
 
+## Structural Duplication (Lies + Soul)
+
+- Sibling integration modules with the same exported shape where only product names, IDs, or injected client types change
+- Repeated registry classes built from the same `Map` + `register/get/all|list/clear` skeleton across domains
+- Adapter wrappers that map the same backend data into the same local shape with renamed nouns only
+
+**Fix:** If the files are near-twins today, surface one representative finding and name the spread. Suggest a shared mapper/factory only when it stays readable; otherwise mark it as a **Consider** finding and note the likely divergence point.
+
 ## Dependency Creep (Lies)
 
 - `node-fetch` when `fetch` is global (Node 18+, Bun, Deno)


### PR DESCRIPTION
## Summary
- make structural duplication a first-class anti-slop check instead of a finding that can get crowded out
- add duplication/copy-paste trigger terms to the anti-slop frontmatter for better discovery
- add TypeScript reference guidance for near-twin integration modules and repeated registry classes
- refresh the README inventory line to match the skill's current scope

## Test plan
- ./scripts/lint-skills.sh skills
- ./scripts/validate-spec.sh skills
- git diff --check
- markdownlint-cli2 README.md skills/anti-slop/SKILL.md skills/anti-slop/references/typescript.md