### PR TITLE
feat(git, ci-cd): add forgejo-cli, Gitea/Woodpecker CI, runners, best-practices

### DIFF
--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: ci-cd
 description: >
-  · Write, review, or architect CI/CD pipelines - GitHub Actions, GitLab CI, Forgejo.
-  Covers pipeline security, SHA pinning, SBOM, and runner configuration. Triggers: 'ci/cd',
-  'pipeline', 'github actions', 'gitlab ci', 'forgejo', '.github/workflows', 'runner',
-  'sha pinning'.
+  · Write, review, or architect CI/CD pipelines across GitHub Actions, GitLab, Forgejo/Gitea
+  Actions, and Woodpecker. Covers pipeline security (SHA pinning, SBOM), self-hosted runners,
+  dependency updates, linting, scanning, and review gates. Triggers: 'ci/cd', 'pipeline',
+  'github actions', 'gitlab ci', 'forgejo', 'gitea', 'woodpecker', 'runner', 'dependabot',
+  'renovate', 'trivy', 'gitleaks', 'merge queue', 'codeowners'.
 license: MIT
-compatibility: "Optional: gh (GitHub CLI), glab (GitLab CLI)"
+compatibility: "Optional: gh (GitHub CLI), glab (GitLab CLI), fj (Forgejo CLI)"
 paths:
   - ".github/workflows/*.yml"
   - ".gitlab-ci.yml"
   - ".forgejo/workflows/*.yml"
+  - ".gitea/workflows/*.yml"
+  - ".woodpecker/*.yaml"
+  - ".woodpecker.yaml"
 metadata:
   source: iuliandita/skills
   date_added: "2026-03-24"
@@ -20,29 +24,34 @@ metadata:
 
 # CI/CD Pipelines: Multi-Platform Production Infrastructure
 
-Write, review, and architect CI/CD pipelines across GitHub Actions, GitLab CI/CD, and Forgejo
-CI/CD. The goal is secure, fast, auditable pipelines that satisfy both engineering needs and
-compliance requirements (PCI-DSS 4.0).
+Write, review, and architect CI/CD pipelines across GitHub Actions, GitLab CI/CD, Forgejo
+Actions, Gitea Actions, and Woodpecker. The goal is secure, fast, auditable pipelines that
+satisfy both engineering needs and compliance requirements (PCI-DSS 4.0).
 
 **Target versions** (March 2026):
 - **GitHub Actions**: ubuntu-24.04 runners (ubuntu-latest), arm64 GA, artifact v4, attestations GA
 - **GitLab CI/CD**: GitLab 18.10, CI/CD Catalog GA, CI Components with typed `spec: inputs`
-- **Forgejo CI/CD**: Forgejo v14.0, Runner v12.7.x (multi-connection support since v12.7.0)
+- **Forgejo Actions**: Forgejo v14.0, Runner v12.7.x (multi-connection support since v12.7.0)
+- **Gitea Actions**: Gitea v1.23.x, act runner v0.2.x (GA since Gitea 1.21, March 2024)
+- **Woodpecker CI**: v3.13.x (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)
 - **Supply chain**: cosign v3.x (Sigstore), Syft/Trivy for SBOM, SLSA v1.0
 
-This skill covers four domains depending on context:
+This skill covers six domains depending on context:
 - **Workflow design** - stages, jobs, caching, artifacts, parallelism, reusable patterns
 - **Security** - supply chain hardening, SHA pinning, secret management, OIDC, least-privilege
 - **Compliance** - PCI-DSS 4.0 Req 6.x mapping, SBOM generation, signed artifacts, audit trails
-- **Cross-platform** - writing pipelines that work across GitHub/GitLab/Forgejo, migration patterns
+- **Cross-platform** - writing pipelines that work across GitHub/GitLab/Forgejo/Gitea/Woodpecker, migration patterns
+- **Runners** - install, register, executor choice, Linux vs macOS, hardening (see `references/runners.md`)
+- **Best practices** - dependency updates, linting, scanning, review gates, rollout order (see `references/best-practices.md`)
 
 ## When to use
 
-- Writing or reviewing CI/CD pipeline configs (workflows, `.gitlab-ci.yml`, Forgejo actions)
+- Writing or reviewing CI/CD pipeline configs (GitHub/Forgejo/Gitea Actions, `.gitlab-ci.yml`, `.woodpecker/*.yaml`)
 - Designing pipeline architecture (stages, parallelism, caching, deployment strategies)
 - Hardening pipelines against supply chain attacks (SHA pinning, image signing, provenance)
 - Setting up security scanning in CI (SAST, SCA, container scanning, secret detection)
-- Configuring runners, caching strategies, or artifact management
+- Configuring runners (install, register, executor choice, hardening) - see `references/runners.md`
+- Setting up caching strategies or artifact management
 - PCI-DSS 4.0 compliance for CI/CD (Req 6.2.1, 6.2.4, 6.3.2, 6.4.2, 6.5.3)
 - Migrating pipelines between platforms (GitLab -> GitHub, GitHub -> Forgejo)
 - Troubleshooting failed pipelines, flaky jobs, or runner issues
@@ -93,9 +102,12 @@ every failure with file and line reference.
 |--------|----------|
 | `.github/workflows/*.yml` | GitHub Actions |
 | `.gitlab-ci.yml` | GitLab CI/CD |
-| `.forgejo/workflows/*.yml` | Forgejo CI/CD |
+| `.forgejo/workflows/*.yml` | Forgejo Actions |
+| `.gitea/workflows/*.yml` | Gitea Actions |
+| `.woodpecker/*.yaml` or `.woodpecker.yaml` | Woodpecker (Gitea/Forgejo) |
 | User says "work" / "gitlab" / `glab` | GitLab CI/CD |
-| User says "home" / "forgejo" / "gitea" | Forgejo CI/CD |
+| User says "home" / "forgejo" / `fj` | Forgejo Actions |
+| User says "gitea" | Gitea Actions (or Woodpecker if 1.20 or older) |
 | User says "github" / "ghcr" / `gh` | GitHub Actions |
 
 If unclear, ask. The platforms have significant differences despite surface similarity.
@@ -122,6 +134,9 @@ Before writing pipeline config:
 Read the appropriate reference file:
 - **GitHub Actions**: `references/github-actions.md`
 - **GitLab CI/CD**: `references/gitlab-ci.md`
+- **Gitea CI/CD** (Gitea Actions + Woodpecker): `references/gitea-ci.md`
+- **Self-hosted runners** (all 5 implementations): `references/runners.md`
+- **Best practices** (deps, linting, scanning, review gates, rollout): `references/best-practices.md`
 - **Supply chain / compliance**: `references/supply-chain.md`
 
 For **Forgejo CI/CD**, see the Forgejo section below (smaller scope, inline).
@@ -296,6 +311,49 @@ git checkout <sha>
   The token always has full read-write access (read-only for fork PRs only). Don't assume
   least-privilege from `permissions:` alone - it has no effect on Forgejo.
 
+### Managing Forgejo Actions with `fj`
+
+The community Forgejo CLI (`fj`, v0.4.1+) covers the day-to-day Actions surface: listing
+runs, dispatching workflows, and managing variables/secrets. It is much faster than the web
+UI for bulk secret updates and scriptable for one-shot runs. Install and auth details live
+in the **git** skill (`references/forge-workflows.md`).
+
+```bash
+# List recent runs (for a quick "is CI green on main?" check)
+fj actions tasks
+
+# Trigger a workflow_dispatch run without opening the browser
+fj actions dispatch publish.yaml main --inputs version=1.2.3
+
+# Bulk variable/secret management (writes to the repo scope)
+fj actions variables create CACHE_BUCKET gs://my-bucket
+fj actions secrets create REGISTRY_TOKEN "$REGISTRY_TOKEN"
+```
+
+**What `fj` does not do yet** (as of 0.4.1): stream runner logs, re-run failed jobs, cancel
+running tasks. For those, use the web UI or hit `/api/v1/repos/{owner}/{repo}/actions/tasks/{id}`
+directly. Log streaming across the fleet still belongs in your observability stack, not `fj`.
+
+**On Gitea instead of Forgejo?** Use `tea` (`gitea.com/gitea/tea`) - the Gitea CLI covers
+a similar surface (issues, PRs, releases) against any Gitea 1.20+ instance. Gitea Actions
+lacks `fj`-equivalent CLI tooling; use the web UI or API. If you're running Forgejo,
+prefer `fj` - it tracks Forgejo-specific behavior (AGit, Forgejo Actions quirks) that
+`tea` does not.
+
+### Gitea CI/CD
+
+Gitea ships two viable CI paths: **Gitea Actions** (same `act`-based engine as Forgejo
+Actions, since Gitea 1.21) and **Woodpecker CI** (separate service, container-native,
+webhook-driven). Drone is legacy - do not start new installs.
+
+Quick rule of thumb: if you are migrating from GitHub or want one service to operate,
+use Gitea Actions. If you need proper matrix builds, caching primitives, or lighter
+resource usage, use Woodpecker. Do not run both against the same repo.
+
+See `references/gitea-ci.md` for: action SHA discovery, Gitea-vs-Forgejo Actions
+differences, Woodpecker YAML examples, plugin vs command steps, OAuth setup, matrix
+patterns, and Drone migration guidance.
+
 ### Forgejo release workflow pattern
 
 ```yaml
@@ -379,7 +437,10 @@ the OWASP Top 10 for Agentic Applications, read `references/supply-chain.md`
 ## Reference Files
 
 - `references/github-actions.md` - GitHub Actions patterns, templates, and security hardening
-- `references/gitlab-ci.md` - GitLab CI/CD 18.x patterns, Catalog, Components, security
+- `references/gitlab-ci.md` - GitLab CI/CD 18.x patterns, SaaS vs self-managed differences, Catalog, Components, security
+- `references/gitea-ci.md` - Gitea Actions + Woodpecker CI patterns, setup, matrix builds, Drone migration
+- `references/runners.md` - Self-hosted runners (actions-runner, gitlab-runner, forgejo-runner, act_runner, woodpecker-agent) - install, register, executor choice, Linux vs macOS, security hardening
+- `references/best-practices.md` - Dependency updates (Dependabot/Renovate), layered linting, scanning matrix (secrets/SCA/container/IaC/SAST), review gates, merge queues, rollout order
 - `references/supply-chain.md` - supply chain security, incident timeline, SHA pinning,
   SBOM/SLSA, PCI-DSS compliance, image signing
 

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -91,6 +91,12 @@ every failure with file and line reference.
 - [ ] **Version pinning on tools**: `node:22`, not `node:lts`. `python:3.13`, not `python:3`. Specific versions prevent silent breakage.
 - [ ] **Trigger scoping**: `on: push` without branch/path filters runs on every push to every branch - scope to `branches: [main]` and/or `paths:` filters. Same for GitLab: `rules:` with `if` conditions, not bare `only: [pushes]`.
 - [ ] **No expression injection** (GitHub Actions): `${{ }}` expressions never used directly in `run:` blocks. Assign to `env:` first. `github.event.*` is attacker-controlled. Avoid `github.ref_name` in security-sensitive contexts (injectable via crafted tag/branch names).
+- [ ] **Self-hosted runners ephemeral on public/untrusted repos**: non-ephemeral shell runners on repos that accept outside PRs is the top self-hosted-runner compromise vector. Verify `--ephemeral` (GitHub, Gitea) or capacity-based single-job runners (Forgejo) + approval gates for outside contributors. See `references/runners.md`.
+- [ ] **Docker socket mount scope**: `/var/run/docker.sock` mounted into a job gives it root on the host. Only acceptable for trusted internal pipelines. Public/shared runners need DinD sidecar or rootless buildkit instead.
+- [ ] **Scan gate has a baseline, not a blanket block**: container/IaC/SAST scanners introduced with `exit-code 1` and zero suppression always get disabled. Use the ratchet pattern (non-blocking -> baseline -> block new only) from `references/best-practices.md`.
+- [ ] **Ignore-list entries have expiry dates**: every `.trivyignore`, `.grype.yaml`, Dependabot `ignore`, or Renovate `ignoreDeps` entry includes a comment with revisit date + owner. No dates = zombie tech debt.
+- [ ] **Lockfiles committed**: `package-lock.json`, `bun.lock`, `Cargo.lock`, `go.sum`, `uv.lock` belong in version control for applications. Manifest-only commits break reproducibility.
+- [ ] **Auto-merge gated on tests, not just lint**: Dependabot/Renovate auto-merge without test coverage of the changed area is a supply-chain shortcut.
 
 ---
 

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -31,7 +31,7 @@ satisfy both engineering needs and compliance requirements (PCI-DSS 4.0).
 **Target versions** (March 2026):
 - **GitHub Actions**: ubuntu-24.04 runners (ubuntu-latest), arm64 GA, artifact v4, attestations GA
 - **GitLab CI/CD**: GitLab 18.10, CI/CD Catalog GA, CI Components with typed `spec: inputs`
-- **Forgejo Actions**: Forgejo v14.0, Runner v12.7.x (multi-connection support since v12.7.0)
+- **Forgejo Actions**: Forgejo v14.0, Runner v11.x (stable; check `data.forgejo.org/forgejo/runner` releases for current major tag before pinning)
 - **Gitea Actions**: Gitea v1.23.x, act runner v0.2.x (GA since Gitea 1.21, March 2024)
 - **Woodpecker CI**: v3.13.x (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)
 - **Supply chain**: cosign v3.x (Sigstore), Syft/Trivy for SBOM, SLSA v1.0

--- a/skills/ci-cd/references/best-practices.md
+++ b/skills/ci-cd/references/best-practices.md
@@ -1,0 +1,427 @@
+# CI/CD Best Practices: Patterns That Hold Up
+
+Opinionated patterns for building CI/CD pipelines that stay useful over time. Focused on
+**integration decisions** - what to run, where, when, and how strictly - not on tool
+tutorials. Tools change; the patterns don't.
+
+Scope: dependency updates, linting, scanning, review gates, and rollout. For tool-specific
+usage, see:
+
+- SHA pinning, SBOM, cosign: `supply-chain.md`
+- Platform-specific syntax: `github-actions.md`, `gitlab-ci.md`, `gitea-ci.md`
+- Self-hosted runners: `runners.md`
+- Code-level security findings and OWASP-style audits: the **security-audit** skill
+- PR review mechanics: the **code-review** skill
+
+---
+
+## 1. Dependency Update Strategy
+
+Automated dependency updates are not optional in 2026. The question is only which bot,
+what frequency, and what auto-merges.
+
+### Dependabot vs Renovate
+
+| Factor | Dependabot | Renovate |
+|--------|-----------|----------|
+| Platforms | GitHub only | GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, Forgejo |
+| Ecosystems | ~20 | 90+ |
+| Grouping | Limited (by ecosystem + update type) | Arbitrary regex/rules; monorepo presets |
+| Auto-merge | Requires separate GitHub Action workflow | Built-in, config-driven |
+| Security-only updates | Default path | Available via `vulnerabilityAlerts` |
+| Config | `.github/dependabot.yml` | `renovate.json` (or org-level preset) |
+| Setup cost | Zero on GitHub | App install + JSON config |
+
+**Rule of thumb**: GitHub-only, small repo, you want it working in five minutes -
+Dependabot. Monorepo, multi-forge, or more than one project sharing update policy -
+Renovate. The two can co-exist but don't; pick one per repo.
+
+**Forgejo/Gitea note**: Dependabot does not work there. Renovate is the only viable
+automated updater. Run Renovate on a schedule via Forgejo/Gitea Actions (self-hosted
+Renovate) or use the hosted Renovate app on Codeberg if your repo is there.
+
+### What to group
+
+Noise is the enemy. A repo generating 30+ update PRs per week gets ignored. Group
+aggressively:
+
+- **By ecosystem**: all Node.js dev dependencies in one PR, all production in another
+- **By scope**: all AWS SDK packages, all OpenTelemetry packages, all linting tools
+- **By update type**: all patches together, all minor together, majors individually
+- **By vendor monorepo**: `@aws-sdk/*`, `@sentry/*`, `@opentelemetry/*`
+
+Renovate preset for this: `"extends": ["config:recommended", "group:allNonMajor",
+"group:monorepos"]`. Dependabot does ecosystem + update-type grouping only (added in 2023);
+it cannot do vendor-monorepo grouping.
+
+### Auto-merge policy
+
+The safe default:
+
+| Change | Auto-merge? |
+|--------|-------------|
+| Patch update to dev dependency | Yes, if CI green |
+| Patch update to production dependency | Yes, if CI green AND has tests for the changed area |
+| Minor update to dev dependency | Yes, if CI green |
+| Minor update to production dependency | Manual review |
+| Major update (anything) | Always manual |
+| Security update (any severity) | Auto-open, manual merge (never skip review on sec) |
+| Indirect / transitive | Usually auto if direct passes |
+
+"CI green" must include tests, not just lint. Auto-merging on lint-only gates has bitten
+enough teams that it's a documented anti-pattern.
+
+### Security-only updates
+
+For repos with low tolerance for churn (stable libraries, old LTS branches), configure
+the bot to open PRs **only for security advisories**:
+
+- Dependabot: `open-pull-requests-limit: 0` on the main config + rely on the separate
+  `version: 2` security updates path (security updates are opened regardless of limits)
+- Renovate: `"extends": ["default:disableAllUpdates", "security:only"]`
+
+Pair with a quarterly "update sweep" where someone manually bumps everything else.
+
+### Lockfiles and pinning
+
+- **Commit lockfiles.** `package-lock.json`, `bun.lock`, `Cargo.lock`, `go.sum`,
+  `uv.lock`, `Pipfile.lock`. The lockfile is the reproducibility guarantee; the manifest
+  alone is not.
+- **Never hand-edit lockfiles.** Regenerate after manifest changes. Hand-edits break
+  integrity checksums and bite months later.
+- **Libraries vs applications**: libraries commit manifests but typically not lockfiles
+  (consumers resolve); applications always commit lockfiles. Exception: Rust libraries
+  that ship binaries commit both.
+- **Pin dev tooling.** Your linter version matters - `eslint@9.17.0` vs `eslint@9.18.0`
+  can flip lint results on unchanged code. Pin via the same lockfile.
+
+### Ignore lists, not forever
+
+Every `ignore` / `allowlist` entry needs an expiry date in a comment. Unmaintained ignore
+lists become zombie tech debt. Example:
+
+```json
+{
+  "ignoreDeps": [
+    "lodash"
+  ],
+  "// lodash": "Pinned at 4.17.21 pending audit - revisit 2026-Q2 - owner: platform"
+}
+```
+
+---
+
+## 2. Linting: Pre-commit → CI → Blocking
+
+Linting works when it's fast locally and authoritative in CI. Three layers, each with a
+different job:
+
+### Layer 1: Pre-commit (local, optional but recommended)
+
+Catch the obvious stuff before the commit ever happens. Use `prek` (Rust, 10x faster) or
+`pre-commit` (Python, bigger ecosystem). Shared config at `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.2
+    hooks:
+      - id: ruff
+      - id: ruff-format
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.0
+    hooks:
+      - id: gitleaks
+```
+
+Pre-commit is advisory. Do not treat it as the source of truth - developers can skip it
+with `--no-verify` or have it misconfigured locally. CI runs the same checks to enforce.
+
+### Layer 2: CI (authoritative)
+
+CI runs the full linter suite on every PR. Same config as pre-commit where possible, so
+there's no "works on my machine" divergence.
+
+Language-specific linters to wire up:
+
+| Language | Linter | Notes |
+|----------|--------|-------|
+| Python | `ruff` (replaces flake8 + black + isort + more) | Fast, opinionated, one-tool-fits-most |
+| JS/TS | `eslint` + `prettier` | Or `biome` (Rust-based, replaces both) |
+| Go | `golangci-lint` | Wraps 50+ linters, one config |
+| Rust | `cargo clippy` + `cargo fmt` | Both blocking |
+| Shell | `shellcheck` | Blocking; mature since forever |
+| YAML | `yamllint` | Catches stupid indentation bugs |
+| Dockerfile | `hadolint` | Flags anti-patterns like `ADD` instead of `COPY` |
+| Terraform | `tflint` + `terraform fmt -check` | Plus `tfsec`/Trivy for security |
+| Ansible | `ansible-lint` | |
+| Markdown | `markdownlint-cli2` | Optional; useful for docs-heavy repos |
+
+### Layer 3: CI linters people forget
+
+These lint your **CI itself** and catch bugs that would otherwise only show up at runtime:
+
+- **`actionlint`** - lints GitHub Actions / Forgejo Actions / Gitea Actions YAML for
+  syntax errors, unknown expressions, outdated action versions. Run on every PR touching
+  `.github/workflows/` or `.forgejo/workflows/`.
+- **`shellcheck`** on inline `run:` blocks - `actionlint` invokes it automatically for
+  shell steps.
+- **`yamllint`** on all CI YAML - catches tab/space mix-ups and duplicate keys before the
+  pipeline silently uses the wrong value.
+- **`hadolint`** on Dockerfiles that run in CI (including runner images).
+
+These four catch more real bugs per line of config than any other CI-lint investment.
+
+### Caching lint tools
+
+Lint jobs should complete in under 60s. Slow lint = skipped lint. Cache:
+
+- Python: `~/.cache/ruff`, `~/.cache/pre-commit` (key: hash of lock file + config)
+- Node: `~/.cache/npm` or `bun install --frozen-lockfile` cached; `eslint` cache file
+- Go: `~/.cache/go-build`, `~/go/pkg/mod`
+- Rust: `~/.cargo/registry`, `target/` (with `cargo-cache` or `Swatinem/rust-cache`)
+
+### Fix vs check
+
+In CI, always run with `--check` / `--no-fix`. Auto-fix in CI is a foot-gun: the PR's
+HEAD gets silently rewritten, reviews get harder, and merge conflicts appear from
+nowhere. Auto-fix belongs in pre-commit or a manual `make fix` target.
+
+---
+
+## 3. Scanning: What, When, Where
+
+Scanners all claim "shift left." In practice, you run different scanners at different
+pipeline stages for different reasons.
+
+### Scanning matrix
+
+| Scanner type | Tool (2026 default) | Pre-commit | On PR | On merge to main | Pre-release | Continuous |
+|--------------|--------------------|-----------:|:-----:|:----------------:|:-----------:|:----------:|
+| Secret scanning | `gitleaks` (or `trufflehog`) | Yes | Yes | Yes | - | Yes (push-protection) |
+| SCA (library CVEs) | Trivy `fs` or Grype | - | Yes | Yes | Yes | Yes (cron) |
+| Container image | Trivy `image` or Grype | - | On image change | Yes | Yes (blocking) | Yes (registry-side) |
+| IaC misconfig | Trivy `config` (absorbs tfsec) + Checkov | - | On IaC change | Yes | - | - |
+| SAST | Semgrep / CodeQL | - | Yes | Yes | Yes | Weekly deep scan |
+| License | Trivy `--scanners license` or FOSSA | - | Yes | Yes | Yes | - |
+| SBOM | Syft | - | - | Yes (artifact) | Yes (attest) | - |
+
+### Secret scanning: three layers
+
+1. **Push protection** at the forge (GitHub Secret Scanning, Gitea/Forgejo via gitleaks
+   server-side hook). Rejects the push entirely if a known secret pattern is detected.
+2. **Pre-commit** with `gitleaks protect` - same scan client-side, faster feedback.
+3. **CI on every PR** - catches what slipped past both. Run against `git diff` to keep
+   it fast, not the full history.
+
+Scan the **diff**, not the whole repo, on every PR. Full-history scans belong on a
+nightly cron or pre-release job; they take minutes and block nothing useful on a PR.
+
+### Container scanning: Trivy vs Grype
+
+Both are good. Pick one per pipeline and stick with it.
+
+- **Trivy** - one binary, scans images + filesystems + IaC + secrets + licenses. Good
+  default for teams who want fewer tools. After the 2025 TeamPCP incident, pin to a
+  verified version (`v0.69.3` or later from a trusted source; avoid `v0.69.4/5/6` which
+  were compromised).
+- **Grype** - vulnerability-matching only, but has **risk scoring** that combines CVSS
+  + EPSS (exploit probability) + CISA KEV. Better signal-to-noise on severity gates -
+  a critical CVE with 0.1% EPSS is not the same as a high CVE in CISA KEV with 95% EPSS,
+  and Grype surfaces that difference.
+
+Run container scans **twice**:
+
+1. **In the image build pipeline**, before push to registry. Fail the build on severity
+   threshold exceeded.
+2. **Registry-side, continuously** (Harbor, GHCR, ECR all have this). Catches CVEs
+   published after your image was built. Feed findings into an alert, not a build break.
+
+### Severity gates: ratchet pattern
+
+Turning on a scanner that finds 400 Criticals and blocking CI is how scanners get turned
+off the next day. The rollout that works:
+
+1. **Week 1** - run the scanner, **non-blocking**, post findings as a PR comment. Team
+   sees the reality.
+2. **Week 2-3** - fix or suppress every Critical. Record the baseline.
+3. **Week 4** - turn on **blocking for new Criticals only** (compare against baseline).
+   Existing Criticals stay in the ignore list with an expiry date.
+4. **Month 2** - extend to Highs for new vulnerabilities.
+5. **Month 3+** - work through the baseline. Drop entries as vulnerabilities are fixed.
+
+Non-blocking forever means nobody fixes anything. Blocking from day 1 means nobody ships.
+The ratchet lets both work.
+
+### SAST: don't block on it
+
+SAST tools (Semgrep, CodeQL, SonarQube) generate false positives. Run them on PRs for
+visibility and as a weekly deep scan against main, but **don't gate merges on SAST
+findings** unless you have a tuned ruleset and a team that triages weekly. Gating on
+noisy SAST is how you get "SAST fatigue" and ignored findings.
+
+Exception: very specific SAST rules with near-zero false positives (e.g. Semgrep's
+`hardcoded-secret`, `dangerous-eval`) are fine to block on.
+
+### License scanning
+
+Default ignored; flipped on when legal asks. Trivy `--scanners license` is the simplest.
+Block on "unknown" or "copyleft-strict" (AGPL-3.0) when the org's license policy
+prohibits them; otherwise advisory only.
+
+---
+
+## 4. Review Gates and Policy-as-Code
+
+CI enforces mechanical checks. Reviews enforce judgment. Both need to be
+automatable-but-not-automated.
+
+### CODEOWNERS
+
+`.github/CODEOWNERS` / `.gitlab/CODEOWNERS` / `.forgejo/CODEOWNERS`. Path-based
+auto-assignment for reviews. Keep it specific enough to be useful, general enough to be
+maintainable:
+
+```
+# Own by default
+*                                   @org/platform
+
+# Security-critical paths need security team
+/auth/                              @org/platform @org/security
+/crypto/                            @org/security
+.github/workflows/                  @org/platform @org/security
+
+# Infra changes need SRE
+/terraform/                         @org/sre
+/k8s/                               @org/sre
+/.github/actions/                   @org/sre @org/platform
+
+# Domain ownership
+/services/payments/                 @org/payments-team
+/services/notifications/            @org/messaging-team
+```
+
+Pair with **required review from CODEOWNERS** in branch protection. Without the "required
+review" bit, CODEOWNERS is suggestion-only.
+
+### Required status checks
+
+On protected branches, require:
+
+| Check type | Required? | Why |
+|------------|-----------|-----|
+| Lint | Yes | Cheap; no reason to ever merge lint failures |
+| Unit tests | Yes | The baseline contract |
+| Integration tests | Yes (on main-bound PRs) | Catches integration bugs |
+| E2E tests | Maybe | Flaky E2E breaks more PRs than it catches bugs - gate as advisory until flake rate <1% |
+| Type check | Yes (for typed languages) | Cheap |
+| Build | Yes | If CI can't build, nobody can |
+| Secret scan | Yes | Blocking on secrets is non-negotiable |
+| Container scan | Yes (for new/changed Criticals only) | Ratchet pattern above |
+| SAST | Advisory | Too noisy for hard block |
+| Coverage | Usually no, sometimes yes | Covered below |
+| SBOM diff | Advisory | Surfaces dependency changes for review |
+
+### Coverage thresholds
+
+"95% coverage or the build fails" is a cargo cult. Coverage measures what's exercised,
+not what's tested. Reasonable patterns:
+
+- **No regression below baseline**: block if coverage drops more than 0.5% from main.
+  Rewards adding tests without demanding perfection.
+- **Per-PR coverage floor**: changed lines in the PR must hit some threshold
+  (`codecov` / `coverallsapp` support this as "patch coverage"). Forces new code to be
+  tested without re-testing legacy.
+- **No overall threshold on untested legacy code**. Don't demand 80% coverage on a
+  codebase that has 15% - you'll get tests written to cover lines, not behavior.
+
+### Merge queues
+
+For high-velocity repos, merge queues prevent "green PR merges, base branch goes red
+five minutes later" - the classic PR interaction bug.
+
+| Forge | Mechanism | Behavior |
+|-------|-----------|----------|
+| GitHub | Merge Queue (GA 2023) | Sequential: creates a temp branch with base + queued PRs; reruns required checks against that; merges if green. Workflows need `on: merge_group` trigger. |
+| GitLab Premium+ | Merge Trains | Parallel: each queued MR gets a cumulative-state ref; pipelines run in parallel. If one fails, it drops out and subsequent pipelines restart. |
+| Forgejo/Gitea | No native merge queue. Use `merge-queue` GitHub Action or manual coordination. |
+| Bitbucket | "Auto-merge" but not a true merge queue. |
+
+Rule of thumb: enable a merge queue once you have >5 PRs merging per day and >2% of
+merges trigger a post-merge revert. Below that, the queue adds latency without much
+benefit.
+
+### Policy-as-code (advanced)
+
+When review rules get complex enough to encode, reach for policy engines:
+
+- **OPA / Conftest** - write Rego policies that gate CI or admission. Good for
+  Terraform/K8s manifests, container images, PR metadata ("all PRs touching X must have
+  label Y").
+- **Sentinel** (Terraform Enterprise) - same idea, HashiCorp-native.
+- **GitLab Security Policies** / **GitHub Repository Rulesets** - declarative policies
+  that apply across repos in an org. Use these over per-repo branch protection when
+  managing >20 repos.
+
+---
+
+## 5. Rollout Order
+
+Introducing all of the above at once is how you get an org-wide pipeline revolt. The
+order that works in practice:
+
+### Week 1-2: foundation
+
+1. **Lockfiles everywhere** + **lint-as-CI** (advisory, informational comment only).
+   No team hates learning that `yamllint` catches real bugs.
+2. **Secret scanning, blocking.** Secrets are the one thing that should block from day
+   one. Gitleaks on PR + push protection if the forge supports it.
+3. **Dependabot or Renovate**, configured for weekly schedule, grouping on, **no
+   auto-merge yet**.
+
+### Month 1: gates
+
+4. **Lint becomes blocking.** Fix everything that fails; then flip the switch.
+5. **Test suites blocking** on the paths everyone touches. Unit + integration for core.
+6. **Branch protection + CODEOWNERS.** Required review, no direct push to main.
+
+### Month 2: security
+
+7. **Container scan, non-blocking**, post findings to PR.
+8. **Baseline existing Criticals.** Fix what you can; suppress what you can't with
+   expiry dates.
+9. **Container scan blocking on new Criticals.**
+10. **SBOM generation** on releases (attest but don't gate).
+
+### Month 3: polish
+
+11. **Auto-merge for Dependabot/Renovate patches** with test gates.
+12. **Merge queue** if velocity warrants it.
+13. **Ratchet up** scan severity: Highs now gate.
+14. **Coverage regression gate** (not absolute threshold).
+
+### Don't do these
+
+- **Block day 1 on SAST.** False-positive fatigue guaranteed.
+- **Block on absolute coverage thresholds.** Tests get written to fix the number, not the
+  code.
+- **Auto-merge majors.** Semver is not a contract with reality.
+- **Turn on 10 scanners at once.** Each needs baseline + triage time; the team hits
+  "ignore all" mode and you're worse off than before.
+- **Require every check to pass on drafts.** Drafts are for WIP; save the gate budget
+  for ready-for-review PRs.
+
+---
+
+## Cross-references
+
+- SHA pinning, image signing, SBOM attestations: `supply-chain.md`
+- Platform-specific pipeline syntax: `github-actions.md`, `gitlab-ci.md`, `gitea-ci.md`
+- Self-hosted runner hardening: `runners.md`
+- Tool-level security audits (CVE triage, exploit chains): **security-audit** skill
+- PR-level code review practices: **code-review** skill
+- Git workflow that pairs with these CI gates: **git** skill

--- a/skills/ci-cd/references/best-practices.md
+++ b/skills/ci-cd/references/best-practices.md
@@ -257,6 +257,26 @@ off the next day. The rollout that works:
 Non-blocking forever means nobody fixes anything. Blocking from day 1 means nobody ships.
 The ratchet lets both work.
 
+### How to implement "block on new only" in practice
+
+"Compare against baseline" sounds nice; the mechanic varies per scanner:
+
+- **Trivy**: maintain `.trivyignore` at the repo root. One CVE ID per line with an expiry
+  comment (`CVE-2024-XXXXX  # glibc, upstream fix pending, revisit 2026-Q3 - owner: platform`).
+  Run `trivy image --ignorefile .trivyignore --exit-code 1 --severity CRITICAL ...` in CI.
+  CVEs in the ignore file pass; anything new fails. Trivy has no built-in diff mode;
+  the ignorefile *is* the baseline.
+- **Grype**: similar via `--fail-on critical` + a `.grype.yaml` `ignore:` block keyed by CVE
+  ID. Supports glob-style matching for transient fix windows.
+- **Docker Scout / Snyk / Anchore Enterprise**: these have first-class "baseline" or
+  "policy" objects stored server-side - CI reads the policy rather than a file.
+- **GitHub Secret Scanning, Dependabot**: baseline is implicit - the forge remembers which
+  alerts are open, dismissed, or resolved. CI just blocks on "new alerts" without a file.
+
+Whichever scanner, **expiry dates on ignore entries are the load-bearing bit**. Without
+them, suppressions become zombie tech debt and the baseline grows forever. Put the expiry
+in a comment and run a quarterly sweep to revisit expired entries.
+
 ### SAST: don't block on it
 
 SAST tools (Semgrep, CodeQL, SonarQube) generate false positives. Run them on PRs for

--- a/skills/ci-cd/references/gitea-ci.md
+++ b/skills/ci-cd/references/gitea-ci.md
@@ -1,0 +1,186 @@
+# Gitea CI/CD: Patterns & Templates
+
+Gitea ships two viable CI paths in 2026. Which one you use depends on the instance version
+and whether you want CI baked into Gitea or run as a separate service.
+
+| Option | When it fits | Syntax |
+|--------|--------------|--------|
+| **Gitea Actions** (since Gitea 1.21, GA) | Migrating from GitHub; want CI in the same service | GitHub Actions subset (act-based) |
+| **Woodpecker CI** (3.x, 2026) | Pre-1.21 Gitea, lightweight self-host, matrix/caching focus | Woodpecker YAML, `.woodpecker/*.yaml` |
+| **Drone** (legacy) | Existing deployments only - unmaintained since Harness acquisition | Drone YAML |
+
+Do not run both Gitea Actions and Woodpecker for the same repo; pick one. Running both
+means two sets of webhooks, two runners, double the secret surface.
+
+---
+
+## Gitea Actions
+
+Same `act`-based engine as Forgejo Actions, same GitHub Actions syntax subset, same SHA
+pinning and action resolution concerns. All Forgejo Actions guidance in `SKILL.md` applies,
+with these differences:
+
+| Aspect | Forgejo Actions | Gitea Actions |
+|--------|-----------------|---------------|
+| Workflow path | `.forgejo/workflows/*.yml` | `.gitea/workflows/*.yml` (or `.github/workflows/`) |
+| Action mirror | `code.forgejo.org/actions/*` | `gitea.com/actions/*` or configured proxy |
+| AGit | Supported | Not supported |
+| CLI | `fj actions` | No first-class CLI; use `tea` for basic ops or the API |
+
+### Action SHA discovery
+
+Same pattern as Forgejo: `git ls-remote` against your instance's mirror, or the API:
+
+```bash
+curl -s https://gitea.example.com/api/v1/repos/actions/checkout/git/refs/tags/v4.2.2 \
+  | jq -r '.object.sha'
+```
+
+### Gitea Actions gotchas
+
+- **`permissions:` not enforced** - Gitea accepts the field but does not restrict the
+  workflow token. Identical to Forgejo. Do not assume least-privilege from `permissions:`
+  alone.
+- **Action marketplace compatibility** - most GitHub actions work (`actions/checkout`,
+  `actions/setup-node`, `docker/*`). Marketplace actions that use GitHub-specific API
+  calls silently fail.
+- **Runner labels** - no `ubuntu-latest`. Use the labels registered with `act_runner`
+  (commonly `ubuntu-latest` mapped to a specific image in the runner config, or custom
+  labels like `docker`).
+
+### Minimal Gitea Actions workflow
+
+```yaml
+# .gitea/workflows/ci.yml
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha>  # pin to SHA from your Gitea mirror
+      - run: bun install --frozen-lockfile
+      - run: bun run test
+```
+
+---
+
+## Woodpecker CI
+
+Architecturally different from Actions-based CI: a separate server-plus-agents service
+that Gitea/Forgejo talks to via webhook. Smaller surface, container-native, Raspberry-Pi
+friendly. Written in Go, MIT-licensed. Current stable: 3.13.x (2026).
+
+### Config layout
+
+`.woodpecker/*.yaml` in the repo root. Each file is a separate pipeline. No
+multi-job-per-file like Actions - one pipeline per file, one agent per pipeline by default.
+
+```yaml
+# .woodpecker/ci.yaml
+when:
+  - event: [push, pull_request]
+    branch: main
+
+steps:
+  - name: lint
+    image: oven/bun:1.2
+    commands:
+      - bun install --frozen-lockfile
+      - bun run lint
+
+  - name: test
+    image: oven/bun:1.2
+    commands:
+      - bun run test
+    when:
+      - event: pull_request
+
+  - name: publish
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      registry: git.example.com
+      repo: git.example.com/team/app
+      username: ci
+      password:
+        from_secret: registry_token
+    when:
+      - event: tag
+```
+
+### Two step types
+
+- **Command steps** (`commands:`) - run arbitrary commands in a container image.
+- **Plugin steps** (`settings:`) - use pre-built plugin images that accept structured
+  config. Plugin ecosystem is small (~50 common plugins); for anything niche, fall back
+  to command steps with shell scripts.
+
+### Secrets
+
+Secrets live in the Woodpecker UI, scoped per-repo or per-org. Reference with
+`from_secret: <name>`. No environment scoping (closer to Forgejo than GitHub here).
+
+### Setup on Gitea / Forgejo
+
+1. Register an OAuth app in Gitea (`Settings -> Applications -> OAuth2 Applications`).
+2. Deploy Woodpecker server + at least one agent (docker-compose reference in the
+   Woodpecker docs).
+3. Point `WOODPECKER_GITEA=true` and `WOODPECKER_GITEA_URL=https://git.example.com` at
+   the server; paste the OAuth client ID/secret.
+4. In Woodpecker UI, activate the repo - it installs the webhook automatically.
+
+For Forgejo, swap `WOODPECKER_GITEA*` for `WOODPECKER_FORGEJO*`.
+
+### Matrix builds
+
+Woodpecker supports true matrix at the pipeline level, which Gitea/Forgejo Actions still
+handle awkwardly:
+
+```yaml
+matrix:
+  NODE_VERSION: [20, 22]
+  OS: [linux/amd64, linux/arm64]
+
+steps:
+  - name: test-${{ matrix.NODE_VERSION }}-${{ matrix.OS }}
+    image: node:${{ matrix.NODE_VERSION }}
+    commands:
+      - npm test
+```
+
+---
+
+## Choosing between Gitea Actions and Woodpecker
+
+**When Woodpecker beats Gitea Actions**:
+- Gitea instance is older than 1.21 (no Actions support)
+- You want CI as an independent service (easier to scale runners, easier to swap later)
+- You need proper matrix builds, caching primitives, or per-step resource limits - Actions
+  covers matrix but caching is weaker and resource limits are runner-level only
+- You want a smaller attack surface than full Actions compatibility brings
+
+**When Gitea Actions beats Woodpecker**:
+- Migrating from GitHub - copy-paste `.github/workflows/` with light edits
+- Want one service to operate and monitor
+- Need the GitHub Actions marketplace ecosystem (most actions work; some need mirroring)
+
+---
+
+## Drone (legacy)
+
+Drone was the original Gitea CI pairing. Harness acquired it in 2021 and effectively stopped
+maintaining the OSS edition. Existing deployments work; do not start new Drone installs in
+2026. Woodpecker is a community fork that kept the project alive and diverged significantly;
+the YAML is related but not drop-in compatible.
+
+---
+
+## Cross-references
+
+- Forgejo Actions patterns (same engine, mostly transferable): `SKILL.md` Forgejo section
+- GitHub Actions supply chain hardening: `references/github-actions.md`
+- Supply chain incident patterns: `references/supply-chain.md`

--- a/skills/ci-cd/references/gitlab-ci.md
+++ b/skills/ci-cd/references/gitlab-ci.md
@@ -61,7 +61,7 @@ silently no-op on the wrong tier:
 | Feature | Tier | Behavior on lower tier |
 |---------|------|------------------------|
 | **Merge Trains** (`needs:` + merge strategy) | Premium+ | No merge train; normal merge |
-| **Secure scanning** (`container_scanning`, `sast`, `dast`, `secret_detection`) | Works on CE, results UI limited to Ultimate | Jobs run; findings not in MR widget on CE/Premium |
+| **Secure scanning** (`container_scanning`, `sast`, `dast`, `secret_detection`) | Jobs run on CE; MR widget with findings requires Premium+; full security dashboard + vulnerability management requires Ultimate | On CE, findings appear only in raw job artifacts / reports; no MR widget, no dashboard |
 | **Compliance pipelines** (`compliance_frameworks`) | Ultimate | Ignored silently |
 | **Protected environment approvals (multi-stage)** | Premium+ | Single approval only |
 | **CI/CD for external repos** | Premium+ | Unavailable |

--- a/skills/ci-cd/references/gitlab-ci.md
+++ b/skills/ci-cd/references/gitlab-ci.md
@@ -16,6 +16,101 @@ CI/CD Catalog GA, Components with typed inputs, rules-based workflows.
 
 ---
 
+## gitlab.com (SaaS) vs Self-Managed
+
+The `.gitlab-ci.yml` syntax is identical. Operational behavior is not. Before writing
+pipeline config, know which deployment you are targeting.
+
+### Compute minutes / runner quotas
+
+| Mode | Runner model | Quota |
+|------|--------------|-------|
+| **gitlab.com Free** | Shared SaaS runners (Linux small) | 400 compute min/month, Linux only |
+| **gitlab.com Premium** | Shared + larger Linux/macOS/Windows | 10,000 compute min/month |
+| **gitlab.com Ultimate** | All of the above | 50,000 compute min/month |
+| **Self-managed CE/EE** | Your runners | Effectively unlimited (your hardware) |
+
+**"Compute minutes"** replaced the old "CI minutes" name in 2024. Linux small = 1x multiplier;
+Linux medium/large = 2x/3x; macOS = 6x; Windows = 1x. SaaS jobs on paid tiers can burn through
+quota fast if you run matrix builds on macOS without realizing the 6x multiplier.
+
+**Self-managed**: quotas can still be imposed per project/group via admin settings, but the
+default is unlimited. If the pipeline hangs with "no runner available," check runner tags and
+registration - it is never a quota problem on self-managed.
+
+### Runner types and tags
+
+| Runner type | Where it lives | Typical tag |
+|-------------|---------------|-------------|
+| **SaaS shared (Linux)** | GitLab-managed | `saas-linux-small-amd64`, `saas-linux-medium-amd64`, `saas-linux-large-amd64` |
+| **SaaS shared (macOS)** | GitLab-managed | `saas-macos-medium-m1` |
+| **SaaS shared (Windows)** | GitLab-managed | `saas-windows-medium-amd64` |
+| **Self-managed shared** | Your infra, group/instance scope | Your tags (e.g. `docker`, `k8s`) |
+| **Project-specific** | Your infra, single project | Your tags |
+
+On gitlab.com, `tags:` picks the SaaS runner class (and cost multiplier). On self-managed,
+`tags:` picks which of your registered runners takes the job. A pipeline written for
+gitlab.com with `tags: [saas-linux-medium-amd64]` will sit pending forever on self-managed
+unless you register a runner with that exact tag.
+
+### Tier-gated features in `.gitlab-ci.yml`
+
+Self-managed EE without a license behaves like CE. Several features parse without error but
+silently no-op on the wrong tier:
+
+| Feature | Tier | Behavior on lower tier |
+|---------|------|------------------------|
+| **Merge Trains** (`needs:` + merge strategy) | Premium+ | No merge train; normal merge |
+| **Secure scanning** (`container_scanning`, `sast`, `dast`, `secret_detection`) | Works on CE, results UI limited to Ultimate | Jobs run; findings not in MR widget on CE/Premium |
+| **Compliance pipelines** (`compliance_frameworks`) | Ultimate | Ignored silently |
+| **Protected environment approvals (multi-stage)** | Premium+ | Single approval only |
+| **CI/CD for external repos** | Premium+ | Unavailable |
+| **Pipeline subscriptions** (cross-project triggers) | Premium+ | Ignored silently |
+
+**How to detect at runtime**: `$GITLAB_FEATURES` is a predefined CI variable containing a
+comma-separated list of enabled feature flags (e.g. `merge_trains`, `security_dashboard`).
+Check this in `rules:` if you maintain one pipeline across SaaS-Ultimate and self-managed CE.
+
+### Predefined variables that differ
+
+| Variable | gitlab.com | Self-managed |
+|----------|------------|--------------|
+| `CI_SERVER_HOST` | `gitlab.com` | Your hostname (e.g. `gitlab.example.com`) |
+| `CI_SERVER_URL` | `https://gitlab.com` | Your URL |
+| `CI_SERVER_FQDN` | `gitlab.com` | Your FQDN |
+| `CI_API_V4_URL` | `https://gitlab.com/api/v4` | `https://<host>/api/v4` |
+| `GITLAB_FEATURES` | Full list per tier | CE-limited list or EE features from license |
+| `CI_PROJECT_URL` | `https://gitlab.com/group/project` | `https://<host>/group/project` |
+
+Never hardcode `gitlab.com` in a pipeline. Use `$CI_SERVER_HOST` and `$CI_API_V4_URL` so the
+same config works on either deployment. Hardcoded hostnames are a common migration blocker
+when moving a project from SaaS to self-managed or vice versa.
+
+### Auth to the GitLab API from jobs
+
+- **gitlab.com**: `CI_JOB_TOKEN` has scoped access to the project; `GITLAB_TOKEN` (user
+  PAT) still works but is rate-limited per user.
+- **Self-managed**: same primitives, plus admins can configure higher rate limits, disable
+  the instance-level `CI_JOB_TOKEN` scope expansion, or issue longer-lived PATs.
+- **OIDC to cloud providers**: works identically via `id_tokens:` - the JWT's `iss` claim
+  is `CI_SERVER_URL`, which means self-managed needs its own trust configuration in AWS/GCP
+  (can't share the `https://gitlab.com` trust policy).
+
+### Operational differences that bite
+
+- **Upgrade cadence**: gitlab.com is always current; self-managed can lag months. Feature
+  documentation assumes the latest version. Check `/help` on the self-managed instance for
+  actual version before assuming a feature exists.
+- **Runner image pre-warming**: SaaS runners have common images cached. Self-managed
+  runners pull cold unless you warm the image cache or run a pull-through registry.
+- **Artifact storage limits**: gitlab.com caps job artifacts (size and retention per tier);
+  self-managed limits are whatever the admin configured (often higher).
+- **Outbound network**: SaaS jobs have unrestricted egress; self-managed often runs behind
+  a corporate proxy. Configure runner `http_proxy`/`https_proxy` env vars at the runner
+  level, not in every job.
+
+---
+
 ## Pipeline Structure
 
 ### Recommended stage order

--- a/skills/ci-cd/references/runners.md
+++ b/skills/ci-cd/references/runners.md
@@ -148,7 +148,7 @@ check_interval = 0
 |----|---------|
 | Binary (Linux) | Download from `code.forgejo.org/forgejo/runner/releases/latest`, verify with `gpg`, `install -m 755 ... /usr/local/bin/forgejo-runner` |
 | Binary (macOS) | Same, pick `darwin-arm64` or `darwin-amd64` |
-| OCI container | `docker pull data.forgejo.org/forgejo/runner:11` (runs as uid 1000) |
+| OCI container | `docker pull data.forgejo.org/forgejo/runner:<major>` (current stable tag is `:11`; check `https://data.forgejo.org/forgejo/-/packages/container/runner/versions` for the latest tag before pinning. Runs as uid 1000.) |
 | Docker Compose | Reference compose file in upstream docs - pairs with a DinD sidecar |
 | Kubernetes | Community Helm charts exist; no official chart yet |
 
@@ -521,8 +521,8 @@ in GitLab's `config.toml`, equivalent settings in other runners. Verify images a
 tagged with `:latest` (which forces re-pull when the registry has a newer digest).
 
 **DinD races on parallel jobs**: two jobs on the same runner both starting a DinD sidecar
-fight over port 2375. Lower concurrency on DinD runners or use kubernetes backend which
-gives each job its own network namespace.
+fight over port 2376 (TLS, default since Docker 20+) or 2375 (no TLS). Lower concurrency
+on DinD runners or use kubernetes backend which gives each job its own network namespace.
 
 ---
 

--- a/skills/ci-cd/references/runners.md
+++ b/skills/ci-cd/references/runners.md
@@ -1,0 +1,534 @@
+# CI/CD Runners: Install, Configure, Harden
+
+Cross-platform reference for self-hosted CI runners. Covers the five implementations in
+common use as of 2026:
+
+| Runner | Platform | Language | Common executors |
+|--------|----------|----------|------------------|
+| `actions-runner` | GitHub Actions (self-hosted) | C# / .NET | shell (default), container via action |
+| `gitlab-runner` | GitLab CI/CD | Go | shell, docker, docker-autoscaler, kubernetes, instance, ssh |
+| `forgejo-runner` | Forgejo Actions | Go (forked from `act`) | docker, host (shell), LXC, docker-in-docker |
+| `act_runner` | Gitea Actions | Go (from `act`) | docker, host (shell) |
+| `woodpecker-agent` | Woodpecker CI | Go | docker, kubernetes, local (shell) |
+
+**`act_runner` vs `forgejo-runner`**: both descend from the `act` project. Forgejo forked
+in 2023 and the two have since diverged - different config defaults, different label syntax
+edges, different registration APIs. They are not interchangeable; pick the one that matches
+the forge you run.
+
+---
+
+## Choosing an Executor
+
+Before installing any runner, decide the isolation and concurrency model. This matters more
+than which runner you pick.
+
+### Two-axis decision matrix
+
+| | Persistent (reused across jobs) | Ephemeral (one job, then destroyed) |
+|-|--------------------------------|--------------------------------------|
+| **Shell / host** | Fast, leaky. Solo/internal repos only. State leaks between jobs. | Rare (needs VM/machine recycling). macOS iOS builds sometimes. |
+| **Container / pod** | Docker executor on a long-lived runner. Standard default. | Kubernetes executor, docker-autoscaler, `--ephemeral` flag. Correct default for untrusted code. |
+
+**Rule of thumb**: if the repo is public or accepts PRs from outside your org, runners
+**must** be ephemeral + containerized. Non-ephemeral shell runners on public repos is the
+single most common CI pwnage vector (documented extensively by Synacktiv, Sysdig).
+
+### Shell vs Docker executor
+
+| Aspect | Shell | Docker |
+|--------|-------|--------|
+| Isolation | None - jobs share the host filesystem, env, and installed tools | Per-job container, own filesystem layer |
+| Setup cost | Install tools on host, manage versions manually | Pull image; tools baked in |
+| Speed | Fastest (no container overhead) | Slower first run (image pull), comparable after warm cache |
+| Caching | Ad-hoc (shared host caches are a leak risk) | Image layer cache + per-job volume mounts |
+| Network | Host network | Container network (configurable) |
+| macOS native builds (iOS) | **Required** - Docker on macOS is a Linux VM | Cannot build native macOS artifacts |
+| Public repo safety | **Never** | Safe with `--ephemeral` + network egress controls |
+| Debug ergonomics | SSH to host, run commands directly | `docker exec` into a failed job's container (harder on one-shot) |
+
+Rule: shell for internal Linux/macOS builds where you control every commit; docker for
+everything else.
+
+### Docker-in-Docker (DinD) vs docker socket mount
+
+When jobs need to build images or run containers themselves:
+
+- **Socket mount** (`-v /var/run/docker.sock:/var/run/docker.sock`): fast, simple.
+  **Warning**: jobs can control the host Docker daemon. Untrusted code can escape the
+  runner in one step. Only for trusted internal pipelines.
+- **DinD** (`dind` sidecar on port 2375/2376): per-job Docker daemon, proper isolation.
+  Slower (need to re-pull layers per job) but correct for shared runners.
+- **rootless buildkit** (`buildx` with a rootless daemon): the 2026 default for image
+  builds - no privileged containers, no socket mount, no DinD complexity.
+
+---
+
+## `gitlab-runner`
+
+### Install
+
+| OS | Command |
+|----|---------|
+| Debian/Ubuntu | `curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.deb.sh" \| sudo bash && sudo apt install gitlab-runner` |
+| RHEL/Fedora | `curl -L ".../script.rpm.sh" \| sudo bash && sudo dnf install gitlab-runner` |
+| Arch | `paru -S gitlab-runner` |
+| macOS (Intel + Apple Silicon) | `brew install gitlab-runner && brew services start gitlab-runner` |
+| Binary (any Linux) | Download from `gitlab-runner-linux-<arch>` release, `install -m 755 ... /usr/local/bin/gitlab-runner` |
+| Docker | `docker run -d --name gitlab-runner --restart always -v /srv/gitlab-runner/config:/etc/gitlab-runner -v /var/run/docker.sock:/var/run/docker.sock gitlab/gitlab-runner:latest` |
+| Kubernetes | Official Helm chart `gitlab/gitlab-runner` |
+
+Linux packages register a `gitlab-runner` user and a systemd service. macOS `brew services`
+registers a launchd agent under the installing user (not root - this matters for permissions).
+
+### Register
+
+```bash
+# Interactive
+sudo gitlab-runner register
+
+# Non-interactive (scriptable)
+sudo gitlab-runner register \
+  --non-interactive \
+  --url https://gitlab.example.com \
+  --registration-token "$GITLAB_RUNNER_TOKEN" \
+  --executor docker \
+  --docker-image "alpine:3.19" \
+  --description "docker-runner-01" \
+  --tag-list "docker,linux,amd64"
+```
+
+Tokens come from **Admin Area -> CI/CD -> Runners -> Register an instance runner** for
+instance-scoped, or **Settings -> CI/CD -> Runners** per-group/project. GitLab 17+
+deprecated the old "registration token" flow in favor of authentication tokens issued
+per-runner - check your instance.
+
+### Config location
+
+`/etc/gitlab-runner/config.toml` (Linux/Docker) or `~/.gitlab-runner/config.toml` (macOS
+user install, Windows). One file holds multiple runners. Example:
+
+```toml
+concurrent = 4
+check_interval = 0
+
+[[runners]]
+  name = "docker-runner-01"
+  url = "https://gitlab.example.com"
+  token = "glrt-xxxxxxxxxxxxxxxxxxxx"
+  executor = "docker"
+  [runners.docker]
+    image = "alpine:3.19"
+    privileged = false
+    volumes = ["/cache"]
+    pull_policy = ["if-not-present"]
+```
+
+### Executor choice
+
+- **shell** - runner user executes commands directly on the host. Fast, unsafe. Use for
+  internal builds only.
+- **docker** - per-job container. Default recommendation.
+- **docker-autoscaler** - docker executor backed by a fleeting cloud plugin (AWS, GCP,
+  Azure). Scales machines up/down per demand. Replaces the legacy docker-machine executor
+  (deprecated in 16.x, removed in 18.x).
+- **kubernetes** - pod per job. Use when you already run a k8s cluster. Scales beautifully
+  but has the highest cold-start latency.
+- **instance** - full host access, one runner per machine, for jobs that need root (kernel
+  tests, hardware access).
+- **ssh** - connects to an external box. Legacy; prefer docker-autoscaler or instance.
+
+---
+
+## `forgejo-runner`
+
+### Install
+
+| OS | Command |
+|----|---------|
+| Binary (Linux) | Download from `code.forgejo.org/forgejo/runner/releases/latest`, verify with `gpg`, `install -m 755 ... /usr/local/bin/forgejo-runner` |
+| Binary (macOS) | Same, pick `darwin-arm64` or `darwin-amd64` |
+| OCI container | `docker pull data.forgejo.org/forgejo/runner:11` (runs as uid 1000) |
+| Docker Compose | Reference compose file in upstream docs - pairs with a DinD sidecar |
+| Kubernetes | Community Helm charts exist; no official chart yet |
+
+No distro packages in the major repos as of 2026. Install is manual tarball / docker on
+both Linux and macOS.
+
+### Register
+
+```bash
+# Interactive
+forgejo-runner register
+
+# Non-interactive
+forgejo-runner register \
+  --no-interactive \
+  --instance https://git.example.com \
+  --token "$FORGEJO_RUNNER_TOKEN" \
+  --name "runner-01" \
+  --labels "docker:docker://node:20-bookworm,ubuntu-22.04:docker://node:20-bookworm"
+```
+
+Token from **Site Administration -> Actions -> Runners -> Create new runner** (instance
+scope) or per-repo runner settings.
+
+**Offline registration** (declarative / IaC friendly): generate a secret on the Forgejo
+side, then have the runner create its own registration file without network round-trip:
+
+```bash
+# On the Forgejo server
+forgejo forgejo-cli actions register --secret <40-hex-char-secret>
+
+# On the runner machine
+forgejo-runner create-runner-file --instance https://git.example.com --secret <same-secret>
+```
+
+This is the pattern to use with Ansible, Terraform, or NixOS - the `.runner` file is
+reproducible and doesn't need manual token copy-paste.
+
+### Config location
+
+`config.yml` in the runner's working directory (wherever you run `forgejo-runner daemon`).
+Generate with `forgejo-runner generate-config > config.yml`. Essentials:
+
+```yaml
+runner:
+  file: .runner                    # state file - keep safe
+  capacity: 1                      # concurrent jobs; raise for bigger boxes
+  timeout: 3h
+  labels:
+    - docker:docker://node:20-bookworm
+    - host
+
+container:
+  network: ""                      # auto-detect; set to "host" for host-network jobs
+  privileged: false                # flip to true only if jobs need DinD
+  options: ""
+  workdir_parent: ""
+  valid_volumes: []                # whitelist host paths jobs may mount
+
+cache:
+  enabled: true
+  dir: ""                          # default: ./artifacts
+```
+
+### Executor choice
+
+Backends are picked per-label via the `labels` list:
+
+- `docker://<image>` - runs the job in a container from that image (default path)
+- `host` - runs the job as shell commands on the runner host (no isolation)
+- `lxc:<profile>` - Forgejo-only; runs inside an LXC container. Heavier than docker,
+  lighter than a VM
+- `docker-in-docker` (via privileged container + dind sidecar) - for jobs that build images
+
+Forgejo exposes LXC as a first-class option that Gitea's `act_runner` does not. Useful
+when you want kernel-level isolation without the cost of a full VM.
+
+---
+
+## `act_runner` (Gitea)
+
+### Install
+
+| OS | Command |
+|----|---------|
+| Binary | Download from `gitea.com/gitea/act_runner/releases`, nightly from `dl.gitea.com/act_runner/` |
+| Docker | `docker pull docker.io/gitea/act_runner:latest` |
+| Docker Compose | Example in upstream docs |
+
+### Register
+
+```bash
+# Interactive
+./act_runner register
+
+# Non-interactive
+./act_runner register --no-interactive \
+  --instance https://gitea.example.com \
+  --token "$GITEA_RUNNER_TOKEN" \
+  --name "runner-01" \
+  --labels "ubuntu-latest:docker://node:20-bookworm,ubuntu-22.04:docker://node:20-bookworm"
+
+# Ephemeral (v0.2.12+) - exits after one job
+./act_runner register --ephemeral ...
+```
+
+Tokens from **Site Administration -> Actions -> Runners** (instance), org settings, or
+repo settings.
+
+### Config location
+
+Generate with `./act_runner generate-config > config.yaml`. Structure is nearly identical
+to `forgejo-runner`'s; differences worth knowing:
+
+- Default labels use `ubuntu-*` names directly (aligning with GitHub Actions expectations)
+- `act_runner` has a first-class `--ephemeral` flag on `register`; on `forgejo-runner`,
+  ephemeral is controlled by exiting the daemon after each task (via wrapper scripts) or
+  capacity=1 + systemd restart
+
+### Executor choice
+
+Two backends: `docker://<image>` and `host`. No LXC support. For jobs that need to build
+images, use docker socket mount (trusted pipelines only) or a DinD sidecar.
+
+### Docker Compose pattern
+
+```yaml
+services:
+  runner:
+    image: docker.io/gitea/act_runner:latest
+    environment:
+      GITEA_INSTANCE_URL: https://gitea.example.com
+      GITEA_RUNNER_REGISTRATION_TOKEN: ${TOKEN}
+      GITEA_RUNNER_NAME: runner-01
+    volumes:
+      - ./data:/data
+      - /var/run/docker.sock:/var/run/docker.sock   # DANGEROUS for untrusted code
+```
+
+Swap the socket mount for a DinD sidecar on shared/public instances.
+
+---
+
+## `actions-runner` (GitHub Actions, self-hosted)
+
+### Install
+
+GitHub does not ship package manager installs. Runners are downloaded per-repo / org /
+enterprise with a pre-baked URL that includes a short-lived token.
+
+**Linux x64** (pattern - exact version and token from the GitHub UI under **Settings ->
+Actions -> Runners -> New self-hosted runner**):
+
+```bash
+mkdir actions-runner && cd actions-runner
+curl -o runner.tar.gz -L \
+  "https://github.com/actions/runner/releases/download/v2.322.0/actions-runner-linux-x64-2.322.0.tar.gz"
+tar xzf runner.tar.gz
+./config.sh \
+  --url https://github.com/your-org/your-repo \
+  --token AAAA... \
+  --labels "linux,docker,self-hosted" \
+  --ephemeral \
+  --runnergroup default \
+  --disableupdate
+./run.sh
+```
+
+**macOS (Apple Silicon)**: identical flow, pick `osx-arm64` tarball. For Intel Macs, pick
+`osx-x64`. Both require Xcode Command Line Tools (`xcode-select --install`) for most
+iOS/macOS build pipelines.
+
+### Service install
+
+```bash
+# Linux (systemd)
+sudo ./svc.sh install
+sudo ./svc.sh start
+
+# macOS (launchd)
+./svc.sh install
+./svc.sh start
+```
+
+On macOS, the service runs as the installing user - matters for GUI access (iOS
+simulator, Xcode) and for keychain unlock. Running `actions-runner` as a dedicated service
+account that can't unlock the login keychain is a common iOS CI bug.
+
+### Executor model
+
+`actions-runner` is shell-only by default. It executes job steps directly on the host.
+Container isolation is achieved at the **workflow** level via `jobs.<id>.container:` and
+`jobs.<id>.services:`, which the runner orchestrates via Docker on the host. The runner
+itself doesn't have "docker executor" as a separate install mode - it always runs on the
+host and optionally spawns containers.
+
+Implication: the **runner host itself is the trust boundary**. Attackers who compromise a
+job can see everything the runner user can see. Ephemeral runners rebuilt from scratch
+per job are the only real fix.
+
+### Autoscaling: ARC
+
+GitHub's recommended autoscaling pattern is **Actions Runner Controller (ARC)** on
+Kubernetes. Upstream maintained at `actions/actions-runner-controller`. It creates a pod
+per job, registers it as ephemeral, runs the job, and deletes the pod. Equivalent to
+`gitlab-runner` with the kubernetes executor; different architecture.
+
+Do not autoscale persistent runners - GitHub explicitly documents this as unsupported.
+
+---
+
+## `woodpecker-agent`
+
+### Install
+
+Woodpecker splits into `woodpecker-server` (one instance) and `woodpecker-agent` (many,
+does the work).
+
+| Method | Command |
+|--------|---------|
+| Docker | `docker pull woodpeckerci/woodpecker-agent:latest` |
+| Docker Compose | Pair with the server compose file; reference in upstream docs |
+| Binary | Download from GitHub releases, binary + env file |
+| Kubernetes | Official Helm chart `woodpecker-ci/woodpecker` |
+
+### Configure
+
+Agents talk to the server over gRPC. Minimum env:
+
+```bash
+WOODPECKER_SERVER=woodpecker-server:9000
+WOODPECKER_AGENT_SECRET=<shared secret from server config>
+WOODPECKER_BACKEND=docker        # or kubernetes, local
+WOODPECKER_MAX_WORKFLOWS=4        # concurrent workflow steps
+```
+
+### Backend choice
+
+| Backend | Use case |
+|---------|----------|
+| `docker` | Default. Each step runs in a container. Same DinD/socket tradeoffs as other runners. |
+| `kubernetes` | Each step becomes a Pod. Temporary PVC glues steps in one pipeline. Use when you have k8s. |
+| `local` | Each step runs as a local process on the agent. No isolation; useful for testing the agent itself or highly trusted hosts. |
+
+### Agent scaling
+
+Idle agent ~30 MB RAM. Run many small agents (one per machine, or one per k8s node) rather
+than one beefy agent with high concurrency - failure of one agent takes fewer jobs with it.
+
+---
+
+## Linux vs macOS Differences
+
+### Package availability
+
+| Runner | Linux packages | macOS install |
+|--------|---------------|---------------|
+| `gitlab-runner` | Official deb/rpm/AUR | `brew install gitlab-runner` |
+| `forgejo-runner` | None - tarball or docker | tarball (`darwin-arm64`/`darwin-amd64`) |
+| `act_runner` | None - tarball or docker | Tarball or via docker (Apple Silicon requires rosetta-free binary) |
+| `actions-runner` | None - GitHub-hosted tarball | Same tarball flow |
+| `woodpecker-agent` | None - docker is the norm | Docker via Colima/OrbStack or binary |
+
+### Service management
+
+| OS | Mechanism | Notes |
+|----|-----------|-------|
+| Linux | systemd unit (`gitlab-runner.service`, `forgejo-runner.service`, etc.) | Run as dedicated system user. `loginctl enable-linger` if using rootless Podman/Docker |
+| macOS | launchd plist (`LaunchAgents` for user, `LaunchDaemons` for system) | User agents need an active login session to unlock keychain; system daemons can't access the login keychain |
+| Windows | Windows Service via `nssm` or the runner's own installer | Same keychain/credential isolation issues as macOS |
+
+### Containerization on macOS
+
+Docker on macOS = Linux VM (Docker Desktop, Colima, OrbStack, Podman Machine). This breaks
+two things:
+
+1. **Native macOS builds** can't run in containers. iOS/macOS CI must use shell executors
+   on real Macs. Ephemerality has to come from VM snapshots or reinstalled machines, not
+   per-job containers.
+2. **Resource overhead** is higher - every job step pays the Linux-VM tax. For pure Linux
+   builds, a cheap Linux box is usually better than a Mac.
+
+Rule: if the pipeline produces Linux artifacts, use a Linux runner. Macs are for macOS/iOS
+artifacts only.
+
+### File system quirks
+
+- **macOS case-insensitive by default** - repos with files differing only in case break.
+  Use APFS case-sensitive for CI volumes or add a CI check.
+- **Linux containers on macOS file share** (Docker Desktop bind mounts) have notoriously
+  slow I/O. For heavy CI, put caches on a tmpfs or dedicated volume, not a bind mount.
+
+---
+
+## Security Hardening
+
+### Must-dos
+
+1. **Never run self-hosted runners on public repos without ephemeral mode.** Anyone who
+   can open a PR can run code on your runner. This is how runner-as-backdoor attacks start.
+2. **Run the runner as a dedicated non-root user.** `gitlab-runner`, `forgejo-runner`,
+   `act_runner` all create dedicated users in their systemd units; verify the user has no
+   sudo and no access to other services' data.
+3. **Drop docker socket access if jobs don't need to build images.** Mounting
+   `/var/run/docker.sock` is equivalent to giving the job root on the host.
+4. **Isolate runner network egress.** Runners should not reach internal services they
+   don't need. Firewall outbound to registry + package repos + forge API only.
+5. **Separate runners for trust levels.** Prod-deploying runners (with cloud credentials)
+   should never run PR jobs from untrusted authors. Use separate runner groups, labels,
+   or entire runner hosts.
+
+### Should-dos
+
+- **Ephemeral everywhere possible**: `gitlab-runner` + kubernetes/docker-autoscaler;
+  `actions-runner` with `--ephemeral`; `act_runner --ephemeral`; `forgejo-runner` with
+  capacity=1 + systemd restart; `woodpecker-agent` with k8s backend.
+- **Rootless container runtime**: rootless Podman + rootless Buildkit for image builds.
+  Eliminates privileged containers entirely.
+- **Forward runner logs off-host**: log lines are evidence of compromise. On-host logs get
+  wiped by attackers or by the ephemeral teardown.
+- **Pin runner binary versions**. `--disableupdate` (GitHub), pinned apt versions
+  (GitLab), pinned container tags (Forgejo/Gitea/Woodpecker). Auto-update is a supply
+  chain vector.
+- **Monitor for stuck runners**. Jobs that hang forever are a sign of DoS or compromise
+  attempts.
+
+### Public-repo safety
+
+Never use non-ephemeral self-hosted runners on a public repo. The documented attack is
+trivial: fork, open a PR with a malicious workflow change, the runner executes it with
+persistent access to previous jobs' caches, credentials, and local state. If you must run
+self-hosted on a public repo:
+
+- GitHub: require approval before workflows run for outside contributors (Repo
+  Settings -> Actions -> Approval required). Plus `--ephemeral`.
+- GitLab: use protected variables + protected branches/tags. Shared runners tagged for
+  untrusted jobs. Premium+ has "pre-approve MR pipelines".
+- Forgejo/Gitea: Actions default to not running on PRs from forks unless enabled. Keep it
+  that way.
+- Woodpecker: similar default.
+
+---
+
+## Common Failure Modes
+
+**"Runner is offline but process is running"**: token rotation, network ACL change, or
+clock skew. Check the runner log - the handshake error names the cause.
+
+**"Job waits forever, never starts"**: runner tag/label mismatch. On GitLab, `tags:
+[linux]` requires a runner registered with the exact tag `linux`. On Forgejo/Gitea,
+`runs-on: ubuntu-latest` needs the runner to declare `ubuntu-latest:docker://...`.
+
+**"Docker: permission denied /var/run/docker.sock"**: the runner user isn't in the
+`docker` group. `usermod -aG docker <runner-user>`, then restart the runner.
+
+**"Working directory already exists, clean failed"**: shell executor state leak from a
+previous job. Stop using shell for shared runners or wipe the workdir on each run. This is
+the leak that makes shell runners unsafe.
+
+**"Out of disk space" mid-build**: Docker image layers accumulate on long-lived runners.
+Schedule `docker system prune --volumes --filter "until=24h"` on a cron on the runner
+host, or use ephemeral runners.
+
+**macOS keychain unlock prompt blocks job**: runner is running as a user without an active
+login session. For iOS builds, run the runner as the logged-in user with `security
+unlock-keychain` at the start of each job (and do not commit the keychain password).
+
+**Runner pulls cold on every job**: no image pull cache. `pull_policy = ["if-not-present"]`
+in GitLab's `config.toml`, equivalent settings in other runners. Verify images are not
+tagged with `:latest` (which forces re-pull when the registry has a newer digest).
+
+**DinD races on parallel jobs**: two jobs on the same runner both starting a DinD sidecar
+fight over port 2375. Lower concurrency on DinD runners or use kubernetes backend which
+gives each job its own network namespace.
+
+---
+
+## Cross-References
+
+- GitHub Actions security patterns: `references/github-actions.md`
+- GitLab CI/CD (tags, compute minutes, SaaS vs self-managed): `references/gitlab-ci.md`
+- Gitea Actions / Woodpecker pipeline patterns: `references/gitea-ci.md`
+- Supply chain / SHA pinning for runner images: `references/supply-chain.md`

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -88,6 +88,7 @@ verify against this list:**
 - [ ] **Lock files regenerated after conflict resolution.** After resolving conflicts in dependency files (`package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`), re-run the package manager to regenerate the lock file. Never manually merge lock files. Then regenerate: `npm install`, `yarn install`, `go mod tidy`, or `cargo generate-lockfile`.
 - [ ] **Force-push safety.** If force-push is needed, always use `--force-with-lease` (refuses if remote has unfetched commits). Plain `--force` requires explicit user approval and team coordination.
 - [ ] **Version info dated.** When citing tool versions, include a date so readers know when to re-check. Stale version numbers cause silent breakage.
+- [ ] **Forge-CLI subcommands verified.** Before scripting `fj`/`gh`/`glab`/`tea` commands in a runbook, hooks, or CI, confirm the subcommand and flags exist on the target version (`<cli> <cmd> --help`). These CLIs add, rename, and remove subcommands across minor versions; docs lag behind the binary.
 
 ---
 

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -2,12 +2,13 @@
 name: git
 description: >
   · Git operations - branches, commits, remotes, conflicts, hooks, signing, releases,
-  PR/MR workflows, and multi-forge support (GitHub, GitLab, Forgejo). Also trigger when
+  PR/MR workflows, and multi-forge support (GitHub, GitLab, Forgejo, Gitea). Also trigger when
   the user is clearly doing git work without saying "git" (e.g., "push this", "cut a release").
   Triggers: 'git', 'commit', 'branch', 'merge', 'rebase', 'tag', 'hook', 'signing',
-  'PR', 'MR', 'release', 'changelog', 'conventional commits', 'gh', 'glab'.
+  'PR', 'MR', 'release', 'changelog', 'conventional commits', 'gh', 'glab', 'fj', 'tea',
+  'forgejo', 'gitea'.
 license: MIT
-compatibility: "Requires git. Optional: gh (GitHub CLI), glab (GitLab CLI)"
+compatibility: "Requires git. Optional: gh (GitHub CLI), glab (GitLab CLI), fj (Forgejo CLI)"
 metadata:
   source: iuliandita/skills
   date_added: "2026-03-24"
@@ -26,6 +27,7 @@ compliance requirements (PCI-DSS 4.0).
 - **git**: 2.53.x (current stable). Git 3.0 expected late 2026 (reftable default, SHA-256 default)
 - **GitHub CLI (`gh`)**: 2.89.x
 - **GitLab CLI (`glab`)**: 1.90.x
+- **Forgejo CLI (`fj`)**: 0.4.1 (March 2026). Rust-written, official community CLI at `codeberg.org/forgejo-contrib/forgejo-cli`. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
 - **Forgejo**: v14.0.3 (current stable). Critical RCE (CVE-2025-68937) patched in v13.0.2+.
 - **prek**: 0.3.x (Rust, recommended) or **pre-commit**: 4.5.x (Python, largest ecosystem)
 - **git-filter-repo**: 2.47.x

--- a/skills/git/references/forge-workflows.md
+++ b/skills/git/references/forge-workflows.md
@@ -125,8 +125,10 @@ export GITLAB_HOST=https://gitlab.example.com
 export GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 glab mr list
 
-# Per-command override
-glab --host gitlab.example.com mr list
+# Per-invocation override via env var (most reliable)
+GITLAB_HOST=https://gitlab.example.com glab mr list
+
+# `glab api` accepts --hostname directly
 glab api "projects/:id/pipelines" --hostname gitlab.example.com
 ```
 
@@ -244,7 +246,7 @@ does not cover yet (e.g. branch protection management).
 | Platform | Command |
 |----------|---------|
 | Arch / CachyOS (AUR) | `paru -S forgejo-cli` (or `cargo install forgejo-cli`) |
-| Debian / Ubuntu | `sudo apt install forgejo-cli` |
+| Debian sid / Ubuntu 25.10+ | `sudo apt install forgejo-cli` (not in Debian stable or Ubuntu LTS as of April 2026) |
 | Fedora | `sudo dnf copr enable lihaohong/forgejo-cli && sudo dnf install forgejo-cli` |
 | macOS | `brew install forgejo-cli` |
 | Nix | `nix profile install nixpkgs#forgejo-cli` |

--- a/skills/git/references/forge-workflows.md
+++ b/skills/git/references/forge-workflows.md
@@ -98,6 +98,54 @@ Tags trigger release workflows. Ensure:
 
 ## GitLab
 
+GitLab runs in three deployment modes that share a CLI and API but differ operationally:
+
+| Mode | Who runs it | License | CI runners |
+|------|-------------|---------|-----------|
+| **gitlab.com** (SaaS) | GitLab Inc. | Paid tiers (Free, Premium, Ultimate) with seat + compute limits | Shared SaaS runners, metered by "compute minutes" |
+| **Self-managed CE** (FOSS) | You | MIT-licensed Community Edition | Your own runners, effectively unlimited |
+| **Self-managed EE** (with license) | You | EE binary with applied license key | Your own runners, effectively unlimited |
+
+Self-managed CE and EE use the same binary; EE activates additional features only when a
+license key is applied. An unlicensed EE install behaves exactly like CE, so the usual
+pattern for self-hosting is "install EE, license later if needed" to avoid a reinstall.
+
+### `glab` against self-hosted vs `gitlab.com`
+
+`glab` auto-detects the host from the git remote, so most of the time no host flag is needed.
+When it does matter (scripts, cron jobs, repos without remotes yet), these three knobs exist:
+
+```bash
+# One-time interactive login for a self-hosted instance
+glab auth login --hostname gitlab.example.com
+# paste a token or go through OAuth if the instance supports it
+
+# Environment variable - overrides auto-detection for a shell/script
+export GITLAB_HOST=https://gitlab.example.com
+export GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
+glab mr list
+
+# Per-command override
+glab --host gitlab.example.com mr list
+glab api "projects/:id/pipelines" --hostname gitlab.example.com
+```
+
+**Config location**: `~/.config/glab-cli/config.yml` globally; `.git/glab-cli/` per-repo
+overrides. Tokens live in the OS secret store (libsecret/kwallet on Linux) unless the user
+opts into the config file.
+
+**CLI provenance**: `glab` was originally `profclems/glab` (community); GitLab Inc. adopted
+it in 2023 and it now lives at `gitlab.com/gitlab-org/cli`. The old `profclems/glab` repo is
+archived. Scripts referencing the old install path still work but point readers to the new
+location.
+
+**Multiple instances** (e.g. `gitlab.com` + work self-hosted): `glab auth login` once per
+host. `glab` picks the right token based on the repo's remote. For repos without a remote
+yet, use `GITLAB_HOST` or `--host`.
+
+**SSH-IP vs hostname mismatch**: if the SSH remote resolves to an IP and the web URL uses
+a hostname, `glab mr list` can fail. Use `glab api` with URL-encoded paths (see `ci-cd/references/gitlab-ci.md`).
+
 ### MR creation with `glab`
 
 ```bash
@@ -186,50 +234,167 @@ rules:
 
 ## Forgejo
 
-### PR creation (no official CLI)
+Forgejo has a Gitea-compatible REST API and a community CLI, **`forgejo-cli`** (binary `fj`),
+maintained under `codeberg.org/forgejo-contrib/forgejo-cli`. `fj` is the right default for
+interactive use; fall back to `curl` against the API for scripting, CI, or anything `fj`
+does not cover yet (e.g. branch protection management).
 
-Forgejo has a REST API compatible with Gitea. No official CLI, but `tea` (community) works
-for basic operations.
+### `fj` install
+
+| Platform | Command |
+|----------|---------|
+| Arch / CachyOS (AUR) | `paru -S forgejo-cli` (or `cargo install forgejo-cli`) |
+| Debian / Ubuntu | `sudo apt install forgejo-cli` |
+| Fedora | `sudo dnf copr enable lihaohong/forgejo-cli && sudo dnf install forgejo-cli` |
+| macOS | `brew install forgejo-cli` |
+| Nix | `nix profile install nixpkgs#forgejo-cli` |
+| Any with Rust | `cargo install forgejo-cli` or `cargo binstall forgejo-cli` |
+| Binaries | Releases tab on Codeberg (x86_64 Linux/Windows) |
+
+Verify: `fj --version` (should report 0.4.1+ as of March 2026; earlier releases have a PKCE
+bug that breaks `fj auth login`).
+
+### `fj` authentication
+
+Two flows. Pick based on whether your instance is in the default OAuth client list
+(Codeberg, `forgejo.org`, Disroot, and ~12 others ship client IDs; self-hosted usually is not).
+
+**OAuth (browser)** - default for supported public instances:
 
 ```bash
-# Create PR via API
-curl -s -X POST "https://git.example.com/api/v1/repos/{owner}/{repo}/pulls" \
-  -H "Authorization: token ${FORGEJO_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "title": "feat(pipeline): add subscription scheduler",
-    "body": "## Summary\n- Added cron-based subscription scheduling\n\n## Test plan\n- [ ] Scheduler fires on configured cron",
-    "head": "feat/subscription-scheduler",
-    "base": "main"
-  }'
+# Log in to the default host (first run prompts for host)
+fj auth login
 
-# List PRs
-curl -s "https://git.example.com/api/v1/repos/{owner}/{repo}/pulls?state=open" \
-  -H "Authorization: token ${FORGEJO_TOKEN}" | jq '.[].title'
+# Log in to a specific instance
+fj -H codeberg.org auth login
 ```
 
-### Forgejo releases
+**Token (self-hosted / no OAuth)** - generate at
+`https://<instance>/user/settings/applications` with the scopes you actually need
+(`write:repository`, `write:issue`, `write:user` covers normal dev work), then:
 
 ```bash
-# Create release via API
-curl -s -X POST "https://git.example.com/api/v1/repos/{owner}/{repo}/releases" \
-  -H "Authorization: token ${FORGEJO_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "tag_name": "v1.2.3",
-    "name": "v1.2.3",
-    "body": "## Changes\n- feat: user search\n- fix: auth bypass",
-    "draft": false,
-    "prerelease": false
-  }'
+fj -H git.example.com auth add-key
+# paste the token when prompted
 ```
 
-### Forgejo branch protection
+**Config location (Linux)**: `~/.config/forgejo-cli/client_ids` for custom instance client IDs.
+Credentials live in the OS secret store (libsecret/kwallet on Linux), not plaintext.
 
-Forgejo supports branch protection via web UI and API:
+**Per-repo auto-detection**: when inside a git repo, `fj` resolves the host from the `origin`
+remote. No `-H` flag needed for day-to-day operations.
+
+**Multi-instance setups** (e.g. self-hosted Forgejo + Codeberg mirror): run `fj auth login`
+once per host; `fj` picks the right credential based on the repo's remote or the `-H` override.
+
+### `fj` PR workflow
 
 ```bash
-# Protect branch via API
+# Create a PR from the current branch
+fj pr create "feat(pipeline): add subscription scheduler" \
+  --body-from-file .github/pr-body.md \
+  --base main
+
+# Autofill title and body from commits
+fj pr create --autofill
+
+# AGit flow - push directly to the upstream without forking
+# (Forgejo feature; pushes to refs/for/<base> and opens the PR in one step)
+fj pr create "feat(x): ..." --agit
+
+# Shorthand: --autofill + --agit
+fj pr create -aA
+
+# Open the new-PR page in the browser instead
+fj pr create --web
+
+# View a PR (owner/repo#N, or ^N when cwd is the fork and you want the parent repo)
+fj pr view forgejo-contrib/forgejo-cli#42
+fj pr checkout ^16
+
+# Status with CI check polling (blocks until all checks finish)
+fj pr status --wait
+
+# Merge (rebase + delete source branch)
+fj pr merge --method rebase --delete
+
+# Close with a message
+fj pr close 42 --with-msg "superseded by #45"
+```
+
+Merge methods: `merge`, `rebase`, `rebase-merge`, `squash`, `fast-forward-only`. Match the
+repo's branch protection policy - `fj` will surface the error if the method is not allowed.
+
+### `fj` issues
+
+```bash
+fj issue create "token refresh races on concurrent logins" \
+  --repo org/repo --body-from-file bug.md
+fj issue create --web               # new-issue page in browser
+fj issue create --template bug.md   # use a repo issue template
+fj issue view 16
+fj issue view 16 comments
+fj issue comment 16 "reproduces on v1.2.3 with OIDC enabled"
+fj issue close org/repo#16 --with-msg "fixed in #45"
+fj issue search --state open --label bug
+```
+
+### `fj` releases and tags
+
+`fj` can publish releases (listed as a supported capability in the README), but as of
+v0.4.1 the wiki does not yet document the exact `fj release` subcommand flags. Run
+`fj release --help` on the target version to confirm syntax before scripting.
+
+The reliable pattern is git-side tagging + `fj` for the release object:
+
+```bash
+# Annotated tag + push (fj works alongside git, not instead of it)
+git tag -a v1.2.3 -m "v1.2.3"
+git push origin v1.2.3
+
+# Publish the release for the pushed tag via fj
+# Flags (title, body-from-file, prerelease, asset upload) track closely to `gh release`
+# and `glab release`; verify against `fj release --help` on your installed version.
+fj release --help
+```
+
+When `fj release` is not yet an option in your installed version, fall back to the REST
+API section below - `POST /api/v1/repos/{owner}/{repo}/releases` is stable.
+
+For projects that prefer one command to tag + release, `fj tag` (new in v0.4.0) manages
+git tags on the Forgejo side; keep tag creation in git and the release in `fj` for a
+clean separation.
+
+### `fj` Forgejo Actions
+
+`fj` manages Actions variables, secrets, and manual dispatch. It does not yet expose
+log streaming or re-run controls - use the web UI for those.
+
+```bash
+# List recent action runs
+fj actions tasks
+
+# Manually dispatch a workflow_dispatch workflow
+fj actions dispatch publish.yaml main --inputs version=1.2.3
+
+# Variables (non-secret config)
+fj actions variables list
+fj actions variables create CACHE_BUCKET gs://my-bucket
+fj actions variables delete CACHE_BUCKET
+
+# Secrets (write-only; value never echoed back)
+fj actions secrets list
+fj actions secrets create REGISTRY_TOKEN "$REGISTRY_TOKEN"
+fj actions secrets delete REGISTRY_TOKEN
+```
+
+### Falling back to the REST API
+
+`fj` does not cover branch protection, webhooks, or org/team admin. Use `curl` against
+the Gitea-compatible API:
+
+```bash
+# Protect a branch
 curl -s -X PUT "https://git.example.com/api/v1/repos/{owner}/{repo}/branch_protections" \
   -H "Authorization: token ${FORGEJO_TOKEN}" \
   -H "Content-Type: application/json" \
@@ -242,17 +407,50 @@ curl -s -X PUT "https://git.example.com/api/v1/repos/{owner}/{repo}/branch_prote
     "enable_status_check": true,
     "block_on_rejected_reviews": true
   }'
+
+# Create a PR without fj (CI contexts where installing fj is overkill)
+curl -s -X POST "https://git.example.com/api/v1/repos/{owner}/{repo}/pulls" \
+  -H "Authorization: token ${FORGEJO_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "feat(x): ...",
+    "body": "summary + test plan",
+    "head": "feat/x",
+    "base": "main"
+  }'
 ```
 
 ### Forgejo-specific gotchas
 
-- **No `permissions:` in Actions** - silently ignored (unlike GitHub where it scopes GITHUB_TOKEN)
+- **No `permissions:` in Actions** - silently ignored (unlike GitHub where it scopes GITHUB_TOKEN).
 - **Self-signed certs** - `GIT_SSL_NO_VERIFY=true` may be needed for git operations. Set per-remote:
-  `git config http.https://git.example.com/.sslVerify false`
+  `git config http.https://git.example.com/.sslVerify false`. For `fj`, ensure the CA is in
+  the system trust store; `fj` uses the OS TLS stack and does not expose a skip-verify flag.
 - **Runner availability** - self-hosted runners can be down. Check runner status before relying
   on CI for branch protection checks.
 - **Mirror sync delay** - if Forgejo mirrors from GitHub (or vice versa), there's a sync interval.
   Don't expect immediate consistency across forges.
+- **`fj` version** - `fj auth login` fails with PKCE errors on v0.4.0 and earlier. Use 0.4.1+.
+- **AGit requires Forgejo 7+** - older self-hosted instances reject `refs/for/<branch>` pushes.
+  Fall back to `fj pr create` without `--agit` (push a branch first).
+
+### On Gitea, not Forgejo?
+
+`tea` (`gitea.com/gitea/tea`) is the Gitea community CLI. It predates `fj` and still works
+against Gitea 1.20+ instances. Install: `go install code.gitea.io/tea@latest`, Arch
+`paru -S tea-bin`, macOS `brew install tea-cli`. Auth: `tea login add --name home --url
+https://gitea.example.com --token <token>` (no OAuth flow - token only).
+
+Rough feature parity: `tea pulls create`, `tea issues create`, `tea releases create`,
+`tea repos clone`. No AGit support (Gitea does not ship it), no Actions secret/variable
+CLI (`tea` predates Gitea Actions and has not caught up). If you are still on Gitea for
+infrastructure reasons, `tea` covers the basics; for anything Actions-related, fall back
+to the Gitea-compatible REST API directly.
+
+**Running Forgejo?** Use `fj`, not `tea`. `fj` tracks Forgejo-specific behavior (AGit,
+Forgejo Actions secrets/variables, v14 features) that `tea` does not. `tea` still works
+against Forgejo because the API is Gitea-compatible, but you will miss Forgejo features
+and hit rough edges where the two projects have diverged.
 
 ---
 


### PR DESCRIPTION
## Summary

- **git skill**: document `fj` (forgejo-cli v0.4.1) install/auth/PR/issue/actions flows; document GitLab SaaS vs self-managed differences (`glab` hostname config, CLI provenance); add `tea` fallback for Gitea users; removed unverified `fj release create` flags (wiki does not document them yet — readers told to check `fj release --help`)
- **ci-cd skill**: add Gitea Actions + Woodpecker CI as first-class platforms (extracted to `references/gitea-ci.md`); document GitLab SaaS vs self-managed operational differences (compute minutes, runner tags, tier-gated features, `CI_SERVER_*` vars) in `references/gitlab-ci.md`
- **New: `references/runners.md`** (534 lines) — install/register/executor/hardening for all 5 self-hosted runner implementations (`actions-runner`, `gitlab-runner`, `forgejo-runner`, `act_runner`, `woodpecker-agent`); Linux vs macOS differences (launchd vs systemd, keychain traps for iOS CI, macOS containerization tax); public-repo safety + ephemeral patterns
- **New: `references/best-practices.md`** (447 lines) — Dependabot/Renovate strategy with grouping/auto-merge matrix, layered linting (pre-commit → CI → blocking), scanning matrix (secrets/SCA/container/IaC/SAST placement), severity gate ratchet pattern with per-scanner baseline mechanics, CODEOWNERS + required checks + merge queues, rollout order
- **AI self-check**: ci-cd skill gets 6 new items (ephemeral runners, docker socket scope, scan ratchet, ignore expiry, lockfiles, auto-merge test gate); git skill gets 1 new item (forge-CLI subcommand verification)

Quality gates:

- 5 iterations of `skill-creator` per skill (frontmatter, description optimization, trigger overlap, cross-refs, version freshness, banned words / unicode audit)
- 5 iterations of `skill-refiner` (cross-model diff review via fresh-context Claude, behavioral tests, plateau detection)
- Removed 1 hallucinated command-flag block (`fj release create --title --body-from-file --prerelease`) — wiki does not document these yet; readers now told to verify via `fj release --help`
- All verified findings applied; 8 disputed cross-model flags discarded after primary verification

## Test plan

- [x] `scripts/lint-skills.sh` — 33 skills, 0 errors, 0 warnings
- [x] `scripts/validate-spec.sh` — 33 skills, 0 spec violations, 0 warnings
- [ ] CI `Quality Gates` workflow green on PR
- [ ] release-please opens automated minor-version release PR after merge (1.21.0 → 1.22.0 triggered by `feat(...)` commit)