### PR TITLE
feat(kali-linux): add Kali distro admin skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-**33 production-tested skills** - Kubernetes, Terraform, Docker, Ansible, CI/CD, HTTP APIs, databases, AI/ML, testing, virtualization, Arch Linux, networking, MCP servers, security audits, pentesting, code review, prose audits, dev workflow orchestration, and more.
+**36 production-tested skills** - Kubernetes, Terraform, Docker, Ansible, CI/CD, HTTP APIs, databases, AI/ML, testing, virtualization, Arch Linux, Debian-family, RPM-family, Kali Linux, networking, localization, browsing, MCP servers, security audits, pentesting, code review, prose audits, dev workflow orchestration, and more.
 
 Built on the [Agent Skills open standard](https://agentskills.io/specification). Works with any tool that supports it.
 
@@ -69,7 +69,7 @@ The loop: **Score -> Improve -> Verify -> Keep or Revert -> Repeat.**
 
 ## What's in the box
 
-31 production-tested skills covering:
+36 production-tested skills covering:
 
 ### Infrastructure & Operations
 
@@ -79,6 +79,7 @@ The loop: **Score -> Improve -> Verify -> Keep or Revert -> Repeat.**
 | **arch-btw** | Arch Linux and CachyOS administration - pacman, paru, AUR, systemd, bootloader and kernel recovery |
 | **debian-ubuntu** | Debian and Debian-family administration - apt, dpkg, PPAs, snaps, systemd, GRUB, AppArmor, HWE, and distro-specific quirks |
 | **rhel-fedora** | Fedora and RHEL-family administration - dnf, yum, SELinux, firewalld, dracut, subscription-manager, and clone-specific quirks |
+| **kali-linux** | Kali Linux administration - branches, metapackages, live USB persistence, offensive tool families, NetHunter, and lab-safe distro workflow |
 | **docker** | Dockerfiles, Compose, Podman, Buildah, multi-stage builds, image signing, container hardening |
 | **kubernetes** | Manifests, Helm charts, Gateway API, Kustomize, ArgoCD, sealed secrets, PCI-DSS compliance |
 | **terraform** | Terraform/OpenTofu - HCL patterns, module design, state management, policy-as-code, compliance |
@@ -110,16 +111,20 @@ The loop: **Score -> Improve -> Verify -> Keep or Revert -> Repeat.**
 | **anti-ai-prose** | Audits writing for AI tells - vocabulary (delve, tapestry), syntax (negative parallelism, tricolons), tone (travel-guide voice, vague attribution), formatting (em-dash abuse). Covers docs, READMEs, wikis, PRs, emails, slides, creative writing |
 | **backend-api** | HTTP backend APIs - FastAPI, Express, NestJS, REST/OpenAPI contracts, auth flows, versioning, pagination, idempotency |
 | **testing** | Unit, integration, E2E, accessibility, and performance tests - Vitest, Jest, Playwright, pytest, Go testing, cargo test, TDD workflows, mocking strategies, CI test infrastructure |
+| **localize** | App localization and i18n audits - find hardcoded strings, translation flow gaps, locale fallback issues, and framework-specific i18n mistakes |
+| **dev-cycle** | Start-to-finish dev workflow - pull, branch, size changes, test, review, and prep work for clean implementation cycles |
 | **git** | Commits, branches, hooks, signing, multi-forge workflows (GitHub, GitLab, Forgejo), release management |
 | **command-prompt** | Shell scripting across zsh, bash, POSIX sh, fish, nushell - dotfiles, completions, one-liners |
 | **mcp** | MCP server development - protocol patterns, transport, auth, input validation, injection prevention |
 | **ai-ml** | LLM integrations, RAG pipelines, agent systems, embeddings, evaluation harnesses, local inference, fine-tuning, structured output, tool use, cost optimization, safety guardrails |
 | **full-review** | Orchestrates code-review + anti-slop + security-audit + update-docs in one pass |
+| **deep-audit** | Five-wave repo audit - recon, code quality, domain skills, sequential security, and docs or git hygiene in one structured pass |
 
 ### Tooling & Meta
 
 | Skill | What it does |
 |-------|-------------|
+| **browse** | Token-efficient web browsing and scraping - lightweight extraction, focused page reads, and link-following without full browser overhead |
 | **prompt-generator** | Turn scattered ideas into structured LLM prompts - system prompts, templates, prompt engineering |
 | **roadmap** | Keep a gitignored `ROADMAP.md` current - capture ideas, shipped work, priorities, and competitor signals |
 | **routine-writer** | Write Claude Code routine prompts - self-contained tasks that run unattended on Anthropic cloud via schedule, API, or GitHub triggers. Emits `/schedule` CLI commands and `/fire` curl templates |

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -68,7 +68,7 @@ stale package-version table.
 - RPM-family distros and tooling - use **rhel-fedora**. That includes RHEL, Fedora, Rocky, AlmaLinux, Oracle Linux, and Amazon Linux.
 - Ubuntu Core and snap-only transactional workflows - outside this skill; do not treat them like ordinary apt-managed Ubuntu hosts
 - NixOS or declarative system management - outside this skill; route to a dedicated NixOS skill when one exists
-- Kali offensive tooling, pentest workflow, or training-image specifics - outside this skill; route to a dedicated Kali skill when one exists
+- Kali offensive tooling, pentest workflow, or training-image specifics - use **kali-linux**
 - OPNsense or pfSense appliance work - use **firewall-appliance**
 
 ---
@@ -116,7 +116,7 @@ Before returning Debian or Ubuntu commands, verify:
 | **Linux Mint** | Ubuntu LTS derivative | Cinnamon/XFCE focus. Mint-specific repos and update manager. PPAs from Ubuntu often work. |
 | **Pop!_OS** | Ubuntu derivative with extras | System76 firmware, COSMIC desktop, Pop repos, `system76-power`. NVIDIA ISO available. |
 | **Devuan** | Debian derivative with a major service-model split | Do not assume systemd, `systemctl`, or Ubuntu-style desktop/session plumbing. Verify init and service tooling first. |
-| **Kali** | Debian-derived security distro | Fine for base apt, kernel, boot, or service administration, but not for offensive tooling, training images, or pentest workflow assumptions. A dedicated Kali skill should handle that later. |
+| **Kali** | Debian-derived security distro | Fine for base apt, kernel, boot, or service administration, but use **kali-linux** for Kali-specific branches, images, metapackages, training-image workflow, and offensive-distro context. |
 | **Other Debian-based** | Confirm repo model | Do not assume vanilla Debian or Ubuntu behavior. |
 
 ### Step 2: Gather current system state

--- a/skills/debian-ubuntu/references/derivatives-and-hwe.md
+++ b/skills/debian-ubuntu/references/derivatives-and-hwe.md
@@ -61,7 +61,7 @@ Debian-derived distro specifics that materially change package, boot, or service
 
 ### Kali
 - Kali is Debian-derived, so apt, dpkg, boot, and kernel basics can still fit this skill.
-- Do not treat Kali like a generic desktop or server distro when the question is really about offensive tooling, lab images, or pentest workflow. That should move to a dedicated Kali skill later.
+- Do not treat Kali like a generic desktop or server distro when the question is really about offensive tooling, lab images, branch-specific behavior, or pentest workflow. Route those cases to **kali-linux**.
 - Be conservative with desktop and hardening assumptions because Kali images, package sets, and intended use differ from stock Debian.
 
 ### Other Debian-based distros

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: kali-linux
+description: >
+  · Administer Kali Linux as a Debian-derived security distro - apt, branches,
+  metapackages, images, live USB persistence, ARM and Purple images, NetHunter,
+  wireless, GPU, and lab hygiene. Triggers: 'kali', 'kali rolling',
+  'kali snapshot', 'kali-tweaks', 'nethunter', 'kali tools',
+  'kali metapackage', 'kali live usb', 'kali arm'. Not for generic Debian hosts
+  (**debian-ubuntu**), exploitation (**lockpick**), vulnerability research
+  (**zero-day**), or defensive review (**security-audit**).
+license: MIT
+compatibility: Requires Kali Linux or Kali images with apt and Kali repositories
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-04-22"
+  effort: high
+  argument_hint: "[issue-or-workflow]"
+---
+
+# Kali Linux: Kali Administration, Tooling, and Lab Workflow
+
+Administer Kali Linux without flattening it into plain Debian or into a bag of offensive tools.
+Start by identifying which Kali lane you are actually on - rolling install, last-snapshot,
+live USB, VM image, Purple image, NetHunter, or a throwaway lab box - then separate base OS
+health from tool-selection questions, branch hygiene, hardware support, and engagement scope.
+Kali is Debian-shaped, but the places where it goes wrong are usually Kali-specific: branch
+mixing, metapackage sprawl, stale images, persistence mistakes, hardware edge cases, or people
+using the wrong tool family for the job.
+
+**Versions worth pinning** (verified April 2026):
+
+Only pin versions or dated anchors here when they materially affect compatibility or
+troubleshooting shape. For ordinary package work, prefer the live branch and repo state over a
+stale package table.
+
+| Component | Version or date | Why it matters |
+|-----------|-----------------|----------------|
+| **Current dated Kali image release** | 2026.1 | current image baseline and release notes |
+| Branch docs | 2026-04 / verify live | branch behavior and safe lane selection matter more than a single package version |
+| Metapackage docs | 2025-07 / verify live | tool-family grouping and install scope matter more than memorizing one package list |
+| Kali 2026.1 kernel lane | 6.18 | release-image baseline for hardware and driver expectations |
+
+## When to use
+
+- Package management on Kali with `apt`, `dpkg`, `apt-cache`, repo sanity checks, keyrings, or branch validation
+- Kali image and install questions: live ISO, netinst, ARM and SBC images, VM images, persistence, and recovery
+- Kali branch and source-list questions: `kali-rolling`, `kali-last-snapshot`, selective branch use, and mirror hygiene
+- Metapackage planning: `kali-linux-default`, `kali-linux-everything`, focused `kali-tools-*` bundles, desktop metapackages, and `kali-tweaks`
+- Selecting the right Kali tool family for the job before installing half the archive by accident
+- Kali desktop and laptop work: Xfce, GNOME, KDE, i3, PipeWire, GPU drivers, capture tooling, and VM guest behavior
+- Wireless, SDR, Bluetooth, RFID, HID, USB, and offensive-hardware support that is really a Kali host or package problem
+- NetHunter and mobile-adjacent Kali questions where the issue is image, package, kernel, or host-tooling shape rather than exploit technique
+- Safe lab setup, intentionally vulnerable practice targets, snapshot workflow, and separation between lab and production systems
+- Base Linux ops on Kali when the Kali-specific repo, branch, image, or tool context matters more than generic Debian advice
+
+## When NOT to use
+
+- Generic Debian, Ubuntu, Mint, or Pop!_OS administration without Kali-specific context - use **debian-ubuntu**
+- Shell syntax, quoting, or script portability - use **command-prompt**
+- Network architecture, DNS, VPNs, reverse proxies, or firewall design - use **networking**
+- Docker, Podman, image builds, or container runtime issues - use **docker**
+- Hypervisor configuration, passthrough wiring, or VM platform issues where the fault is clearly outside the Kali guest - use **virtualization**
+- Kubernetes cluster or manifest work - use **kubernetes**
+- Fleet-wide Linux configuration via playbooks - use **ansible**
+- Exploitation, privilege escalation, lateral movement, or post-exploitation on live targets - use **lockpick**
+- Novel vulnerability hunting, reverse engineering depth work, fuzzing, or proof-of-concept research - use **zero-day**
+- Defensive hardening, vuln triage, or broad security review - use **security-audit**
+- OPNsense or pfSense appliance work - use **firewall-appliance**
+
+---
+
+## AI Self-Check
+
+Before returning Kali commands or tool recommendations, verify:
+
+- [ ] **Kali lane identified**: rolling install, last-snapshot, live USB, VM image, Purple image, NetHunter, or a custom lab box. Advice diverges fast.
+- [ ] **Not flattened into plain Debian**: do not give generic Debian advice without checking Kali branches, metapackages, and package origin first.
+- [ ] **Branch model understood**: `kali-rolling` vs `kali-last-snapshot` vs partial or development branches such as `kali-experimental`, `kali-bleeding-edge`, and `kali-dev`. Do not mix them casually.
+- [ ] **Repo state is clean**: no blind Debian repo additions, no stale image assumptions, no broken `kali-archive-keyring`, and no contradictory source lists.
+- [ ] **Upgrade path is coherent**: prefer `apt update` plus `apt full-upgrade` on Kali when package transitions matter. Do not cargo-cult `apt upgrade` and call it done.
+- [ ] **Image mode identified**: installed system, live media, persistence-backed live media, VM image, or mobile image. Recovery steps differ.
+- [ ] **Metapackage scope is intentional**: do not suggest `kali-linux-everything` when a focused `kali-tools-*` bundle is the sane answer.
+- [ ] **Tool family matches the task**: information gathering, vulnerability assessment, web, passwords, wireless, reverse engineering, exploitation, post-exploitation, forensics, reporting, or labs.
+- [ ] **Authorization boundary respected**: Kali tool recommendations still require authorized scope. A tool index is not permission.
+- [ ] **Lab packages are treated as intentionally vulnerable**: `kali-linux-labs` exists for controlled practice, not for everyday workstation installs.
+- [ ] **Wireless and hardware path is real**: chipset, firmware, monitor mode, injection support, SDR stack, USB passthrough, and kernel modules match the actual hardware.
+- [ ] **GPU and capture stack is coherent**: VM passthrough, host acceleration, PipeWire, browser capture, and desktop session line up before blaming the tool.
+- [ ] **NetHunter is not treated like normal desktop Kali**: mobile kernels, Android host constraints, rootless vs full chroot shape, and missing systemd-style tooling can change which checks even make sense.
+- [ ] **Correct handoff chosen**: once the question becomes exploitation methodology, route to **lockpick**. Once it becomes original vulnerability discovery, route to **zero-day**.
+- [ ] **Diagnostic errors are not silenced**: do not hide useful failure output with `2>/dev/null` on commands whose error reason matters. Use `2>&1 || true` when gathering.
+
+---
+
+## Workflow
+
+### Step 1: Identify the Kali lane first
+
+| Lane | Default stance | What changes |
+|------|----------------|--------------|
+| **Installed Kali rolling** | default for most users | continuous updates, package drift matters, repo hygiene is everything |
+| **Kali last-snapshot** | safer, more frozen lane | release-like behavior between versioned snapshots |
+| **Live ISO / live USB** | treat as ephemeral first | persistence, overlay state, and storage layout change recovery |
+| **VM image** | check guest tooling and hypervisor assumptions | shared clipboard, display, USB passthrough, and virtual NIC quirks matter |
+| **ARM / SBC image** | check board-specific image assumptions first | boot firmware, storage media, peripherals, and package expectations differ from amd64 installs |
+| **Kali Purple image** | security distro with blue-team flavor | package mix and image choice differ from a standard red-team workstation |
+| **NetHunter** | mobile and kernel-sensitive | Android host, custom kernels, HID, and wireless support change the answer |
+| **Partial or development branch user** | slow down immediately | `kali-experimental`, `kali-bleeding-edge`, and `kali-dev` are not casual defaults |
+
+### Step 2: Gather current system state
+
+Start narrow, then widen only if the failing layer is still unclear.
+
+Baseline checks for every Kali case:
+
+```bash
+cat /etc/os-release
+uname -r
+grep -Rhv '^#\|^$' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>&1 || true
+apt-cache policy 2>&1 || true
+apt-cache policy kali-archive-keyring kali-defaults kali-linux-core kali-linux-default 2>&1 || true
+apt list --upgradable 2>&1 | tail -n +2
+findmnt /
+lsblk -f
+dpkg -l | grep '^ii  kali-' | head -40
+```
+
+Add subsystem probes only when the task needs them. On NetHunter or other mobile-adjacent
+environments, skip desktop or systemd-specific probes that do not exist there.
+
+```bash
+# services and logs
+ps -p 1 -o comm=
+command -v systemctl >/dev/null 2>&1 && systemctl --failed 2>&1 || true
+command -v journalctl >/dev/null 2>&1 && journalctl -b -p warning..alert 2>&1 || true
+
+# boot and storage
+findmnt /boot 2>&1 || true
+findmnt /boot/efi 2>&1 || true
+
+# desktop and capture path
+echo "Session=$XDG_SESSION_TYPE Desktop=$XDG_CURRENT_DESKTOP"
+loginctl list-sessions 2>&1 || true
+systemctl status display-manager 2>&1 || true
+systemctl --user --failed 2>&1 || true
+systemctl --user status pipewire pipewire-pulse wireplumber xdg-desktop-portal 2>&1 || true
+command -v wpctl >/dev/null 2>&1 && wpctl status
+
+# hardware, wireless, GPU, and NetHunter
+lspci -k | grep -Ei 'vga|3d|display|network|wireless'
+lsusb
+rfkill list 2>&1 || true
+iw dev 2>&1 || true
+journalctl -b | grep -Ei 'nvrm|nvidia|amdgpu|i915|xe|ath|iwlwifi|brcm|rtl|mt76|drm' 2>&1 || true
+command -v dkms >/dev/null 2>&1 && dkms status 2>&1 || true
+command -v airmon-ng >/dev/null 2>&1 && airmon-ng 2>&1 || true
+command -v nethunter >/dev/null 2>&1 && nethunter -h 2>&1 | head -20
+```
+
+### Step 3: Load only the relevant reference
+
+| Task type | Reference |
+|-----------|-----------|
+| apt, sources, keyrings, rolling vs snapshot, mirrors | `references/packages-branches-and-repos.md` |
+| choosing metapackages and understanding Kali tool families | `references/metapackages-and-tool-families.md` |
+| live USB, persistence, installers, VM images, recovery | `references/images-live-persistence-and-recovery.md` |
+| wireless, GPU, SDR, USB, Bluetooth, NetHunter, hardware support | `references/wireless-gpu-hardware-and-nethunter.md` |
+| scope discipline, vulnerable labs, snapshots, safe practice | `references/lab-safety-and-scope.md` |
+| recurring Kali breakage patterns and edge cases | `references/gotchas-and-special-situations.md` |
+
+Do not load every reference by default. Pick the one that matches the failure mode, then widen
+only if the first layer is clean.
+
+### Step 3.5: Stay here or hand off
+
+| Request shape | Route |
+|---------------|-------|
+| install, package, image, persistence, hardware, or tool-family selection on Kali | stay in **kali-linux** |
+| hypervisor config, USB passthrough, guest display acceleration, or VM platform wiring | use **virtualization** |
+| exploit, pivot, privilege escalate, or run post-exploitation workflow on an authorized target | use **lockpick** |
+| fuzz, reverse engineer deeply, hunt a novel bug, or build a PoC | use **zero-day** |
+| review the target code or service for defensive findings | use **security-audit** |
+| generic Debian-family host admin with no Kali-specific context | use **debian-ubuntu** |
+
+### Step 4: Change one layer at a time
+
+- Fix source lists and package state before debugging tools that may simply be missing or mismatched.
+- Fix image or persistence layout before declaring the live USB broken.
+- Fix desktop session and capture plumbing before blaming Burp, Wireshark, or browser tooling.
+- Fix hardware support and firmware before blaming monitor mode, injection, SDR, or Bluetooth tools.
+- Pick the smallest metapackage that matches the workflow instead of installing everything.
+- Keep labs and production separate. Prefer snapshots, throwaway VMs, and isolated USB media.
+
+### Step 5: Validate before closing
+
+```bash
+apt-cache policy package_name
+command -v systemctl >/dev/null 2>&1 && systemctl status unit_name 2>&1 || true
+journalctl -u unit_name -b 2>&1 || true
+dpkg -l | grep '^ii  kali-' | head -20
+command -v msfconsole 2>/dev/null || true
+command -v nmap 2>/dev/null || true
+command -v aircrack-ng 2>/dev/null || true
+```
+
+Reboot only when the boot path, persistence story, or kernel change is understood and at least
+one known-good recovery path remains.
+
+---
+
+## Troubleshooting Pattern
+
+Keep triage cross-layer and boring:
+
+1. Confirm the Kali lane, branch, image type, and repo state.
+2. Identify the failing layer: packages, image or persistence, desktop session, hardware, or tool selection.
+3. Pull the right logs before changing config.
+4. Change one layer at a time and retest.
+5. Keep scope and safety separate from tool installation.
+
+Core log sweep:
+
+```bash
+journalctl -b -p warning..alert
+journalctl --user -b
+dmesg --level=err,warn
+journalctl -u unit_name -b 2>&1 || true
+```
+
+Broad pattern sweeps when you need correlation, not first-pass precision:
+
+```bash
+journalctl -b | grep -Ei 'nvrm|nvidia|amdgpu|i915|xe|ath|iwlwifi|brcm|rtl|mt76|drm' 2>&1 || true
+journalctl --user -b | grep -Ei 'portal|pipewire|webrtc|burp|wireshark' 2>&1 || true
+```
+
+When the problem smells like "Kali is broken," check the boring causes first:
+
+- source-list drift or stale keyring
+- branch mixing
+- huge metapackage install on weak hardware
+- USB passthrough or monitor-mode expectations that the chipset cannot satisfy
+- live USB persistence corruption
+- VM guest additions and display stack mismatch
+
+---
+
+## Default Decisions
+
+- **Kali means branch hygiene first.** The repo state explains more failures than exotic package folklore.
+- **Prefer `kali-rolling` unless there is a clear reason not to.** It is the main branch most users should be on.
+- **Use `kali-last-snapshot` when the user wants calmer release-like behavior.** Do not enable it beside `kali-rolling` just because more sounds better.
+- **Prefer focused metapackages.** `kali-tools-*` bundles beat `kali-linux-everything` unless the box truly exists to be a giant toolbox.
+- **Treat Kali as a workflow distro, not just a package repo.** Image choice, persistence, hardware, and scope matter as much as package names.
+- **Stay package-focused when the ask is package-focused.** Installing `nuclei`, `burpsuite`, `hashcat`, or reversing tools stays here until the question turns into defensive review, offensive workflow, or novel vulnerability research.
+- **Labs should be disposable.** Snapshots, throwaway VMs, and isolated media beat hand-maintaining a single sacred pentest laptop forever.
+- **Tool families come before individual tool bikeshedding.** Pick the category, then the tool, then the package.
+- **Wireless and SDR work are hardware stories first.** Chipset support, firmware, passthrough, power, and monitor-mode reality matter more than menu entries.
+- **Route offensive depth correctly.** Kali can install the tools, but **lockpick** owns exploitation workflow and **zero-day** owns novel bug discovery.
+
+---
+
+## Quick Triage Checklist
+
+| Symptom | First checks |
+|---------|-------------|
+| `apt` weirdness after install | source lists, `apt-cache policy`, keyring package, branch mixing, `apt full-upgrade` pending |
+| Tool missing even though metapackage was installed | `dpkg -l`, `apt-cache depends`, command path, package split, transitional package |
+| Live USB lost changes | persistence partition, mount state, overlay corruption, wrong image mode |
+| VM feels broken or blind to USB gear | hypervisor guest tools, USB passthrough, network mode, display acceleration |
+| Wireless tools do not see monitor mode or injection | chipset support, firmware, rfkill, USB power, passthrough, kernel module |
+| SDR or hardware tools misbehave | package state, udev access, kernel modules, USB permissions, device firmware |
+| Burp or browser capture feels broken | desktop session, CA import, proxy binding, PipeWire or portal path for GUI helpers |
+| NetHunter issue | Android version, kernel support, image flavor, HID and wireless support, mobile package lane |
+| System is huge and slow | metapackage sprawl, desktop choice, background services, `kali-linux-everything` regret |
+| Nothing makes sense | check gotchas reference - branch mixing, stale keyring, persistence drift, VM passthrough mistakes, and unsupported Wi-Fi chipsets explain a lot |
+
+---
+
+## Reference Files
+
+- `references/packages-branches-and-repos.md` - Kali branch model, source lists, keyrings, updates, and package-state recovery
+- `references/metapackages-and-tool-families.md` - what the main Kali metapackages install, how the tool families map to real workflows, and when to hand off to lockpick or zero-day
+- `references/images-live-persistence-and-recovery.md` - installer ISOs, netinst, live images, Purple images, VM images, persistence, and recovery flow
+- `references/wireless-gpu-hardware-and-nethunter.md` - Wi-Fi, Bluetooth, RFID, SDR, GPU, USB passthrough, and NetHunter-specific hardware realities
+- `references/lab-safety-and-scope.md` - disposable lab setup, intentionally vulnerable targets, snapshots, and authorization boundaries
+- `references/gotchas-and-special-situations.md` - recurring Kali breakage patterns and edge cases
+
+---
+
+## Related Skills
+
+- **debian-ubuntu** - base Debian-family administration. Use it for generic apt-family hosts; use this skill when Kali-specific branches, images, metapackages, or tool context matter.
+- **lockpick** - exploitation, post-exploitation, and escalation on authorized targets. This skill helps choose and maintain Kali tooling; lockpick handles the offensive workflow itself.
+- **zero-day** - vulnerability discovery, reverse engineering depth, fuzzing, and proof-of-concept work. This skill covers the Kali environment and tool families that support that work.
+- **security-audit** - defensive hardening and vuln review instead of offensive distro workflow.
+- **virtualization** - hypervisor setup, guest provisioning, passthrough, and VM platform issues once the fault is clearly outside the Kali guest.
+- **command-prompt** - shell syntax, wrappers, aliases, and script portability when the real issue is the shell rather than Kali.
+- **networking** - network services, VPNs, DNS, proxies, and firewall design beyond host-level Kali package questions.
+
+---
+
+## Rules
+
+1. **Identify the Kali lane before prescribing commands.** Installed rolling, snapshot, live media, VM image, Purple, and NetHunter differ where it matters.
+2. **Do not treat Kali like generic Debian with a dragon wallpaper.** Branches, metapackages, images, and hardware expectations change the answer.
+3. **Do not mix branches casually.** `kali-rolling`, `kali-last-snapshot`, `kali-experimental`, `kali-bleeding-edge`, and `kali-dev` each have a purpose. Random mixing usually ends in package pain.
+4. **Prefer focused metapackages over giant installs.** Install the tool family that matches the job before reaching for `kali-linux-everything`.
+5. **Keep lab and production separate.** Practice targets, vulnerable apps, and offensive tooling belong on disposable systems or isolated boxes.
+6. **Respect scope.** Recommending Kali tools is not permission to use them outside authorized environments.
+7. **Treat hardware claims as hardware claims.** Monitor mode, injection, SDR capture, HID, and GPU acceleration depend on actual chipsets, firmware, and passthrough support.
+8. **Live USB and persistence are their own failure domain.** Do not debug them like a normal installed root filesystem.
+9. **Hand off correctly.** Once the work becomes exploitation methodology, use **lockpick**. Once it becomes original vulnerability research, use **zero-day**.
+10. **Reach for common Kali failure patterns before exotic explanations.** Stale keyrings, branch drift, metapackage sprawl, persistence corruption, and unsupported hardware explain a large share of the mess.

--- a/skills/kali-linux/references/gotchas-and-special-situations.md
+++ b/skills/kali-linux/references/gotchas-and-special-situations.md
@@ -1,0 +1,50 @@
+# Kali Gotchas and Special Situations
+
+The boring failures win a lot.
+
+## Common failure patterns
+
+### Branch drift
+The user thinks they are on normal rolling, but sources show snapshot or partial branches too.
+Result: dependency weirdness and package confusion.
+
+### Stale keyring
+Repo metadata errors look dramatic, but the fix starts with trust material and package state, not
+random mirror hopping.
+
+### Metapackage regret
+The machine is slow, crowded, and messy because someone installed `kali-linux-everything` on a
+small VM when they really needed one or two focused bundles.
+
+### Live persistence drift
+The user swears settings are saved, but the boot entry or persistence mount says otherwise.
+
+### VM passthrough lies
+The package is installed, the command exists, but the Wi-Fi adapter, SDR, or USB debugger never
+reaches the guest correctly.
+
+### Unsupported wireless expectations
+The adapter can connect to Wi-Fi but cannot do monitor mode or injection. Kali is not the thing
+lying; the chipset marketing probably is.
+
+### Desktop-session blame
+Burp, Wireshark helpers, browser tooling, or capture workflows look broken when the real issue is
+session plumbing, PipeWire, portals, or the hypervisor display stack.
+
+## Triage shortcuts
+
+```bash
+apt-cache policy 2>&1 || true
+grep -Rhv '^#\|^$' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>&1 || true
+dpkg -l | grep '^ii  kali-' | head -30
+findmnt | grep -Ei 'live|overlay|persistence' 2>&1 || true
+rfkill list 2>&1 || true
+iw dev 2>&1 || true
+lsusb
+```
+
+## Decision rule
+
+If the problem can be explained by branch state, image type, persistence, passthrough, firmware,
+or chipset support, explain that first. Only move to exotic theories after the basic story is
+clean.

--- a/skills/kali-linux/references/images-live-persistence-and-recovery.md
+++ b/skills/kali-linux/references/images-live-persistence-and-recovery.md
@@ -1,0 +1,79 @@
+# Kali Images, Live Media, Persistence, and Recovery
+
+Kali ships in several shapes. The recovery path depends on which shape the user is actually using.
+
+## Official image types
+
+Kali 2026.1 image directories include:
+- installer ISOs
+- netinst ISOs
+- prebuilt VM images
+- checksums and GPG signatures
+- Purple installer image on amd64
+
+## ARM and SBC images
+
+Kali also ships ARM images for boards such as Raspberry Pi and other SBCs. Treat these as a
+separate lane: boot firmware, storage media, peripherals, and image choice are board-specific and
+should not be debugged like generic amd64 installs.
+
+Use the image type as part of the diagnosis, not just the distro name.
+
+## Installed system vs live media
+
+| Mode | What changes |
+|------|--------------|
+| Installed root filesystem | normal package and boot recovery rules apply |
+| Live ISO | ephemeral by default; changes vanish unless persistence exists |
+| Live USB with persistence | overlay and persistence partition become first-class suspects |
+| VM image | hypervisor, guest additions, USB passthrough, and display stack matter |
+
+## Persistence questions
+
+When a user says Kali forgot changes after reboot, check:
+- was it live media?
+- was persistence created at all?
+- is the persistence partition mounting?
+- is the wrong boot entry being used?
+- did the overlay get corrupted?
+
+Useful checks:
+```bash
+findmnt /
+findmnt /run/live/medium 2>&1 || true
+findmnt | grep -Ei 'persistence|overlay|live' 2>&1 || true
+lsblk -f
+```
+
+## Verification discipline
+
+Kali publishes `SHA256SUMS` and GPG signatures for release images. Prefer those over SHA1 and
+prefer verified official images over mystery USB media.
+
+## Recovery pattern
+
+1. Confirm image type.
+2. Confirm whether the system is installed or live.
+3. Confirm persistence layout if live.
+4. Verify storage and mountpoints.
+5. Only then chase package or desktop issues.
+
+## Purple and specialized images
+
+Kali Purple images are still Kali, but the image choice changes expectations about what should be
+preinstalled and what kind of workflow the user expects. Do not assume the default red-team image
+set when they explicitly chose Purple.
+
+## VM notes
+
+VM image pain often comes from the hypervisor, not Kali itself:
+- broken USB passthrough hides Wi-Fi adapters and SDR gear
+- weak display acceleration makes desktop tools feel broken
+- NAT or host-only mode changes how scanners and sniffers behave
+- shared clipboard and drag-and-drop issues are guest-tooling issues, not pentest-tool bugs
+
+## What not to do
+
+- Do not debug live persistence like a normal installed root filesystem.
+- Do not recommend reinstalling the whole image before checking mount and overlay state.
+- Do not trust an ISO that was never checksum-verified.

--- a/skills/kali-linux/references/lab-safety-and-scope.md
+++ b/skills/kali-linux/references/lab-safety-and-scope.md
@@ -1,0 +1,40 @@
+# Kali Lab Safety and Scope
+
+Kali lowers the friction to run security tooling. It does not lower the bar for authorization.
+
+## Baseline rules
+
+- Use Kali tooling only inside an authorized scope.
+- Keep practice targets and production systems separate.
+- Prefer disposable VMs, snapshots, and isolated USB media.
+- Treat `kali-linux-labs` as intentionally vulnerable training content, not workstation furniture.
+
+## Recommended lab shapes
+
+| Shape | Good for | Why |
+|-------|----------|-----|
+| Throwaway VM | most practice and package testing | easy snapshots and rollback |
+| Dedicated USB install | field kit or travel box | isolated from main workstation |
+| Nested lab in virtualization stack | multi-host training ranges | fast reset and repeatable states |
+| NetHunter lab device | mobile hardware and HID practice | keeps phone-specific quirks contained |
+
+## Good habits
+
+- snapshot before large metapackage installs
+- snapshot before branch changes
+- verify image checksums before first boot
+- keep notes on which adapters, SDRs, and cables actually work
+- separate "tooling install complete" from "operator workflow complete"
+
+## Hand-off boundaries
+
+- For live offensive workflow and escalation methodology, move to **lockpick**.
+- For novel bug hunting and proof-of-concept work, move to **zero-day**.
+- For defensive review of the target's code or config, move to **security-audit**.
+
+## What not to normalize
+
+- installing giant metapackages on a production laptop without a rollback plan
+- using intentionally vulnerable labs on the same box that holds client data
+- mixing experimental branches just to grab one shiny tool
+- assuming a successful install means safe or legal use

--- a/skills/kali-linux/references/metapackages-and-tool-families.md
+++ b/skills/kali-linux/references/metapackages-and-tool-families.md
@@ -1,0 +1,155 @@
+# Kali Metapackages and Tool Families
+
+Kali is easier to manage when you think in bundles and workflows instead of one giant package dump.
+The official metapackage docs and `kali-meta` page are the map.
+
+## Big-picture install bundles
+
+| Metapackage | What it does | Good default |
+|-------------|--------------|--------------|
+| `kali-linux-core` | base Kali system plus core offensive essentials such as `netcat-traditional` and `tcpdump` | minimal Kali with the right flavor |
+| `kali-linux-headless` | default install without GUI | remote VM, cloud lab, thin box |
+| `kali-linux-default` | tools included in normal desktop images | most general-purpose Kali installs |
+| `kali-linux-arm` | ARM-suitable tool mix | SBCs and ARM devices |
+| `kali-linux-nethunter` | NetHunter-related tooling | mobile and Android-adjacent workflows |
+| `kali-linux-large` | older larger desktop bundle | legacy expectations |
+| `kali-linux-everything` | every metapackage and tool bundle | only when disk, bandwidth, and patience are cheap |
+| `kali-linux-labs` | intentionally vulnerable practice environments | controlled training only |
+
+Practical rule: start with `kali-linux-default` or a small focused install. Reach for
+`kali-linux-everything` only when the machine truly exists to be a huge toolbox.
+
+## Desktop and system metapackages
+
+Kali also exposes system and desktop bundles such as:
+- `kali-system-core`
+- `kali-system-cli`
+- `kali-system-gui`
+- `kali-desktop-core`
+- `kali-desktop-gnome`
+- `kali-desktop-xfce`
+- `kali-desktop-kde`
+- `kali-desktop-i3`
+
+Those matter because many "tool problems" are actually desktop or session problems.
+Burp, browser helpers, proxy tools, capture utilities, and USB GUI apps care about the session.
+
+## Workflow-oriented tool families
+
+The Kali metapackage docs group tools by job. That grouping is the fastest way to decide what to
+install.
+
+### `kali-tools-information-gathering`
+Use for reconnaissance and discovery before touching the target deeply.
+Examples from the Kali tools index include discovery and recon-oriented tooling such as `theharvester`.
+
+### `kali-tools-vulnerability`
+Use for vulnerability assessment and surface mapping.
+Examples from the official tools index and release notes include `nuclei`, `nikto`, and GVM-related tooling where available.
+If the user wants broad defensive review of their own project rather than Kali package selection,
+hand off to **security-audit**.
+
+### `kali-tools-web`
+Use for web testing and content discovery.
+Examples confirmed on the Kali tools pages include:
+- `sqlmap` - SQL injection automation
+- `gobuster` - fast content and directory discovery
+- `dirb`, `dirsearch`, `ffuf`, `feroxbuster` - wordlist-driven content discovery
+- `whatweb` - web fingerprinting
+- `wpscan` - WordPress assessment
+- `burpsuite` and `caido` - intercepting and manual web workflow
+- `sstimap` and `XSStrike` - SSTI and XSS-focused testing in the 2026.1 release lane
+
+### `kali-tools-passwords`
+Use for credential auditing and cracking workflows.
+Examples confirmed on Kali tool pages include:
+- `hashcat` - offline cracking with GPU-friendly workflows
+- `hydra` - online login brute forcing and service credential testing
+
+### `kali-tools-wireless`
+Use when the user needs the family view, not one protocol silo.
+This umbrella overlaps with narrower hardware bundles such as:
+- `kali-tools-802-11`
+- `kali-tools-bluetooth`
+- `kali-tools-rfid`
+- `kali-tools-sdr`
+- `kali-tools-voip`
+
+Examples confirmed on Kali tool pages include:
+- `aircrack-ng` suite - Wi-Fi capture, replay, and cracking workflow
+- `kismet` - broad wireless discovery and capture ecosystem
+- `reaver` and `wash` - WPS testing
+- `wifite`, `fluxion`, `wifiphisher`, `airgeddon` - campaign-style wireless testing helpers
+
+### `kali-tools-reverse-engineering`
+Use for binary inspection and reversing workflows.
+If the task becomes deep vulnerability discovery, exploitability research, or fuzzing strategy,
+hand off to **zero-day**.
+The 2026.1 release also added `GEF`, which improves GDB-based reversing and exploit debugging.
+
+### `kali-tools-exploitation`
+Use for exploitation tooling packages and launchers.
+Examples confirmed on Kali tool pages include `metasploit-framework` and its many helper commands
+such as `msfconsole` and `msfvenom`.
+If the user is asking how to conduct exploitation on an authorized target rather than how to keep
+Kali healthy, hand off to **lockpick**.
+
+### `kali-tools-post-exploitation`
+Use for post-access tooling families and operator workflow packages.
+Again, once the question becomes operational tradecraft or escalation flow, this skill should hand
+off to **lockpick**.
+
+### `kali-tools-forensics`
+Use for live and offline evidence collection and analysis.
+Keep this separate from offensive workflow and from generic Linux package debugging.
+
+### `kali-tools-reporting`
+Use for writing up findings, screenshots, and engagement outputs.
+It is easy to ignore, but a complete Kali install for real work usually needs reporting tools too.
+
+### Specialist bundles
+Kali also ships targeted bundles such as:
+- `kali-tools-gpu`
+- `kali-tools-hardware`
+- `kali-tools-crypto-stego`
+- `kali-tools-fuzzing`
+- `kali-tools-windows-resources`
+
+If the request moves from installing fuzzing tools to designing fuzzing strategy, crash triage, or
+novel vulnerability discovery, hand off to **zero-day**.
+
+These are better than shotgun-installing random packages when the user already knows the workflow.
+
+## Tool pages worth remembering
+
+The official Kali tools index is useful because it shows three things at once:
+- the tool page
+- the package name
+- the installed command name
+
+That helps when a user says "I installed it but the command is missing." On Kali, the package,
+page, and command name are often close, but not always identical.
+
+Use this quick lookup flow:
+
+```bash
+apt-cache policy package-name 2>&1 || true
+apt-cache depends package-name 2>&1 || true
+dpkg -L package-name 2>&1 || true
+command -v expected-command 2>/dev/null || true
+```
+
+Check in this order:
+1. did the package really install?
+2. is the package a metapackage or transitional package?
+3. did the real binary land in a different package?
+4. is the binary name different from the package name?
+
+Do not assume package name, tool page name, and command name are the same string.
+
+## Safe routing boundaries
+
+- Use this skill to choose and maintain the Kali package set.
+- Use **lockpick** when the user moves from "what should I install" to "how do I escalate or pivot on an authorized target".
+- Use **zero-day** when the user moves from "which reversing tools do I need" to "help me discover a novel bug or build a PoC".
+- Use **security-audit** when the user is defending an application or service rather than working the Kali workstation itself.

--- a/skills/kali-linux/references/packages-branches-and-repos.md
+++ b/skills/kali-linux/references/packages-branches-and-repos.md
@@ -1,0 +1,109 @@
+# Kali Packages, Branches, and Repos
+
+Kali package health starts with one question: which branch model is this machine following?
+If you skip that question, every later fix is guesswork.
+
+## Branch model
+
+Official Kali docs describe these main lanes:
+
+| Branch | What it is | Default use |
+|--------|------------|-------------|
+| `kali-rolling` | main continuously updated branch | default for most users |
+| `kali-last-snapshot` | frozen release-like branch between Kali releases | safer, calmer installs |
+| `kali-experimental` | partial work-in-progress packages | special cases only |
+| `kali-bleeding-edge` | selected packages auto-updated from upstream git | fast and risky |
+| `kali-dev` | development integration branch | maintainers and testers |
+
+Practical rule: use either `kali-rolling` or `kali-last-snapshot` as the full distro lane. Do not
+enable both just because they sound compatible.
+
+## Healthy source-list patterns
+
+### Rolling install
+```bash
+grep -Rhv '^#\|^$' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>&1 || true
+```
+
+Expected shape is one clear Kali lane, not a soup of Kali plus random Debian suites.
+
+### Snapshot users
+If the user wants calmer behavior, verify they intentionally track the snapshot lane rather than
+accidentally running stale mirrors.
+
+## Core checks
+
+```bash
+apt-cache policy 2>&1 || true
+apt-cache policy kali-archive-keyring kali-defaults kali-linux-core kali-linux-default 2>&1 || true
+apt list --upgradable 2>&1 | tail -n +2
+```
+
+What these tell you:
+- `apt-cache policy` shows which repos are active and which release wins package selection
+- `kali-archive-keyring` tells you whether repo trust is the real issue
+- `kali-defaults` is a good anchor for Kali-specific behavior
+- upgradable package count tells you whether the machine is merely behind versus actually broken
+
+## Upgrade stance
+
+Kali docs recommend:
+
+```bash
+sudo apt update
+sudo apt full-upgrade -y
+```
+
+Use `full-upgrade` when package transitions matter. Kali is rolling enough that a half-updated
+state often causes more pain than the tool the user was trying to install.
+
+## Mirrors and signatures
+
+For images and mirrors, prefer verified downloads and official repo metadata.
+Kali publishes SHA256 sums and GPG signatures for release images. Use those instead of trusting a
+random ISO someone found on a USB stick.
+
+## Common package-state failures
+
+### Stale keyring
+Symptoms:
+- signature warnings
+- repo metadata rejected
+- packages seem present but updates fail
+
+Check:
+```bash
+apt-cache policy kali-archive-keyring 2>&1 || true
+```
+
+### Branch mixing
+Symptoms:
+- weird dependency conflicts
+- package version pinball
+- tools missing expected binaries after install
+
+Check:
+```bash
+grep -Rhv '^#\|^$' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>&1 || true
+apt-cache policy 2>&1 || true
+```
+
+### Transitional packages
+Kali uses metapackages and some transitional packages. A package can install cleanly yet not be
+where the user expects. Check dependencies and the real binary package instead of assuming the
+metapackage owns the executable.
+
+## Recovery pattern
+
+1. Confirm the intended branch.
+2. Clean up source lists until one main lane wins.
+3. Update package metadata.
+4. Run `apt full-upgrade`.
+5. Re-check the exact package and binary.
+
+## What not to do
+
+- Do not bolt Debian stable, testing, or sid repos onto Kali casually.
+- Do not enable every Kali branch at once.
+- Do not treat a broken live ISO the same way as an installed root filesystem.
+- Do not assume a metapackage means a command should exist under the same name.

--- a/skills/kali-linux/references/wireless-gpu-hardware-and-nethunter.md
+++ b/skills/kali-linux/references/wireless-gpu-hardware-and-nethunter.md
@@ -1,0 +1,72 @@
+# Kali Wireless, GPU, Hardware, and NetHunter Notes
+
+A lot of Kali frustration is really hardware frustration.
+
+## Wireless reality
+
+Menu entries do not guarantee capability. Check the actual chipset, firmware, and connection path.
+
+Core checks:
+```bash
+rfkill list 2>&1 || true
+iw dev 2>&1 || true
+lspci -k | grep -Ei 'network|wireless'
+lsusb
+journalctl -b | grep -Ei 'ath|iwlwifi|brcm|rtl|mt76' 2>&1 || true
+command -v airmon-ng >/dev/null 2>&1 && airmon-ng 2>&1 || true
+```
+
+What usually breaks wireless workflows:
+- unsupported chipset for monitor mode or injection
+- missing firmware
+- low USB power on small systems or hubs
+- VM passthrough that exposes the device badly
+- NetworkManager or another service holding the interface in the wrong mode
+
+## SDR, Bluetooth, RFID, and USB gear
+
+Kali has metapackages for SDR, Bluetooth, and RFID, but hardware still decides the truth.
+Check:
+- does the kernel see the device?
+- does the user have access to the device node?
+- did the package install the expected helper binaries?
+- is USB passthrough stable if this is a VM?
+
+## GPU and cracking workflows
+
+For GPU-heavy tools such as `hashcat`, the key question is not "is Kali installed" but:
+- does the GPU exist in this environment?
+- is this bare metal or a VM?
+- does the driver stack match the GPU?
+- is the user asking for packaging help or actual cracking workflow?
+
+If it is packaging and driver shape, stay here.
+If it becomes offensive password-audit tradecraft on an authorized target, that intersects with
+**lockpick**.
+
+## GUI capture and desktop helpers
+
+Desktop tools can fail because the session is broken, not because the security tool is broken.
+Check:
+```bash
+echo "Session=$XDG_SESSION_TYPE Desktop=$XDG_CURRENT_DESKTOP"
+command -v systemctl >/dev/null 2>&1 && systemctl --user status pipewire pipewire-pulse wireplumber xdg-desktop-portal 2>&1 || true
+```
+
+## NetHunter
+
+NetHunter is not just Kali on a phone. It changes the answer because:
+- the Android host and kernel matter
+- HID support depends on the device and kernel
+- wireless injection support is device-specific
+- mobile storage and USB expectations differ from desktop Kali
+
+Core check:
+```bash
+command -v nethunter >/dev/null 2>&1 && nethunter -h 2>&1 | head -20
+```
+
+When a NetHunter question becomes kernel porting or exploit technique, route to **lockpick** for
+authorized offensive workflow. When it becomes original vulnerability discovery, reversing depth
+work, or PoC development, route to **zero-day**. When it becomes defensive review of the target
+system or code, route to **security-audit**.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -463,13 +463,18 @@ collection, run Mode 2 Step 2 (quality checks) to verify no regressions were int
 3. **Verify everything, assume nothing.** AI models hallucinate tool names, CLI flags, version
    numbers, and API endpoints. Every tool, version, flag, and behavior claim in a skill must
    be verified via web search or registry check before writing it down. "I'm pretty sure" is
-   not verification. If you can't confirm it, don't include it. In offline or sandboxed
-   environments, note unverified claims explicitly rather than blocking the review.
+   not verification. If a site blocks simple HTTP clients or Python `urllib`, retry with a
+   browser-like user agent or `curl -A 'Mozilla/5.0'` before marking the claim unverified.
+   If you still can't confirm it, don't include it. In offline or sandboxed environments,
+   note unverified claims explicitly rather than blocking the review.
 4. **Prefer dedicated skill workflows over generic helpers.** When a purpose-built skill and a
    generic planning or brainstorming helper both fit, prefer the purpose-built skill. Generic
    workflow skills are invoked manually when explicitly requested.
 5. **Update the inventory.** After creating, removing, or renaming a skill, update any published
-   inventory file the collection uses and re-run the cross-reference checks.
+   inventory file the collection uses and re-run the cross-reference checks. If the collection
+   has a README skill catalog or headline counts (for example "N production-tested skills"),
+   verify those counts against the live published skill set instead of incrementing by guesswork.
+   Count real public skills from the repo, then make the README match.
 6. **No AI slop in skills.** Skills are meta-prompts - they shape how the model works. Comment
    noise, over-abstraction, aggressive ALL CAPS directives, and "just in case" instructions
    degrade skill performance. Write like a competent human briefing a colleague.


### PR DESCRIPTION
## Summary
- add a new `kali-linux` skill for Kali-specific distro administration, package workflow, image handling, hardware, and lab hygiene
- route Kali-specific cases from `debian-ubuntu` into the new skill
- update the README skill catalog and tighten `skill-creator` inventory guidance

## Test Plan
- [x] `./scripts/lint-skills.sh skills`
- [x] `./scripts/validate-spec.sh skills`