### PR TITLE
feat(skills): add debian and rpm distro admin skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The loop: **Score -> Improve -> Verify -> Keep or Revert -> Repeat.**
 
 ## What's in the box
 
-29 production-tested skills covering:
+31 production-tested skills covering:
 
 ### Infrastructure & Operations
 
@@ -77,6 +77,8 @@ The loop: **Score -> Improve -> Verify -> Keep or Revert -> Repeat.**
 |-------|-------------|
 | **ansible** | Playbooks, roles, collections, Molecule testing, Ansible Vault, CIS benchmarks, compliance hardening |
 | **arch-btw** | Arch Linux and CachyOS administration - pacman, paru, AUR, systemd, bootloader and kernel recovery |
+| **debian-ubuntu** | Debian and Debian-family administration - apt, dpkg, PPAs, snaps, systemd, GRUB, AppArmor, HWE, and distro-specific quirks |
+| **rhel-fedora** | Fedora and RHEL-family administration - dnf, yum, SELinux, firewalld, dracut, subscription-manager, and clone-specific quirks |
 | **docker** | Dockerfiles, Compose, Podman, Buildah, multi-stage builds, image signing, container hardening |
 | **kubernetes** | Manifests, Helm charts, Gateway API, Kustomize, ArgoCD, sealed secrets, PCI-DSS compliance |
 | **terraform** | Terraform/OpenTofu - HCL patterns, module design, state management, policy-as-code, compliance |

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: debian-ubuntu
+description: >
+  · Administer Debian, Ubuntu, and Debian-family distros - apt, dpkg, PPAs, snaps,
+  systemd, GRUB, desktop, PipeWire, GPU, gaming, and firmware. Triggers: 'debian',
+  'ubuntu', 'mint', 'devuan', 'popos', 'pop_os', 'apt', 'dpkg', 'ppa', 'snap',
+  'grub', 'apparmor', 'hwe', 'unattended-upgrades'. Not for Arch/CachyOS
+  (**arch-btw**), shell (**command-prompt**), networking (**networking**), or config
+  management (**ansible**).
+license: MIT
+compatibility: Requires Debian, Ubuntu, or Debian-based distro with apt
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-04-22"
+  effort: high
+  argument_hint: "[issue-or-subsystem]"
+---
+
+# Debian-Ubuntu: Debian and Debian-Based Distro Administration
+
+Administer Debian, Ubuntu, Linux Mint, Pop!_OS, Devuan, and other Debian-derived systems,
+with partial coverage for Kali when the question is about base OS administration rather than
+security-distro workflow. Focus on Debian stable and Ubuntu LTS first, then layer in
+derivative-specific behavior, PPA workflows, snap confinement, Ubuntu HWE, and explicit checks
+for derivatives that diverge on init, packaging defaults, or intended use.
+
+**Versions worth pinning** (verified April 2026):
+
+Only pin versions here when they materially affect compatibility or troubleshooting shape. For
+ordinary Debian and Ubuntu package work, prefer the live distro lane and package policy over a
+stale package-version table.
+
+| Component | Version | Why it matters |
+|-----------|---------|----------------|
+| Debian stable | 13 (trixie) | current stable baseline and repo behavior |
+| Ubuntu LTS | 26.04 (Resolute Raccoon) | current LTS baseline for most Ubuntu guidance |
+| Ubuntu interim lane | verify live | interim releases move fast; check the active upgrade path instead of memorizing one short-lived codename |
+| Ubuntu HWE lane | verify live | kernel metapackage and hardware-enablement behavior matter more than one exact kernel number |
+| NVIDIA driver branch | verify live | proprietary branch choice affects Wayland, gaming, and DKMS behavior |
+| Mesa stack | verify live | AMD and Intel graphics behavior tracks the shipped Mesa lane |
+
+## When to use
+
+- Package management with `apt`, `apt-get`, `dpkg`, `apt-cache`, pinning, or holds
+- PPA management on Ubuntu, Mint, or Pop!_OS (`add-apt-repository`, key handling)
+- Snap and Flatpak workflow, confinement issues, and alternatives
+- systemd service, timer, boot, and journal troubleshooting on Debian-style systems
+- GRUB, initramfs, EFI, kernel, and recovery work on Debian or Ubuntu
+- Release maintenance: dist-upgrades, HWE transitions, release upgrades (`do-release-upgrade`)
+- Desktop stack: Wayland vs X11, GNOME, KDE, Cinnamon, COSMIC, portals, PipeWire, Bluetooth
+- Session startup and laptop work: GDM, SDDM, LightDM, suspend/resume, power profiles, hybrid graphics
+- GPU and gaming: NVIDIA proprietary vs nouveau, AMD Mesa, Intel, Vulkan, Steam, Proton, Gamescope
+- Capture and communication: OBS, WebRTC screen sharing, Discord/Teams, portals, virtual cameras
+- Storage: ext4, Btrfs, LUKS, LVM, TRIM, hibernation
+- Firmware and hardware enablement: `fwupd`, `ubuntu-drivers`, HWE stacks, backports
+- Security: AppArmor profiles, unattended-upgrades, needrestart, debian-security updates
+- Remote gaming and input: Moonlight, Sunshine, Steam Remote Play, controllers
+- Base Linux ops on Debian-style systems: `journalctl`, `dmesg`, `lsblk`, `update-alternatives`
+
+## When NOT to use
+
+- Shell syntax, quoting, or script portability - use **command-prompt**
+- Network architecture, DNS, VPNs, reverse proxies, or firewall design - use **networking**
+- Docker, Podman, image builds, or container runtime - use **docker**
+- Kubernetes cluster or manifest work - use **kubernetes**
+- Fleet-wide Linux configuration via playbooks - use **ansible**
+- Security review, vulnerability triage, or offensive testing - use **security-audit** or **lockpick**
+- RPM-family distros and tooling - use **rhel-fedora**. That includes RHEL, Fedora, Rocky, AlmaLinux, Oracle Linux, and Amazon Linux.
+- Ubuntu Core and snap-only transactional workflows - outside this skill; do not treat them like ordinary apt-managed Ubuntu hosts
+- NixOS or declarative system management - outside this skill; route to a dedicated NixOS skill when one exists
+- Kali offensive tooling, pentest workflow, or training-image specifics - outside this skill; route to a dedicated Kali skill when one exists
+- OPNsense or pfSense appliance work - use **firewall-appliance**
+
+---
+
+## AI Self-Check
+
+Before returning Debian or Ubuntu commands, verify:
+
+- [ ] **Distro and release identified**: Debian stable/testing/unstable, Ubuntu LTS/interim, Mint, Pop!_OS, Devuan, Kali, or another derivative. Advice diverges quickly.
+- [ ] **Init system identified**: do not assume systemd on Devuan or other Debian derivatives without checking PID 1, service manager, and boot tooling first.
+- [ ] **Release model respected**: do not suggest `apt upgrade` when `apt full-upgrade` or `apt dist-upgrade` is required for package transitions. Do not suggest `apt dist-upgrade` casually on Ubuntu without context.
+- [ ] **Repository state clean**: no broken apt lists, missing GPG keys, or mixed releases without pinning.
+- [ ] **Boot stack identified**: GRUB vs other loader, EFI vs BIOS, initramfs generator, and kernel metapackage before changing boot files.
+- [ ] **Fallback path exists**: do not remove the only known-good kernel or break the only boot entry on a remote system.
+- [ ] **PPA trust boundary respected**: review PPA source, key, and maintenance status before adding.
+- [ ] **systemd scope is correct**: distinguish system units from user units and use `systemctl --user` only when appropriate.
+- [ ] **Wayland stack is coherent**: compositor, portal backend, Xwayland compatibility, and user-session services line up.
+- [ ] **Session startup path identified**: display manager, greeter, or TTY launch path known before debugging env propagation.
+- [ ] **Audio stack is coherent**: PipeWire, `pipewire-pulse`, and WirePlumber are not fighting a leftover PulseAudio setup.
+- [ ] **Bluetooth path is complete**: `bluetooth.service` alone is not enough if audio routing, trust, pairing, or profile selection is broken.
+- [ ] **GPU stack matches hardware**: proprietary NVIDIA vs nouveau vs Mesa. Verify actual driver in use before debugging graphics issues.
+- [ ] **Gaming stack includes 32-bit userspace when needed**: Steam and Proton failures often come from missing `i386` graphics libraries.
+- [ ] **Capture stack is coherent**: portal backend, PipeWire, WebRTC or Electron client path, and any virtual camera module choice line up.
+- [ ] **Suspend and hibernation claims are real**: hibernation advice matches actual swap layout, initramfs resume hook, and Secure Boot state.
+- [ ] **AppArmor state is considered**: on Ubuntu, AppArmor denials can silently break services, snaps, or custom binaries.
+- [ ] **Snap confinement is not ignored**: when a snap misbehaves, check interfaces and confinement level before reinstalling.
+- [ ] **HWE kernel path is understood**: Ubuntu HWE stacks transition kernel metapackages. Know whether the system tracks `generic` or `hwe`.
+- [ ] **Diagnostic errors are not silenced**: do not mask failures with `2>/dev/null` on commands whose error reason matters. Use `2>&1 || true` to surface errors without aborting.
+- [ ] **Firmware updates are not conflated with package updates**: `fwupd` and vendor tools (e.g., `system76-firmware`) are separate from `apt upgrade`.
+- [ ] **Debian alternatives are checked**: when a command behaves oddly, verify `update-alternatives` for that binary.
+
+---
+
+## Workflow
+
+### Step 1: Identify the distro lane first
+
+| Distro | Default stance | What changes |
+|--------|----------------|--------------|
+| **Debian stable** | Conservative, pin-oriented | `stable` repo only unless testing/unstable explicitly requested. Backports for select packages. |
+| **Debian testing** | Rolling-ish, with freezes | Closer to Ubuntu but without Ubuntu-specific tooling. |
+| **Debian unstable (sid)** | True rolling | No release, just `sid`. Higher breakage risk. |
+| **Ubuntu LTS** | Default baseline | `do-release-upgrade` for release jumps. HWE kernel optional. Snap presence. |
+| **Ubuntu interim** | Short-lived | Common stepping stone into the current LTS. Quick to EOL. |
+| **Linux Mint** | Ubuntu LTS derivative | Cinnamon/XFCE focus. Mint-specific repos and update manager. PPAs from Ubuntu often work. |
+| **Pop!_OS** | Ubuntu derivative with extras | System76 firmware, COSMIC desktop, Pop repos, `system76-power`. NVIDIA ISO available. |
+| **Devuan** | Debian derivative with a major service-model split | Do not assume systemd, `systemctl`, or Ubuntu-style desktop/session plumbing. Verify init and service tooling first. |
+| **Kali** | Debian-derived security distro | Fine for base apt, kernel, boot, or service administration, but not for offensive tooling, training images, or pentest workflow assumptions. A dedicated Kali skill should handle that later. |
+| **Other Debian-based** | Confirm repo model | Do not assume vanilla Debian or Ubuntu behavior. |
+
+### Step 2: Gather current system state
+
+```bash
+cat /etc/os-release
+uname -r
+ps -p 1 -o comm=
+dpkg-query -W -f='${Package}\t${Version}\n' 'linux-image*' systemd grub-common grub-efi-amd64 2>&1 || true
+dpkg -l | grep -E "^ii.*(systemd|grub|pipewire|nvidia|mesa)" | head -15
+apt-cache policy
+command -v systemctl >/dev/null 2>&1 && systemctl --failed
+journalctl -b -p warning..alert 2>&1 || true
+findmnt /boot
+findmnt /boot/efi
+command -v grub-install >/dev/null 2>&1 && grub-install --version
+lsblk -f
+echo "Session=$XDG_SESSION_TYPE Desktop=$XDG_CURRENT_DESKTOP"
+loginctl list-sessions 2>&1 || true
+command -v systemctl >/dev/null 2>&1 && systemctl status display-manager 2>&1 || true
+command -v systemctl >/dev/null 2>&1 && systemctl --user --failed 2>&1 || true
+command -v systemctl >/dev/null 2>&1 && systemctl --user status pipewire pipewire-pulse wireplumber 2>&1 || true
+command -v systemctl >/dev/null 2>&1 && systemctl --user status xdg-desktop-portal 2>&1 || true
+command -v systemctl >/dev/null 2>&1 && systemctl status apparmor 2>&1 || true
+command -v aa-status >/dev/null 2>&1 && aa-status 2>&1 || true
+command -v wpctl >/dev/null 2>&1 && wpctl status
+command -v bluetoothctl >/dev/null 2>&1 && bluetoothctl show
+command -v snap >/dev/null 2>&1 && snap list | head -10
+command -v flatpak >/dev/null 2>&1 && flatpak list | head -10
+lspci -k | grep -Ei 'vga|3d|display'
+journalctl -b | grep -Ei 'nvrm|nvidia|amdgpu|i915|xe|drm' 2>&1 || true
+journalctl --user -b | grep -Ei 'portal|pipewire|webrtc|obs' 2>&1 || true
+lsmod | grep '^v4l2loopback'
+command -v dkms >/dev/null 2>&1 && dkms status
+findmnt -t btrfs
+command -v systemctl >/dev/null 2>&1 && systemctl status fstrim.timer 2>&1 || true
+apt list --upgradable 2>&1 | tail -n +2
+```
+
+### Step 3: Load only the relevant reference
+
+| Task type | Reference |
+|-----------|-----------|
+| `apt`, `dpkg`, pinning, PPAs, snaps, `.deb` handling | `references/packages-and-repos.md` |
+| systemd units, timers, journal, overrides | `references/systemd-and-journal.md` |
+| GRUB, kernel, initramfs, EFI, recovery | `references/boot-kernel-and-recovery.md` |
+| Ubuntu HWE, release upgrades, Debian lanes, Mint/Pop/Devuan/Kali specifics | `references/derivatives-and-hwe.md` |
+| Wayland, X11, GNOME, KDE, Cinnamon, COSMIC, PipeWire | `references/desktop-audio-and-bluetooth.md` |
+| Display managers, session startup, suspend/resume, power, hybrid graphics | `references/session-display-and-mobile.md` |
+| GPU drivers, Vulkan, Steam, Proton, gaming | `references/graphics-and-gaming.md` |
+| OBS, WebRTC, screen sharing, virtual cameras | `references/capture-and-sharing.md` |
+| ext4, Btrfs, LUKS, LVM, TRIM, hibernation | `references/storage-and-rollback.md` |
+| AppArmor, unattended-upgrades, debian-security | `references/security-and-updates.md` |
+| Remote gaming, controllers, input | `references/remote-gaming-input-and-tooling.md` |
+| Core Linux ops commands and Debian tools | `references/base-linux-and-cli.md` |
+| Recurring Debian/Ubuntu failure patterns | `references/gotchas-and-special-situations.md` |
+
+Do not load every reference by default. Pick the one that matches the failure mode, then widen
+only if the first layer is clean.
+
+### Step 4: Change one layer at a time
+
+- Fix package state before debugging services that may be broken by stale libraries.
+- Fix service configuration before declaring systemd broken.
+- Fix mountpoints and loader state before rebuilding initramfs.
+- On Ubuntu, separate "vanilla Debian behavior" from "Ubuntu snap/HWE/PPA behavior."
+- On Pop!_OS, separate "Ubuntu behavior" from "System76 firmware and power behavior."
+- Prefer reversible steps: package holds, backup kernels, `apt-mark`, saved configs.
+
+### Step 5: Validate before closing
+
+```bash
+apt-cache policy package_name
+systemctl status unit_name
+journalctl -u unit_name -b
+command -v update-grub >/dev/null 2>&1 && update-grub
+command -v grub-install >/dev/null 2>&1 && grub-install --version
+```
+
+Reboot only when the boot path is understood and at least one known-good entry remains.
+
+---
+
+## Troubleshooting Pattern
+
+Keep triage cross-layer and boring:
+
+1. Confirm active distro, release, session type, kernel, and package lane.
+2. Identify failing layer: package state, system service, user service, boot path, desktop session, graphics, or app.
+3. Pull logs before changing config.
+4. Change one layer at a time and retest.
+5. Prefer known-good baseline over tweak stacking.
+
+Core log sweep:
+
+```bash
+journalctl -b -p warning..alert
+journalctl --user -b
+dmesg --level=err,warn
+journalctl -u unit_name -b
+journalctl --user -u pipewire -u wireplumber -u xdg-desktop-portal -b
+```
+
+Broad pattern sweeps when you need correlation, not first-pass precision:
+
+```bash
+journalctl -b | grep -Ei 'nvrm|nvidia|amdgpu|i915|xe|drm' 2>&1 || true
+journalctl --user -b | grep -Ei 'portal|pipewire|webrtc|obs' 2>&1 || true
+```
+
+When a bug looks desktop-only, compare one clean baseline:
+
+- GNOME vs KDE vs Cinnamon vs COSMIC
+- browser WebRTC vs packaged client
+- plain game launch vs Gamescope or MangoHud
+- stock kernel vs HWE kernel
+
+---
+
+## Default Decisions
+
+- **Debian stable means conservative updates.** Pin when mixing repos. Use backports selectively. Avoid `testing` or `sid` packages on stable without a transition plan.
+- **Ubuntu LTS means predictable cadence.** HWE kernels for newer hardware, but they transition metapackages. Know whether the system tracks `linux-generic` or `linux-generic-hwe`.
+- **Use systemd-native tools first.** Reach for `systemctl`, `journalctl`, `timedatectl`, and `localectl` before distro wrappers.
+- **Treat PPAs as exceptions, not defaults.** Review maintainer, signing key, freshness, and package origin before adding one. Remove dead PPAs promptly.
+- **Prefer distro packages before third-party repos.** Use Debian backports, Ubuntu official repos, or vendor packages first; escalate to PPAs only when the distro lane is genuinely insufficient.
+- **Treat snaps as sandboxed first.** Interface and confinement issues explain more snap failures than package bugs.
+- **GRUB and initramfs are one subsystem.** Kernel metapackage, `update-initramfs`, `update-grub`, and EFI fallback all have to agree.
+- **Desktop failures are often session failures.** On Wayland, user units, portals, and session env matter as much as the package list.
+- **Gaming failures are often stack mismatches.** Wrong driver branch, missing `i386` userspace, absent firmware, or broken Proton path is more common than "Linux gaming is bad."
+- **Capture failures are portal/PipeWire failures.** OBS, browser WebRTC, Discord, and Teams often fail at the screencast path.
+- **AppArmor is invisible until it is not.** On Ubuntu, check `aa-status` and journal denials when a service or binary mysteriously fails.
+- **Firmware is separate from packages.** `fwupd` and vendor tools update hardware firmware. Do not expect `apt upgrade` to fix BIOS or SSD firmware.
+
+---
+
+## Quick Triage Checklist
+
+| Symptom | First checks |
+|---------|-------------|
+| Package weirdness after install | `apt update` first. Broken dependencies? `apt -f install`. Held packages? `apt-mark showhold`. Mixed releases? `apt-cache policy` |
+| Service fails after update | Config merge needed? `ucf` or `dpkg --configure -a`. Check unit overrides and `journalctl -b` |
+| Won't boot after kernel work | GRUB menu, fallback kernel, initramfs. From live media, mount root and the ESP, then bind-mount `/dev`, `/proc`, `/sys`, and `/run` before `chroot`; use the boot recovery reference instead of a one-line chroot recipe. |
+| PPA broke the system | `ppa-purge` if available, or manual downgrade + remove after checking package origin with `apt-cache policy` |
+| Snap app misbehaves | `snap connections`, `snap info`, confinement level, interfaces |
+| Desktop weirdness after update | `XDG_SESSION_TYPE`, portal, Xwayland, user services |
+| Bluetooth audio issues | BlueZ pairing, PipeWire nodes, card profile |
+| Game blackscreen/crash | GPU driver (proprietary vs Mesa), Vulkan, Steam `i386` libs, Gamescope/MangoHud |
+| Screen share broken | Wayland vs X11, portal backend, PipeWire user units |
+| Suspend/resume breaks desktop | Sleep state, GPU logs, lock-screen, display manager |
+| NVIDIA/module vanished after kernel change | DKMS drift: `dkms status`, confirm module built for `uname -r`, check HWE transition |
+| Nothing makes sense | Check gotchas reference - mixed repos, stale PPAs, DKMS drift, AppArmor denials, HWE metapackage mismatch |
+
+---
+
+## Reference Files
+
+- `references/packages-and-repos.md` - apt workflow, dpkg, pinning, PPAs, snaps, flatpaks, `.deb` handling
+- `references/systemd-and-journal.md` - systemd service debugging, unit overrides, user units, journal triage
+- `references/boot-kernel-and-recovery.md` - GRUB, kernel metapackages, initramfs, EFI, recovery, and live-ISO chroot
+- `references/derivatives-and-hwe.md` - Ubuntu HWE, release upgrades, Debian lane differences, Mint, Pop!_OS, Devuan, and Kali scope notes
+- `references/desktop-audio-and-bluetooth.md` - X11 vs Wayland, GNOME, KDE, Cinnamon, COSMIC, portals, PipeWire, Bluetooth
+- `references/session-display-and-mobile.md` - GDM, SDDM, LightDM, session env, suspend/resume, power profiles, hybrid graphics
+- `references/graphics-and-gaming.md` - NVIDIA, AMD, Intel, Vulkan, Steam, Proton, Gamescope, MangoHud
+- `references/capture-and-sharing.md` - OBS, WebRTC screen sharing, Discord/Teams, hardware encoding, virtual cameras
+- `references/storage-and-rollback.md` - ext4, Btrfs, LUKS, LVM, TRIM, hibernation, resume
+- `references/security-and-updates.md` - AppArmor, unattended-upgrades, debian-security, needrestart
+- `references/remote-gaming-input-and-tooling.md` - Moonlight, Sunshine, controllers, Steam Remote Play
+- `references/base-linux-and-cli.md` - core Linux inspection commands and Debian tools such as `update-alternatives`
+- `references/gotchas-and-special-situations.md` - recurring Debian/Ubuntu failure patterns and edge cases
+
+---
+
+## Related Skills
+
+- **command-prompt** - shell syntax, zsh or bash behavior, script portability
+- **networking** - network services, DNS, VPNs, firewall design
+- **docker** - container runtime and image concerns instead of host distro administration
+- **kubernetes** - cluster and manifest work that sits above host OS administration
+- **ansible** - codifying Linux changes across many machines
+- **security-audit** - hardening and security review rather than normal package/service administration
+- **arch-btw** - Arch Linux and CachyOS administration (the upstream inspiration for this skill)
+- **update-docs** - after substantial system administration changes that introduce new operational gotchas
+
+---
+
+## Rules
+
+1. **Identify the distro and release before prescribing commands.** Debian stable, testing, sid, Ubuntu LTS or interim, Mint, Pop!_OS, Devuan, and Kali differ where it matters: repos, init systems, kernels, and recovery assumptions.
+2. **No mixed-release advice without pinning context.** Adding `testing` or `sid` sources to Debian stable without apt pinning is usually wrong.
+3. **Keep PPAs in perspective.** Prefer distro packages, Debian backports, or vendor-supported repos first. Use PPAs only when the distro lane is genuinely insufficient, and verify package origin before adding one.
+4. **Know the boot chain before touching it.** Confirm GRUB stage, ESP mount, kernel metapackage, initramfs hooks, and EFI fallback path first.
+5. **Never remove the last known-good kernel path casually.** Especially on remote or encrypted systems.
+6. **Prefer systemd-native diagnostics.** `systemctl`, `journalctl`, and `update-grub` usually tell you more than distro wrappers or generic forum folklore.
+7. **Ubuntu HWE is opt-in complexity.** Treat HWE kernels as additions that must be validated, not magic defaults.
+8. **For Wayland issues, inspect the user session first.** Portals, user units, and Xwayland compatibility usually matter more than package reinstall churn.
+9. **For gaming issues, identify the GPU vendor and userspace first.** Driver branch, Vulkan stack, `i386` multilib, and launch wrappers usually explain more than random tweak cargo cults.
+10. **For capture issues, debug portals and PipeWire before app folklore.** OBS, browser WebRTC, Discord, and Teams often fail at the screencast path.
+11. **AppArmor can silently break things.** On Ubuntu, check `aa-status` and AppArmor denials when a service or binary mysteriously fails.
+12. **Do not oversell hibernation or resume.** These depend on exact swap layout, initramfs resume hook, and Secure Boot state.
+13. **Reach for common Debian/Ubuntu failure patterns before exotic explanations.** Mixed repos, stale PPAs, DKMS drift, AppArmor denials, HWE metapackage mismatch, and snap confinement explain a large share of the chaos.

--- a/skills/debian-ubuntu/references/base-linux-and-cli.md
+++ b/skills/debian-ubuntu/references/base-linux-and-cli.md
@@ -1,0 +1,16 @@
+# Base Linux and CLI
+
+Use this for basic inspection commands on Debian-style systems.
+
+## Common commands
+- `journalctl`
+- `dmesg`
+- `lsblk`
+- `findmnt`
+- `ps aux`
+- `ss -tulpn`
+- `update-alternatives --display name`
+
+## Notes
+- Keep diagnostics boring and factual.
+- Do not hide useful errors with blanket redirection.

--- a/skills/debian-ubuntu/references/boot-kernel-and-recovery.md
+++ b/skills/debian-ubuntu/references/boot-kernel-and-recovery.md
@@ -1,0 +1,16 @@
+# Boot, Kernel, and Recovery
+
+Use this for GRUB, initramfs, EFI, kernel packages, and boot recovery.
+
+## Checks
+- `findmnt /boot`
+- `findmnt /boot/efi`
+- `grub-install --version`
+- `update-grub`
+- `update-initramfs -u` or `update-initramfs -u -k all`
+- `uname -r`
+
+## Notes
+- Know the kernel metapackage before changing anything.
+- Keep one known-good kernel entry around.
+- On EFI systems, verify the ESP mount before reinstalling GRUB.

--- a/skills/debian-ubuntu/references/capture-and-sharing.md
+++ b/skills/debian-ubuntu/references/capture-and-sharing.md
@@ -1,0 +1,13 @@
+# Capture and Sharing
+
+Use this for OBS, browser screen sharing, Discord, Teams, WebRTC, and virtual cameras.
+
+## Checks
+- `systemctl --user status xdg-desktop-portal`
+- `systemctl --user status pipewire wireplumber`
+- `journalctl --user -b | grep -Ei 'portal|pipewire|webrtc|obs'`
+- `lsmod | grep '^v4l2loopback'`
+
+## Notes
+- Most capture failures are portal or PipeWire path failures.
+- Virtual cameras depend on matching session and module state.

--- a/skills/debian-ubuntu/references/derivatives-and-hwe.md
+++ b/skills/debian-ubuntu/references/derivatives-and-hwe.md
@@ -1,0 +1,82 @@
+# Derivatives and HWE
+
+Use this for Ubuntu HWE, Ubuntu release upgrades, Mint, Pop!_OS, Devuan, Kali, and other
+Debian-derived distro specifics that materially change package, boot, or service behavior.
+
+## Checks
+- `cat /etc/os-release`
+- `lsb_release -a 2>&1 || true`
+- `uname -r`
+- `apt-cache policy linux-generic linux-generic-hwe 2>&1 || true`
+- `apt-cache policy 2>&1 | sed -n '1,40p'`
+- `ps -p 1 -o comm=`
+- `command -v systemctl >/dev/null 2>&1 && systemctl --version`
+- `command -v do-release-upgrade >/dev/null 2>&1 && do-release-upgrade --help | head -20`
+- `command -v ubuntu-drivers >/dev/null 2>&1 && ubuntu-drivers devices`
+- `command -v apt-mark >/dev/null 2>&1 && apt-mark showhold`
+
+## Distro notes
+
+### Debian stable
+- Default to conservative package movement and explicit pinning when any non-stable lane appears.
+- Prefer backports over casual mixing with testing or sid.
+
+### Debian testing
+- Treat testing as a moving target with fewer Debian-specific safety rails than stable.
+- Before recommending fixes, check whether the issue is a transient testing transition rather than a local host problem.
+
+### Debian unstable (sid)
+- Treat sid as high-churn and breakage-prone by design.
+- Be stricter about package origin, pinning, and transition awareness than on stable.
+
+### Ubuntu LTS
+- Current LTS baseline is Ubuntu 26.04 LTS (Resolute Raccoon).
+- Common upgrade sources are Ubuntu 24.04 LTS and Ubuntu 25.10.
+- HWE changes the kernel lane. Check whether the host tracks `linux-generic` or `linux-generic-hwe`.
+- PPAs, snaps, and AppArmor are normal parts of the troubleshooting surface here.
+
+### Ubuntu interim
+- Treat interim releases as short-lived stepping stones, not a long-term server baseline.
+- Before advising upgrades, check release support status and the documented path into the current LTS.
+
+### Ubuntu flavors
+- Kubuntu, Xubuntu, Lubuntu, Ubuntu Budgie, and similar flavors still fit this skill when the issue is ordinary apt, boot, kernel, or base service administration.
+- Desktop-session advice must follow the actual flavor stack instead of assuming GNOME defaults.
+
+### Linux Mint
+- Mint follows Ubuntu LTS closely but adds its own update tooling and desktop defaults.
+- Cinnamon and Mint tooling can shift the desktop/session troubleshooting path even when apt behavior is standard Ubuntu underneath.
+- Prefer checking Mint-managed update state before assuming a pure Ubuntu workflow.
+
+### Pop!_OS
+- Pop!_OS layers System76 firmware, power, graphics, and recovery behavior on top of Ubuntu.
+- Confirm whether the issue is ordinary Ubuntu package behavior or a System76-specific layer such as firmware, graphics switching, or COSMIC components.
+- NVIDIA guidance may differ because Pop images and vendor tooling shape the baseline.
+
+### Devuan
+- Devuan is the big service-management exception in this family.
+- Do not assume systemd, `systemctl`, `journalctl`, or Ubuntu-style desktop-session plumbing.
+- Check PID 1, installed init packages, and the actual service-management stack before prescribing commands.
+- For Devuan, package and repository advice may still be Debian-like while service and boot workflows diverge sharply.
+
+### Kali
+- Kali is Debian-derived, so apt, dpkg, boot, and kernel basics can still fit this skill.
+- Do not treat Kali like a generic desktop or server distro when the question is really about offensive tooling, lab images, or pentest workflow. That should move to a dedicated Kali skill later.
+- Be conservative with desktop and hardening assumptions because Kali images, package sets, and intended use differ from stock Debian.
+
+### Other Debian-based distros
+- Explicitly confirm repo model, release base, and service stack first.
+- This bucket can include Zorin OS, elementary OS, and MX Linux, but only if the underlying issue is still ordinary apt, boot, or service administration.
+- If the distro's identity changes the package manager, service stack, or operating model, stop pretending it is just Ubuntu with a different wallpaper.
+
+## What is out of scope
+- RPM-family distros such as RHEL, Fedora, Rocky, AlmaLinux, Oracle Linux, and Amazon Linux
+- NixOS and declarative system-management workflows
+- Kali offensive tooling, exploit workflow, lab-image conventions, or training-specific behavior
+
+## Notes
+- Ubuntu HWE changes the kernel lane.
+- Mint follows Ubuntu LTS and adds its own update tooling.
+- Pop!_OS adds System76 firmware and power behavior.
+- Devuan may break systemd assumptions outright.
+- Kali is only a partial fit here for base OS administration, not for security-distro workflow.

--- a/skills/debian-ubuntu/references/desktop-audio-and-bluetooth.md
+++ b/skills/debian-ubuntu/references/desktop-audio-and-bluetooth.md
@@ -1,0 +1,15 @@
+# Desktop, Audio, and Bluetooth
+
+Use this for Wayland, X11, GNOME, KDE, Cinnamon, COSMIC, PipeWire, and Bluetooth.
+
+## Checks
+- `echo "$XDG_SESSION_TYPE $XDG_CURRENT_DESKTOP"`
+- `systemctl --user status pipewire pipewire-pulse wireplumber`
+- `systemctl --user status xdg-desktop-portal`
+- `wpctl status`
+- `bluetoothctl show`
+
+## Notes
+- Match compositor, portal backend, and session services.
+- If audio is broken, check leftover PulseAudio before reinstalling PipeWire.
+- Bluetooth audio depends on pairing, trust, and profile selection.

--- a/skills/debian-ubuntu/references/gotchas-and-special-situations.md
+++ b/skills/debian-ubuntu/references/gotchas-and-special-situations.md
@@ -1,0 +1,15 @@
+# Gotchas and Special Situations
+
+Use this for recurring Debian and Ubuntu failure patterns.
+
+## Common gotchas
+- Mixed releases without pinning
+- Dead PPAs
+- Interrupted dpkg state
+- DKMS drift after kernel updates
+- AppArmor denials
+- Snap confinement surprises
+- HWE metapackage mismatch
+
+## Notes
+- Check the basic package and boot path before chasing exotic explanations.

--- a/skills/debian-ubuntu/references/graphics-and-gaming.md
+++ b/skills/debian-ubuntu/references/graphics-and-gaming.md
@@ -1,0 +1,13 @@
+# Graphics and Gaming
+
+Use this for NVIDIA, Mesa, Vulkan, Steam, Proton, Gamescope, and desktop gaming failures.
+
+## Checks
+- `lspci -k | grep -Ei 'vga|3d|display'`
+- `journalctl -b | grep -Ei 'nvidia|amdgpu|i915|xe|drm'`
+- `apt-cache policy nvidia-driver mesa-vulkan-drivers`
+- `dpkg --print-foreign-architectures`
+
+## Notes
+- Verify the actual driver in use before blaming the game.
+- Steam/Proton often need 32-bit graphics libraries.

--- a/skills/debian-ubuntu/references/packages-and-repos.md
+++ b/skills/debian-ubuntu/references/packages-and-repos.md
@@ -1,0 +1,17 @@
+# Packages and Repos
+
+Use this when the problem is apt, dpkg, PPAs, packages, or third-party repos.
+
+## Quick checks
+- `apt update`
+- `apt-cache policy package`
+- `apt-mark showhold`
+- `dpkg -l | grep '^ii'`
+- `apt -f install` when dependency state is broken
+
+## Common moves
+- Prefer `apt install package` for new installs.
+- Use `apt full-upgrade` when package transitions require removals or replacements.
+- Use `dpkg --configure -a` after interrupted package operations.
+- Use `add-apt-repository` only after checking the source and key.
+- Use `ppa-purge` or manual downgrade when a PPA breaks the system.

--- a/skills/debian-ubuntu/references/remote-gaming-input-and-tooling.md
+++ b/skills/debian-ubuntu/references/remote-gaming-input-and-tooling.md
@@ -1,0 +1,12 @@
+# Remote Gaming, Input, and Tooling
+
+Use this for Moonlight, Sunshine, Steam Remote Play, controllers, and input quirks.
+
+## Checks
+- `journalctl -b | grep -Ei 'sunshine|moonlight|gamepad|controller'`
+- `lsusb`
+- `udevadm info --query=all --name=/dev/input/event*`
+
+## Notes
+- Confirm the input device is recognized before debugging the app layer.
+- Remote play issues often come from encoding, network, or session state.

--- a/skills/debian-ubuntu/references/security-and-updates.md
+++ b/skills/debian-ubuntu/references/security-and-updates.md
@@ -1,0 +1,14 @@
+# Security and Updates
+
+Use this for AppArmor, unattended-upgrades, security maintenance, and update hygiene.
+
+## Checks
+- `aa-status`
+- `journalctl -b | grep -Ei 'apparmor|denied'`
+- `apt list --upgradable`
+- `systemctl status unattended-upgrades`
+- `needrestart -r l` if installed
+
+## Notes
+- AppArmor denials can look like random app failures.
+- Security updates and firmware updates are separate concerns.

--- a/skills/debian-ubuntu/references/session-display-and-mobile.md
+++ b/skills/debian-ubuntu/references/session-display-and-mobile.md
@@ -1,0 +1,13 @@
+# Session, Display, and Mobile
+
+Use this for display managers, login sessions, suspend/resume, power, and laptop graphics.
+
+## Checks
+- `systemctl status display-manager`
+- `loginctl list-sessions`
+- `systemctl status power-profiles-daemon`
+- `journalctl -b | grep -Ei 'suspend|resume|sleep|gdm|sddm|lightdm'`
+
+## Notes
+- Identify the display manager and launch path before debugging the session.
+- Hybrid graphics changes the output path on laptops.

--- a/skills/debian-ubuntu/references/storage-and-rollback.md
+++ b/skills/debian-ubuntu/references/storage-and-rollback.md
@@ -1,0 +1,13 @@
+# Storage and Rollback
+
+Use this for ext4, Btrfs, LUKS, LVM, TRIM, hibernation, and rollback work.
+
+## Checks
+- `lsblk -f`
+- `findmnt -t btrfs`
+- `systemctl status fstrim.timer`
+- `blkid`
+
+## Notes
+- Snapshots help with rollback but are not backups.
+- Hibernation depends on swap layout and resume configuration.

--- a/skills/debian-ubuntu/references/systemd-and-journal.md
+++ b/skills/debian-ubuntu/references/systemd-and-journal.md
@@ -1,0 +1,16 @@
+# systemd and Journal
+
+Use this for unit failures, boot timing, user services, and logs.
+
+## Checks
+- `systemctl --failed`
+- `systemctl status unit_name`
+- `journalctl -b -p warning..alert`
+- `journalctl -u unit_name -b`
+- `systemctl --user --failed`
+- `journalctl --user -b`
+
+## Notes
+- Distinguish system and user units.
+- Check overrides with `systemctl cat unit_name`.
+- Use `systemctl --user` only for desktop-session services.

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: rhel-fedora
+description: >
+  · Administer RHEL, Fedora, CentOS Stream, Rocky, AlmaLinux, Oracle Linux, and Amazon Linux
+  - dnf, yum, SELinux, systemd, GRUB, dracut, host firewalld, and desktop/GPU work.
+  Triggers: 'rhel', 'fedora', 'centos stream', 'rocky', 'alma', 'almalinux',
+  'oracle linux', 'amazon linux', 'dnf', 'yum', 'selinux', 'rpm fusion', 'akmods'.
+  Not for Arch/Debian, rpm-ostree/image-mode, containers, shell (**command-prompt**),
+  network design (**networking**), or config management (**ansible**).
+license: MIT
+compatibility: Requires Fedora, RHEL, or RHEL-family distro with dnf, yum, or rpm
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-04-22"
+  effort: high
+  argument_hint: "[issue-or-subsystem]"
+---
+
+# RHEL-Fedora: Fedora and RHEL-Family Administration
+
+Administer Fedora, RHEL, Rocky Linux, AlmaLinux, Oracle Linux, Amazon Linux, and nearby
+RPM-family systems without flattening their important differences. Start by separating the
+fast-moving Fedora lane from the conservative enterprise lane, then account for vendor quirks
+such as subscription-manager, CentOS Stream drift, Oracle UEK, Amazon's cloud-first defaults,
+and SELinux or firewalld behavior that people love to blame on the wrong layer.
+
+**Versions worth pinning** (verified April 2026):
+
+Only pin versions here when they materially affect compatibility or troubleshooting shape. For
+ordinary package work, prefer the live distro lane and repo state over a stale package table.
+
+| Component | Version | Why it matters |
+|-----------|---------|----------------|
+| Fedora stable | 42 | current mainstream Fedora baseline |
+| Fedora next branch | 43 / verify live | useful when a bug is really Fedora-next behavior |
+| RHEL enterprise lane | 10.x | current enterprise baseline in the new major lane |
+| RHEL previous major | 9.x | still widely deployed and behaviorally different from 10 |
+| Rocky Linux | verify live major lane | close to RHEL, but current docs and vault state still matter |
+| AlmaLinux | verify live major lane | close to RHEL, but current release notes and policy docs still matter |
+| Oracle Linux | verify live major lane | current Oracle lane matters, but UEK vs RHCK matters more |
+| Amazon Linux | AL2023 / verify live release | release-note lane matters more than memorizing one point version |
+| SELinux | verify live | policy package and mode matter more than memorized version strings |
+| DNF | verify live | Fedora moves faster than enterprise lanes; DNF 5 vs legacy expectations matter |
+| Podman | verify live | rootless and quadlet behavior depend on the shipped distro lane |
+
+## When to use
+
+- Package management with `dnf`, `yum`, `rpm`, local `.rpm` files, repo configuration, or package provenance
+- Fedora repo, COPR, updates-testing, modularity, and release-upgrade work
+- RHEL subscription, entitlement, CodeReady Builder, Insights, EPEL, and clone compatibility questions
+- systemd service, timer, boot, and journal troubleshooting on Fedora or RHEL-family systems
+- GRUB, EFI, `dracut`, initramfs, kernel, `grubby`, and boot recovery work
+- Release maintenance: Fedora `dnf system-upgrade`, RHEL-family major or minor transitions, `leapp` planning
+- Security plumbing: SELinux modes, contexts, booleans, AVC denials, `firewalld`, FIPS-adjacent checks, package signing
+- Container-host work that is really host-admin work: Podman packages, rootless prerequisites, cgroup or SELinux host integration
+- Desktop stack on Fedora Workstation or similar: Wayland vs X11, GNOME, KDE, portals, PipeWire, Bluetooth
+- Session startup and laptop work: GDM, SDDM, suspend or resume, power profiles, hybrid graphics
+- GPU and gaming work: NVIDIA akmods or DKMS, Mesa, Vulkan, Steam, Proton, Gamescope, MangoHud
+- Capture and communication: OBS, WebRTC screen sharing, Discord or Teams, portals, virtual cameras
+- Storage: XFS, ext4, Btrfs, LUKS, LVM, Stratis, TRIM, hibernation
+- Firmware and hardware enablement: `fwupdmgr`, vendor firmware tools, microcode, `mokutil`, Secure Boot
+- Cloud-image and VM defaults on Amazon Linux, RHEL cloud images, Rocky, Alma, and Oracle Linux guests
+- Base Linux ops on RPM-family systems: `journalctl`, `dmesg`, `lsblk`, `grubby`, `rpm -Va`, `restorecon`
+
+## When NOT to use
+
+- Shell syntax, quoting, or script portability - use **command-prompt**
+- Network architecture, DNS, VPNs, reverse proxies, or firewall design - use **networking**
+- Dockerfiles, Compose files, image builds, or container runtime architecture - use **docker**
+- Kubernetes cluster or manifest work - use **kubernetes**
+- Fleet-wide Linux configuration via playbooks - use **ansible**
+- Security review, vulnerability triage, or offensive testing - use **security-audit** or **lockpick**
+- Arch, CachyOS, or other pacman-family systems - use **arch-btw**
+- Debian, Ubuntu, Mint, Pop!_OS, or other apt-family systems - use **debian-ubuntu**
+- Fedora Silverblue, Kinoite, Bazzite, Bluefin, Universal Blue, CoreOS, bootc, or other rpm-ostree / image-mode workflows - outside this skill; do not treat them like ordinary dnf-managed hosts
+- OPNsense or pfSense appliance work - use **firewall-appliance**
+
+---
+
+## AI Self-Check
+
+Before returning Fedora or RHEL-family commands, verify:
+
+- [ ] **Distro lane identified**: Fedora, CentOS Stream, RHEL, Rocky, AlmaLinux, Oracle Linux, Amazon Linux, or another derivative. Advice diverges fast.
+- [ ] **Release lane identified**: Fedora stable vs Rawhide/Branched, RHEL 8 vs 9 vs 10, AL2023 vs old Amazon Linux 2, Oracle Linux with RHCK vs UEK.
+- [ ] **Package path identified**: `dnf`, legacy `yum`, plain `rpm`, or `microdnf`. If the host is rpm-ostree or image-mode, stop and route away instead of treating it like a normal DNF-managed host.
+- [ ] **Repo provenance understood**: base repos, EPEL, CRB/PowerTools/CodeReady Builder, COPR, vendor repos, and third-party release RPMs are not interchangeable.
+- [ ] **Fedora speed respected**: Fedora guidance that is fine on 42 can be stale or wrong on Rawhide and too new for enterprise clones.
+- [ ] **Enterprise conservatism respected**: do not blindly transplant Fedora COPR, raw upstream kernels, or random GitHub RPM repos onto production RHEL-family hosts.
+- [ ] **SELinux considered early**: if the symptom smells like permission, bind mount, custom service, rootless container, or web app weirdness, check AVCs before disabling SELinux.
+- [ ] **SELinux fix is correct**: distinguish labeling (`restorecon`, `semanage fcontext`) from booleans (`setsebool`) and custom policy (`audit2allow`). Do not cargo-cult `setenforce 0`.
+- [ ] **firewalld scope is correct**: runtime vs permanent rules, active zone, interface binding, and rich rules are understood before changing exposure.
+- [ ] **Boot stack identified**: GRUB, EFI mountpoint, kernel package, `dracut`, Secure Boot state, and `grubby` path are known before changing boot files.
+- [ ] **Fallback path exists**: do not remove the only known-good kernel or boot entry on a remote system.
+- [ ] **Vendor kernel path identified**: Oracle UEK vs RHCK, Amazon kernel choices, and NVIDIA akmods/DKMS expectations matter.
+- [ ] **Subscription state known**: on RHEL, entitlement and repo enablement may be the real problem, not package naming.
+- [ ] **Module streams handled consciously**: if AppStream or module streams are involved, verify the active stream before suggesting installs, resets, or downgrades.
+- [ ] **Desktop stack is coherent**: compositor, portal backend, PipeWire, session type, and user services line up.
+- [ ] **Gaming stack includes 32-bit userspace when needed**: Steam and Proton failures often come from missing multilib graphics pieces, not the game itself.
+- [ ] **Capture stack is coherent**: portal backend, PipeWire, WebRTC or Electron path, and any virtual camera module line up with the current session type.
+- [ ] **Cloud-image assumptions are checked**: Amazon Linux, cloud-init images, and minimal RHEL images omit tools you might expect on a full install.
+- [ ] **Upgrade path is real**: Fedora `dnf system-upgrade`, RHEL `leapp`, and clone major-version jumps have different support stories. Do not improvise an in-place major upgrade path.
+- [ ] **Diagnostic errors are not silenced**: do not hide useful failure output with `2>/dev/null` on commands whose errors matter. Use `2>&1 || true` when gathering.
+- [ ] **Version table treated as a hint, not gospel**: if the pinned table is getting old, verify distro release and key package versions live before leaning on it.
+
+---
+
+## Workflow
+
+### Step 1: Identify the distro lane first
+
+| Distro | Default stance | What changes |
+|--------|----------------|--------------|
+| **Fedora stable** | Fast-moving workstation or server baseline | DNF 5 era, COPR exists, frequent rebases, shorter support window |
+| **Fedora Rawhide / Branched** | Slow down | Pre-release behavior, docs and package names can move under you |
+| **CentOS Stream** | Treat as ahead-of-RHEL, not equal-to-RHEL | Preview-ish enterprise lane; package timing and bugs can differ |
+| **RHEL** | Conservative enterprise baseline | Subscription-manager, repo entitlements, supported upgrade paths |
+| **Rocky Linux** | Conservative clone baseline | No subscription-manager, vault behavior, fast follow after upstream |
+| **AlmaLinux** | Conservative clone baseline with its own policies | Mostly RHEL-shaped, but do not pretend it is literally identical |
+| **Oracle Linux** | Check kernel lane immediately | UEK vs RHCK changes driver, storage, and support assumptions |
+| **Amazon Linux 2023** | Cloud-first, vendor-shaped lane | Fedora-derived userland with AWS defaults, no blind RHEL-copying |
+| **Other RPM-based** | Confirm repo and support model | Do not assume Fedora or RHEL rules without evidence |
+
+### Step 2: Gather current system state
+
+```bash
+cat /etc/os-release
+uname -r
+rpm -E '%{?rhel} %{?fedora}'
+rpm -q systemd rpm dnf grub2-common dracut selinux-policy-targeted 2>&1 || true
+dnf --version 2>&1 || yum --version 2>&1 || true
+rpm -qa | grep -E '^(kernel|kernel-core|kernel-uek|dnf|yum|podman|firewalld|selinux-policy)' | head -20
+rpm -qf /etc/redhat-release 2>&1 || true
+dnf repolist --enabled 2>&1 || yum repolist enabled 2>&1 || true
+dnf module list --enabled 2>&1 || true
+subscription-manager status 2>&1 || true
+subscription-manager repos --list-enabled 2>&1 || true
+systemctl --failed 2>&1 || true
+journalctl -b -p warning..alert 2>&1 || true
+getenforce 2>&1 || true
+sestatus 2>&1 || true
+ausearch -m avc -ts boot 2>&1 || true
+firewall-cmd --get-active-zones 2>&1 || true
+firewall-cmd --list-all 2>&1 || true
+findmnt /boot
+findmnt /boot/efi
+grubby --default-kernel 2>&1 || true
+grubby --info=ALL 2>&1 || true
+lsblk -f
+echo "Session=$XDG_SESSION_TYPE Desktop=$XDG_CURRENT_DESKTOP"
+loginctl list-sessions 2>&1 || true
+systemctl status display-manager 2>&1 || true
+systemctl --user --failed 2>&1 || true
+systemctl --user status pipewire pipewire-pulse wireplumber 2>&1 || true
+systemctl --user status xdg-desktop-portal 2>&1 || true
+command -v wpctl >/dev/null 2>&1 && wpctl status
+command -v bluetoothctl >/dev/null 2>&1 && bluetoothctl show
+lspci -k | grep -Ei 'vga|3d|display'
+journalctl -b | grep -Ei 'nvrm|nvidia|amdgpu|i915|xe|drm' 2>&1 || true
+journalctl --user -b | grep -Ei 'portal|pipewire|webrtc|obs' 2>&1 || true
+lsmod | grep '^v4l2loopback' 2>&1 || true
+command -v akmods >/dev/null 2>&1 && akmods --force --kernels "$(uname -r)" --test 2>&1 || true
+command -v dkms >/dev/null 2>&1 && dkms status 2>&1 || true
+findmnt -t btrfs,xfs,ext4
+systemctl status fstrim.timer 2>&1 || true
+fwupdmgr get-devices 2>&1 || true
+dnf check-update 2>&1 || true
+```
+
+### Step 3: Load only the relevant reference
+
+| Task type | Reference |
+|-----------|-----------|
+| `dnf`, `yum`, `rpm`, repo config, EPEL, COPR, modules, local RPMs | `references/packages-and-repos.md` |
+| systemd units, timers, journal, overrides | `references/systemd-and-journal.md` |
+| GRUB, kernel, `dracut`, EFI, `grubby`, recovery | `references/boot-kernel-and-recovery.md` |
+| Fedora vs RHEL vs Rocky vs Alma vs Oracle vs Amazon behavior | `references/derivatives-and-vendor-quirks.md` |
+| Wayland, X11, GNOME, KDE, PipeWire, Bluetooth | `references/desktop-audio-and-bluetooth.md` |
+| Display managers, session startup, suspend or resume, power, hybrid graphics | `references/session-display-and-mobile.md` |
+| GPU drivers, Vulkan, Steam, Proton, gaming | `references/graphics-and-gaming.md` |
+| OBS, WebRTC, screen sharing, virtual cameras | `references/capture-and-sharing.md` |
+| XFS, ext4, Btrfs, LUKS, LVM, Stratis, TRIM, hibernation | `references/storage-and-rollback.md` |
+| SELinux, firewalld, package signing, updates, compliance-adjacent checks | `references/security-and-updates.md` |
+| Remote gaming, controllers, input | `references/remote-gaming-input-and-tooling.md` |
+| Core Linux inspection commands and RPM-family tools | `references/base-linux-and-cli.md` |
+| Recurring Fedora and RHEL-family failure patterns | `references/gotchas-and-special-situations.md` |
+
+Do not load every reference by default. Pick the one that matches the failure mode, then widen
+only if the first layer is clean.
+
+### Step 4: Change one layer at a time
+
+- Fix repo and package state before debugging services that may be broken by wrong package sets.
+- Fix SELinux labeling or policy before declaring the app broken.
+- Fix `firewalld` exposure before blaming service startup.
+- Fix mountpoints and loader state before rebuilding `dracut` or changing kernels.
+- On Fedora, separate "upstream fast-moving distro behavior" from "third-party repo or COPR behavior."
+- On RHEL, separate "package unavailable" from "repo entitlement disabled."
+- On Oracle Linux, confirm UEK vs RHCK before chasing driver and storage symptoms.
+- On Amazon Linux, separate cloud-image defaults and AWS repo choices from generic RHEL folklore.
+- Prefer reversible steps: keep old kernels, save `.repo` files, snapshot if available, preserve SELinux context fixes in policy rather than one-off `chcon` hacks.
+
+### Step 5: Validate before closing
+
+```bash
+rpm -q package_name
+rpm -V package_name
+systemctl status unit_name
+journalctl -u unit_name -b
+getenforce
+sestatus
+firewall-cmd --list-all
+grubby --default-kernel
+```
+
+Reboot only when the boot path is understood and at least one known-good entry remains.
+
+---
+
+## Troubleshooting Pattern
+
+Keep triage cross-layer and boring:
+
+1. Confirm active distro, release lane, package manager, kernel lane, and repo state.
+2. Identify the failing layer: repo/package state, SELinux, firewall, system service, user service, boot path, desktop session, graphics, or app.
+3. Pull the right logs before changing config.
+4. Change one layer at a time and retest.
+5. Prefer known-good baseline over tweak stacking.
+
+Core log sweep:
+
+```bash
+journalctl -b -p warning..alert
+journalctl --user -b
+dmesg --level=err,warn
+journalctl -u unit_name -b
+ausearch -m avc -ts recent
+```
+
+Broad pattern sweeps when you need correlation, not first-pass precision:
+
+```bash
+journalctl -b | grep -Ei 'nvrm|nvidia|amdgpu|i915|xe|drm' 2>&1 || true
+journalctl --user -b | grep -Ei 'portal|pipewire|webrtc|obs' 2>&1 || true
+ausearch -m avc -ts boot 2>&1 || true
+```
+
+When a bug looks desktop-only, compare one clean baseline:
+
+- GNOME vs KDE
+- browser WebRTC vs packaged client
+- plain game launch vs Gamescope or MangoHud
+- RHCK vs UEK on Oracle Linux when kernel behavior is suspect
+- stock repo package vs third-party repo package
+
+---
+
+## Default Decisions
+
+- **Fedora means fast change.** Verify the exact release and avoid stale blog-fix cargo cults.
+- **RHEL means support boundaries matter.** Check entitlements, supported repos, and documented upgrade paths before inventing one.
+- **Clones are close, not identical in process.** Rocky, AlmaLinux, Oracle Linux, and Amazon Linux can share RPM names while differing in policy, repos, kernels, and support tooling.
+- **Use systemd-native tools first.** Reach for `systemctl`, `journalctl`, `loginctl`, and `timedatectl` before wrappers.
+- **Treat SELinux as signal, not as the enemy.** AVC denials usually tell you exactly which layer is wrong.
+- **Treat `firewalld` as stateful plumbing.** Zone, runtime, permanent state, and service definitions all matter.
+- **GRUB, kernel, and `dracut` are one subsystem.** Kernel package, initramfs, Secure Boot state, and bootloader entries have to agree.
+- **Desktop failures are often session failures.** On Wayland, user units, portals, and session env matter as much as the package list.
+- **Gaming failures are often stack mismatches.** Wrong driver branch, missing 32-bit userspace, absent firmware, or a broken Proton path is more common than the game being the real problem.
+- **Cloud images are intentionally skinny.** Missing packages and disabled services are often by design, not corruption.
+
+---
+
+## Quick Triage Checklist
+
+| Symptom | First checks |
+|---------|-------------|
+| Package weirdness after install | `dnf repolist`, `dnf check`, `rpm -q`, module stream mismatch, third-party repo drift |
+| Package unavailable on RHEL | entitlement or CRB missing? `subscription-manager repos --list-enabled`, repo enablement, EPEL assumptions |
+| SELinux broke my app | `getenforce`, `ausearch -m avc -ts recent`, labeling vs boolean vs policy module |
+| Service fails after update | repo drift, dropped config, `systemctl status`, `journalctl -b`, `rpm -V package` |
+| Won't boot after kernel work | EFI mount, `grubby --info=ALL`, `dracut` image, Secure Boot, fallback kernel |
+| Fedora upgrade weirdness | exact Fedora release, `dnf system-upgrade` state, third-party repos, COPR packages |
+| RHEL clone behaves oddly | clone-specific release docs, vault state, EPEL assumptions, unsupported in-place upgrade folklore |
+| Oracle Linux issue | RHCK vs UEK first, then driver/storage/virtualization path |
+| Amazon Linux mismatch | AL2023 vs AL2, cloud-init defaults, AWS package docs, missing extra repos |
+| Desktop weirdness after update | `XDG_SESSION_TYPE`, portal, Xwayland, user services |
+| Bluetooth audio issues | BlueZ pairing, PipeWire nodes, card profile |
+| Game blackscreen/crash | GPU driver, Vulkan, multilib graphics libs, Gamescope/MangoHud |
+| Screen share broken | Wayland vs X11, portal backend, PipeWire user units |
+| Suspend/resume breaks desktop | sleep state, GPU logs, lock-screen, display manager |
+| NVIDIA/module vanished after kernel change | akmods or DKMS drift, Secure Boot signing, current kernel vs installed module |
+| Nothing makes sense | check gotchas reference - repo drift, SELinux labeling, module stream confusion, stale third-party repos, and kernel lane mismatch explain a lot |
+
+---
+
+## Reference Files
+
+- `references/packages-and-repos.md` - DNF, YUM, RPM, local packages, repo files, EPEL, COPR, modules, and package provenance
+- `references/systemd-and-journal.md` - systemd service debugging, unit overrides, user units, journal triage, and safe edit flow
+- `references/boot-kernel-and-recovery.md` - GRUB, `dracut`, kernel packages, `grubby`, EFI, Secure Boot, and recovery workflow
+- `references/derivatives-and-vendor-quirks.md` - Fedora, CentOS Stream, RHEL, Rocky, AlmaLinux, Oracle Linux, and Amazon Linux differences that actually matter
+- `references/desktop-audio-and-bluetooth.md` - X11 vs Wayland, GNOME and KDE notes, portals, PipeWire, and Bluetooth troubleshooting
+- `references/session-display-and-mobile.md` - GDM, SDDM, session env, suspend or resume, power profiles, and hybrid graphics routing
+- `references/graphics-and-gaming.md` - NVIDIA, AMD, Intel, Vulkan, Steam, Proton, Gamescope, MangoHud, and akmods or DKMS notes
+- `references/capture-and-sharing.md` - OBS, WebRTC screen sharing, Discord or Teams routing, hardware encoding, and virtual camera troubleshooting
+- `references/storage-and-rollback.md` - XFS, ext4, Btrfs, LUKS, LVM, Stratis, TRIM, hibernation, and rollback boundaries
+- `references/security-and-updates.md` - SELinux, firewalld, package signing, updates, FIPS-adjacent concerns, and compliance-sensitive defaults
+- `references/remote-gaming-input-and-tooling.md` - Moonlight, Sunshine, controllers, and Steam Remote Play
+- `references/base-linux-and-cli.md` - core Linux inspection commands and RPM-family tools such as `rpm -Va`, `repoquery`, and `restorecon`
+- `references/gotchas-and-special-situations.md` - recurring Fedora and RHEL-family failure patterns, special cases, and what-to-do-next guidance
+
+---
+
+## Related Skills
+
+- **command-prompt** - shell syntax, zsh or bash behavior, script portability
+- **networking** - network services, DNS, VPNs, firewall design beyond host-level `firewalld`
+- **docker** - container runtime and image concerns instead of host distro administration
+- **kubernetes** - cluster and manifest work that sits above host OS administration
+- **ansible** - codifying Linux changes across many machines
+- **security-audit** - hardening and security review rather than normal package and service administration
+- **arch-btw** - Arch Linux and CachyOS administration (same operating-system-admin pattern, different package and release model)
+- **debian-ubuntu** - Debian and Ubuntu administration (same operating-system-admin pattern, different package and distro family)
+- **update-docs** - after substantial system administration changes that introduce new operational gotchas
+
+---
+
+## Rules
+
+1. **Identify the distro and release lane before prescribing commands.** Fedora, CentOS Stream, RHEL, Rocky, AlmaLinux, Oracle Linux, and Amazon Linux differ where it matters: repos, kernels, support tooling, and upgrade paths.
+2. **Do not flatten Fedora and RHEL into one thing.** Fedora is the fast lane. Enterprise clones are not just "older Fedora" with different branding.
+3. **Know the package origin before changing package state.** Repo enablement, release RPMs, module streams, and third-party repos explain a lot of RPM-family chaos.
+4. **Treat SELinux denials as first-class evidence.** Check AVCs before disabling enforcement or blaming the app.
+5. **Use the right SELinux fix.** Prefer proper labeling, booleans, or policy modules over permanent `setenforce 0` and random `chcon` drift.
+6. **Know the boot chain before touching it.** Confirm GRUB stage, EFI mount, kernel package, `dracut`, Secure Boot, and `grubby` state first.
+7. **Never remove the last known-good kernel path casually.** Especially on remote, encrypted, or cloud systems.
+8. **Prefer systemd-native diagnostics.** `systemctl`, `journalctl`, `loginctl`, and `grubby` usually tell you more than forum folklore.
+9. **Be conservative with third-party repos.** COPR on Fedora, EPEL on enterprise clones, vendor RPM repos, and release packages all change the support boundary.
+10. **For desktop and capture issues, inspect the user session first.** Portals, PipeWire, user units, and Xwayland compatibility usually matter more than random reinstall churn.
+11. **For gaming issues, identify the GPU vendor, kernel lane, and userspace first.** Driver branch, Vulkan stack, multilib, Secure Boot, and launch wrappers usually explain more than tweak cargo cults.
+12. **Do not improvise major upgrades.** Fedora major jumps, RHEL `leapp`, and clone major-version moves require a documented path or a rebuild plan.
+13. **Reach for common RPM-family failure patterns before exotic explanations.** Repo drift, SELinux labeling mistakes, module stream confusion, akmods or DKMS drift, and kernel-lane mismatch explain a large share of the chaos.

--- a/skills/rhel-fedora/references/base-linux-and-cli.md
+++ b/skills/rhel-fedora/references/base-linux-and-cli.md
@@ -1,0 +1,24 @@
+# Base Linux and CLI
+
+Use this reference when the task is basic host inspection and you need the RPM-family-native tools.
+
+## Useful commands
+
+```bash
+cat /etc/os-release
+rpm -qa | wc -l
+rpm -q package_name
+rpm -qi package_name
+rpm -V package_name
+repoquery --whatprovides /path/to/file 2>&1 || true
+dnf repolist --enabled 2>&1 || true
+grubby --default-kernel 2>&1 || true
+restorecon -Rv /path 2>&1 || true
+semanage fcontext -l 2>&1 | head -40 || true
+```
+
+## Notes
+
+- `rpm -V` is great when files disappeared or permissions look wrong.
+- `repoquery` beats guessing which package owns a capability.
+- `restorecon` fixes labels; it does not change policy.

--- a/skills/rhel-fedora/references/boot-kernel-and-recovery.md
+++ b/skills/rhel-fedora/references/boot-kernel-and-recovery.md
@@ -1,0 +1,50 @@
+# Boot, Kernel, and Recovery
+
+Use this reference for GRUB, EFI, kernel installs, `dracut`, `grubby`, Secure Boot, and broken
+post-update boots.
+
+## Gather boot facts first
+
+```bash
+findmnt /boot
+findmnt /boot/efi
+lsblk -f
+grubby --default-kernel 2>&1 || true
+grubby --info=ALL 2>&1 || true
+rpm -qa | grep '^kernel' | sort
+dracut --version 2>&1 || true
+mokutil --sb-state 2>&1 || true
+```
+
+## Principles
+
+- Kernel package, initramfs, bootloader entry, and Secure Boot state are one subsystem.
+- Keep at least one known-good kernel entry until the new path is verified.
+- On Oracle Linux, confirm UEK vs RHCK before rebuilding or pruning kernels.
+- On cloud images, bootloader assumptions may differ from full-metal installs.
+
+## Rebuild flow
+
+Only rebuild after mountpoints and target kernel are known.
+
+```bash
+uname -r
+rpm -qa | grep '^kernel' | sort
+TARGET_KVER='set-the-kernel-version-you-actually-need'
+dracut -f --kver "$TARGET_KVER" 2>&1 || true
+grubby --default-kernel 2>&1 || true
+```
+
+If the issue is a newly installed kernel, inspect all entries before setting defaults.
+
+## Recovery stance
+
+- Prefer booting the previous kernel before editing blind.
+- From rescue media, mount root and EFI correctly before chrooting.
+- Verify the initramfs and boot entry for the exact kernel you expect.
+- Do not erase older kernels until the new one actually boots.
+
+## Secure Boot note
+
+NVIDIA, akmods, DKMS, and custom modules often fail at Secure Boot boundaries. Check signing and
+MOK state before blaming the GPU stack itself.

--- a/skills/rhel-fedora/references/capture-and-sharing.md
+++ b/skills/rhel-fedora/references/capture-and-sharing.md
@@ -1,0 +1,20 @@
+# Capture and Sharing
+
+Use this reference for OBS, browser WebRTC, Discord or Teams, screen sharing, hardware encoding,
+and virtual cameras.
+
+## Gather facts
+
+```bash
+systemctl --user status xdg-desktop-portal pipewire wireplumber 2>&1 || true
+journalctl --user -b | grep -Ei 'portal|pipewire|webrtc|obs' 2>&1 || true
+rpm -qa | grep -Ei 'obs|portal|pipewire|v4l2loopback|ffmpeg' | sort
+lsmod | grep '^v4l2loopback' 2>&1 || true
+```
+
+## Patterns
+
+- Wayland screen sharing is usually portal + PipeWire + client support.
+- X11 capture issues are different from Wayland screencast issues.
+- Virtual camera failures often come from kernel-module drift after updates.
+- Hardware encoding failures may be driver, firmware, or SELinux path issues.

--- a/skills/rhel-fedora/references/derivatives-and-vendor-quirks.md
+++ b/skills/rhel-fedora/references/derivatives-and-vendor-quirks.md
@@ -1,0 +1,48 @@
+# Derivatives and Vendor Quirks
+
+Use this reference when the distro family matters more than the package name.
+
+## Fedora
+
+- fast-moving
+- short support window
+- COPR and third-party repos are common
+- release bumps often expose repo lag first
+
+## CentOS Stream
+
+- sits ahead of the next RHEL point release
+- useful for previewing enterprise changes
+- not a drop-in mental model for supported RHEL production guidance
+
+## RHEL
+
+- support tooling and entitlement matter
+- package absence often means repo access or subscription issues
+- major-version upgrades should follow Red Hat's documented path, usually `leapp`
+
+## Rocky Linux and AlmaLinux
+
+- close to RHEL in package shape
+- do not rely on RHEL subscription-manager guidance
+- minor versions rotate into vault / archival paths as new ones land
+- EPEL is common, but still a deliberate support-boundary choice
+
+## Oracle Linux
+
+- check RHCK vs UEK immediately
+- UEK can change driver, storage, container, and support assumptions
+- Oracle docs can differ from generic RHEL advice even when package names look familiar
+
+## Amazon Linux 2023
+
+- AWS-shaped distro, not generic clone behavior
+- cloud-init and image defaults matter a lot
+- package naming and repo expectations can differ from RHEL examples
+- separate AL2023 from old Amazon Linux 2 advice before doing anything else
+
+## Rule of thumb
+
+If the distro is not clearly one of the lanes above, read `/etc/os-release`, check the enabled
+repos, and identify whether the vendor expects Fedora-style speed, RHEL-style support policy, or
+something cloud-specific before prescribing a fix.

--- a/skills/rhel-fedora/references/desktop-audio-and-bluetooth.md
+++ b/skills/rhel-fedora/references/desktop-audio-and-bluetooth.md
@@ -1,0 +1,28 @@
+# Desktop, Audio, and Bluetooth
+
+Use this reference for Fedora Workstation, KDE Spin, or similar desktop issues involving Wayland,
+X11, PipeWire, portals, and Bluetooth routing.
+
+## First-pass commands
+
+```bash
+echo "Session=$XDG_SESSION_TYPE Desktop=$XDG_CURRENT_DESKTOP"
+loginctl list-sessions 2>&1 || true
+systemctl --user --failed 2>&1 || true
+systemctl --user status pipewire pipewire-pulse wireplumber xdg-desktop-portal 2>&1 || true
+wpctl status 2>&1 || true
+bluetoothctl show 2>&1 || true
+```
+
+## Notes
+
+- GNOME on Fedora usually assumes Wayland first.
+- KDE can flip between Wayland and X11 depending on driver quality.
+- PipeWire and WirePlumber are usually the modern baseline.
+- Portal mismatches break screen sharing more often than the app itself.
+- Bluetooth audio issues often need card-profile inspection, not just pairing.
+
+## SELinux reminder
+
+Desktop weirdness from portals, screen sharing, or custom paths can still be SELinux-related.
+Check AVCs before disabling half the session.

--- a/skills/rhel-fedora/references/gotchas-and-special-situations.md
+++ b/skills/rhel-fedora/references/gotchas-and-special-situations.md
@@ -1,0 +1,24 @@
+# Gotchas and Special Situations
+
+Use this reference when the straightforward path failed and the system still looks cursed.
+
+## Common RPM-family traps
+
+- third-party repo drift after a Fedora release bump
+- package not found because CRB / CodeReady Builder / EPEL assumptions are wrong
+- SELinux label drift after manual file moves or custom data paths
+- runtime `firewalld` fix never made permanent
+- Oracle Linux issue caused by UEK assumptions
+- Amazon Linux issue caused by treating AL2023 like generic RHEL 9
+- module stream mismatch causing solver chaos
+- akmods or DKMS drift after a kernel update
+- Secure Boot blocking third-party kernel modules
+- cloud image missing tools that a full install would have
+
+## What to do next
+
+1. simplify the problem to one layer
+2. verify distro lane and repo provenance again
+3. verify SELinux and firewall state again
+4. compare current kernel path to the last known-good path
+5. remove one extra moving part at a time

--- a/skills/rhel-fedora/references/graphics-and-gaming.md
+++ b/skills/rhel-fedora/references/graphics-and-gaming.md
@@ -1,0 +1,22 @@
+# Graphics and Gaming
+
+Use this reference for NVIDIA, AMD, Intel, Vulkan, Steam, Proton, Gamescope, MangoHud, and driver
+or kernel-lane mismatches.
+
+## First-pass commands
+
+```bash
+lspci -k | grep -Ei 'vga|3d|display'
+lsmod | grep -E 'nvidia|amdgpu|i915|xe' 2>&1 || true
+journalctl -b | grep -Ei 'nvrm|nvidia|amdgpu|i915|xe|drm' 2>&1 || true
+vulkaninfo --summary 2>&1 || true
+rpm -qa | grep -Ei 'mesa|nvidia|akmod|kmod|vulkan|steam|gamescope|mangohud' | sort
+```
+
+## Notes
+
+- Fedora NVIDIA and gaming setups often hinge on RPM Fusion state, akmods, Secure Boot, and matching kernel headers.
+- Enterprise clones may use DKMS or vendor repos instead of Fedora-style akmods.
+- Oracle UEK vs RHCK can change out-of-tree module behavior.
+- Steam and Proton still need 32-bit userspace on many setups.
+- Gamescope and MangoHud are useful tests, but also extra moving parts.

--- a/skills/rhel-fedora/references/packages-and-repos.md
+++ b/skills/rhel-fedora/references/packages-and-repos.md
@@ -1,0 +1,88 @@
+# Packages and Repos
+
+Use this reference when the problem is package state, repo config, package provenance, module
+streams, local RPMs, or third-party repo drift.
+
+## Gather package facts first
+
+```bash
+dnf --version 2>&1 || yum --version 2>&1 || true
+dnf repolist --enabled 2>&1 || yum repolist enabled 2>&1 || true
+dnf repoquery package_name 2>&1 || true
+dnf info package_name 2>&1 || true
+dnf module list --enabled 2>&1 || true
+rpm -q package_name
+rpm -qi package_name
+rpm -V package_name
+rpm -qa | sort | head -50
+```
+
+## Package principles
+
+- Prefer distro repos first, then vendor repos, then EPEL or COPR, then manual RPMs.
+- A local `.rpm` install is not proof that the repo state is healthy.
+- `rpm -Uvh` bypasses DNF's dependency planning. Use it only when you know why.
+- On RHEL, package absence often means the right repo is not enabled.
+- On Fedora, package weirdness often means third-party repo lag after a release bump.
+
+## Repo sanity checks
+
+```bash
+grep -R "^\[\|^enabled=\|^baseurl=\|^metalink=" /etc/yum.repos.d/ 2>&1 || true
+dnf repolist all 2>&1 || true
+dnf config-manager --dump 2>&1 || true
+subscription-manager repos --list-enabled 2>&1 || true
+```
+
+Check for:
+- duplicate vendor repos
+- dead mirrorlists or metalinks
+- release RPMs left behind from old versions
+- CRB / CodeReady Builder / PowerTools mismatch
+- EPEL installed where the base distro or support policy does not want it
+
+## Modules and AppStream
+
+Module streams are a classic source of weird package solver behavior.
+
+```bash
+dnf module list package_name 2>&1 || true
+dnf module info package_name:stream 2>&1 || true
+dnf module reset package_name 2>&1 || true
+```
+
+Rules:
+- verify whether a module is actually in play before resetting anything
+- document the active stream before changing it
+- be careful with PostgreSQL, Node.js, PHP, and container tools on older enterprise lanes
+
+## Local RPM handling
+
+Preferred order:
+1. inspect the package
+2. verify signature, signing-key fingerprint, and origin before trusting it
+3. install with DNF so dependencies are resolved
+
+```bash
+rpm -qpR ./package.rpm
+rpm -qpi ./package.rpm
+rpm -K ./package.rpm
+rpm -qi gpg-pubkey-* 2>&1 || true
+dnf install ./package.rpm 2>&1 || true
+```
+
+For third-party release RPMs and repo keys, verify the key fingerprint and source before importing or trusting the repo. `rpm -K` tells you a package is signed, not that the signer is the one you intended to trust.
+
+## Fedora-specific notes
+
+- COPR is convenient, not neutral. Treat it like a trust boundary.
+- Fedora multimedia, Steam, and proprietary-driver work often depends on RPM Fusion state; verify it before debugging package availability or akmods.
+- `updates-testing` is for targeted use, not for permanent random enablement.
+- Release upgrades often expose lagging third-party repos first.
+
+## Enterprise-lane notes
+
+- RHEL may need `subscription-manager` plus CRB enablement before package names make sense.
+- Rocky and Alma often pair with EPEL, but package advice still needs repo provenance.
+- Oracle Linux may provide the package under a different repo or kernel lane expectation.
+- Amazon Linux is its own packaging lane. Avoid blind copy-paste from generic RHEL docs.

--- a/skills/rhel-fedora/references/remote-gaming-input-and-tooling.md
+++ b/skills/rhel-fedora/references/remote-gaming-input-and-tooling.md
@@ -1,0 +1,10 @@
+# Remote Gaming, Input, and Tooling
+
+Use this reference for Moonlight, Sunshine, Steam Remote Play, controllers, and odd input-device
+behavior on RPM-family systems.
+
+## Notes
+
+- Sunshine often intersects with SELinux, firewalld, and GPU encoding support.
+- Controller failures are often udev, Bluetooth profile, Steam input, or kernel-module issues.
+- Remote streaming problems can be host-capture problems disguised as network problems.

--- a/skills/rhel-fedora/references/security-and-updates.md
+++ b/skills/rhel-fedora/references/security-and-updates.md
@@ -1,0 +1,35 @@
+# Security and Updates
+
+Use this reference for SELinux, firewalld, package signing, update cadence, FIPS-adjacent checks,
+and other security-sensitive default behavior.
+
+## SELinux first-pass
+
+```bash
+getenforce
+sestatus
+ausearch -m avc -ts recent 2>&1 || true
+semanage boolean -l 2>&1 | head -40 || true
+```
+
+## firewalld first-pass
+
+```bash
+firewall-cmd --get-active-zones 2>&1 || true
+firewall-cmd --list-all 2>&1 || true
+firewall-cmd --list-all-zones 2>&1 || true
+```
+
+## Update principles
+
+- Fedora updates move fast. Third-party repos lag.
+- RHEL-family updates are slower but shaped by support policy and repo enablement.
+- Package signing failures are evidence. Do not bypass them casually. Do not recommend `--nogpgcheck`, `gpgcheck=0`, or `repo_gpgcheck=0` except in a tightly scoped emergency diagnostic with an explicit risk callout and rollback plan.
+- FIPS or compliance-sensitive hosts need extra caution around crypto, kernels, and unsupported repos.
+
+## SELinux rules of thumb
+
+- relabel when labels are wrong
+- use booleans when the policy already models the intended behavior
+- generate custom policy only after you understand the denial
+- `setenforce 0` is for temporary diagnosis, not a permanent fix

--- a/skills/rhel-fedora/references/session-display-and-mobile.md
+++ b/skills/rhel-fedora/references/session-display-and-mobile.md
@@ -1,0 +1,21 @@
+# Session, Display, and Mobile
+
+Use this reference for display managers, session startup, suspend or resume, power profiles, and
+hybrid graphics on laptops.
+
+## Gather facts
+
+```bash
+systemctl status display-manager 2>&1 || true
+loginctl session-status 2>&1 || true
+systemctl --user show-environment 2>&1 || true
+systemctl status power-profiles-daemon 2>&1 || true
+journalctl -b | grep -Ei 'suspend|resume|sleep|acpi|battery|nvidia|amdgpu' 2>&1 || true
+```
+
+## Patterns
+
+- GDM and SDDM failures are separate from compositor failures.
+- Resume failures are often GPU, lock-screen, or firmware interactions.
+- Power-profile changes can affect hybrid graphics and suspend behavior.
+- Session env problems break portals, keyrings, and user services in weird ways.

--- a/skills/rhel-fedora/references/storage-and-rollback.md
+++ b/skills/rhel-fedora/references/storage-and-rollback.md
@@ -1,0 +1,23 @@
+# Storage and Rollback
+
+Use this reference for XFS, ext4, Btrfs, LUKS, LVM, Stratis, TRIM, hibernation, and rollback
+boundaries.
+
+## Gather facts
+
+```bash
+lsblk -f
+findmnt -t xfs,ext4,btrfs
+pvs 2>&1 || true
+vgs 2>&1 || true
+lvs 2>&1 || true
+cryptsetup status luks-root 2>&1 || true
+systemctl status fstrim.timer 2>&1 || true
+```
+
+## Notes
+
+- XFS is common on enterprise installs. It is not Btrfs; rollback assumptions differ.
+- LVM and LUKS layering matters for hibernation and recovery.
+- Stratis is its own management layer. Do not improvise Btrfs advice onto it.
+- Snapshot presence is not backup presence.

--- a/skills/rhel-fedora/references/systemd-and-journal.md
+++ b/skills/rhel-fedora/references/systemd-and-journal.md
@@ -1,0 +1,61 @@
+# systemd and Journal
+
+Use this reference for service startup failures, timer issues, journal triage, overrides, or
+user-session service problems.
+
+## First-pass commands
+
+```bash
+systemctl --failed
+systemctl status unit_name
+journalctl -u unit_name -b
+journalctl -b -p warning..alert
+systemctl list-timers --all
+systemctl cat unit_name
+systemctl show unit_name | grep -E 'FragmentPath|DropInPaths|Environment='
+```
+
+For desktop and Wayland problems, add:
+
+```bash
+systemctl --user --failed
+journalctl --user -b
+systemctl --user status pipewire wireplumber xdg-desktop-portal
+```
+
+## Read the unit before editing
+
+Check the shipped unit and every override before making claims:
+
+```bash
+systemctl cat unit_name
+find /etc/systemd /usr/lib/systemd /run/systemd -type f | grep unit_name 2>&1 || true
+```
+
+## Safe override flow
+
+Use drop-ins for environment or small exec changes. Do not patch vendor units casually.
+
+```bash
+systemctl edit unit_name
+systemctl daemon-reload
+systemctl restart unit_name
+systemctl status unit_name
+```
+
+## Common RPM-family traps
+
+- Service exists but package is missing files: `rpm -V package_name`
+- Service starts manually but not under systemd: environment, permissions, SELinux, or sandboxing
+- Service bound to port but unreachable: `firewalld`, SELinux labels, or wrong bind address
+- Desktop service weirdness: the problem is under `systemctl --user`, not system scope
+- Repeated restarts after update: old config or changed defaults, not always "systemd is broken"
+
+## Journal reading heuristics
+
+- `journalctl -u unit -b` for the focused story
+- `journalctl -b` for cross-unit correlation
+- `journalctl --user -b` for desktop and session problems
+- `-p warning..alert` trims noise fast
+
+When SELinux is involved, correlate the journal with AVC output instead of guessing.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -182,6 +182,11 @@ Run through the AI Self-Check above. Then:
    any that share >50% of trigger keywords.
 3. **Convention check**: compare frontmatter, structure, and style against 2-3 existing custom
    skills in the same `effort` tier.
+4. **Script-runner reality check**: if the collection uses helper scripts like `lint-skills.sh`
+   or `validate-spec.sh`, verify their expected input shape before trusting the result. Some
+   collections expect a parent directory containing many skill subdirectories, not a direct path
+   to one skill. For single-skill validation, stage the skill inside a temporary parent such as
+   `<tmp>/skills/<skill-name>/SKILL.md` and run the scripts against `<tmp>/skills`.
 
 #### Step 5: Write the files
 
@@ -189,6 +194,10 @@ Run through the AI Self-Check above. Then:
   inside a collection, or the user's specified path for standalone skills
 - Write reference files (if any) to `<skill-dir>/references/`
 - If a collection inventory exists, update it and re-run cross-reference checks
+- If `skill_manage` cannot modify the target because the skill lives in an external repo or
+  non-managed directory, fall back to direct file edits with `patch` or `write_file` on the
+  actual repo paths. Do not stop at the tool limitation if the files are writable and the user
+  asked for the change in-place.
 
 #### Step 6: Forward-test
 

--- a/skills/skill-creator/references/conventions.md
+++ b/skills/skill-creator/references/conventions.md
@@ -501,7 +501,7 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 
 ## 9. Skill Inventory (April 2026)
 
-### Published skills (28)
+### Published skills (30)
 
 | Skill | Effort | Date Added | Domain |
 |-------|--------|-----------|--------|
@@ -515,6 +515,7 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 | code-review | high | 2026-03-25 | Correctness audit |
 | command-prompt | medium | 2026-03-25 | Shell scripting and config |
 | databases | high | 2026-03-24 | Database operations |
+| debian-ubuntu | high | 2026-04-22 | Debian / Ubuntu administration |
 | docker | high | 2026-03-24 | Containers |
 | firewall-appliance | high | 2026-03-30 | OPNsense/pfSense firewall management |
 | full-review | high | 2026-03-22 | Orchestrator (4 parallel audits) |
@@ -524,6 +525,7 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 | mcp | high | 2026-03-30 | MCP server development |
 | networking | high | 2026-03-25 | DNS, reverse proxies, VPNs, nftables, HA |
 | prompt-generator | medium | 2026-03-25 | LLM prompt structuring |
+| rhel-fedora | high | 2026-04-22 | Fedora / RHEL-family administration |
 | roadmap | medium | 2026-04-05 | Gitignored roadmap management and competitor scouting |
 | security-audit | high | 2026-03-25 | Application security review |
 | skill-creator | high | 2026-03-25 | Skill lifecycle management |


### PR DESCRIPTION
## summary
- add the new `debian-ubuntu` admin skill and references
- add the new `rhel-fedora` admin skill and references
- update collection inventory and README entries
- patch `skill-creator` with the single-skill script validation gotcha we hit while building these

## validation
- `bash scripts/lint-skills.sh`
- `bash scripts/validate-spec.sh`
