### PR TITLE
feat(nixos-btw): add NixOS, Nix, flakes, and nix-darwin skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-**36 production-tested skills** - Kubernetes, Terraform, Docker, Ansible, CI/CD, HTTP APIs, databases, AI/ML, testing, virtualization, Arch Linux, Debian-family, RPM-family, Kali Linux, networking, localization, browsing, MCP servers, security audits, pentesting, code review, prose audits, dev workflow orchestration, and more.
+**37 production-tested skills** - Kubernetes, Terraform, Docker, Ansible, CI/CD, HTTP APIs, databases, AI/ML, testing, virtualization, Arch Linux, Debian-family, RPM-family, Kali Linux, NixOS, networking, localization, browsing, MCP servers, security audits, pentesting, code review, prose audits, dev workflow orchestration, and more.
 
 Built on the [Agent Skills open standard](https://agentskills.io/specification). Works with any tool that supports it.
 
@@ -19,7 +19,7 @@ Built on the [Agent Skills open standard](https://agentskills.io/specification).
 
 ---
 
-`kubernetes` `terraform` `docker` `ansible` `archlinux` `cachyos` `pacman` `paru` `aur` `systemd` `helm` `argocd` `ci-cd` `github-actions` `gitlab-ci` `postgresql` `mongodb` `mysql` `networking` `dns` `wireguard` `tailscale` `vpn` `nftables` `opnsense` `pfsense` `mcp` `model-context-protocol` `security-audit` `owasp` `pentesting` `privilege-escalation` `ctf` `code-review` `git` `shell` `zsh` `bash` `prompt-engineering` `pci-dss` `compliance` `devops` `infrastructure-as-code` `iac` `containers` `podman` `buildah` `sealed-secrets` `haproxy` `caddy` `traefik` `nginx` `autoresearch` `self-improving` `llm` `rag` `embedding` `vector-store` `langchain` `langgraph` `openai-sdk` `anthropic-sdk` `agents` `fine-tuning` `ollama` `vllm` `promptfoo` `vitest` `jest` `playwright` `pytest` `tdd` `e2e` `accessibility` `axe-core` `load-testing` `k6` `proxmox` `qemu` `kvm` `libvirt` `packer` `cloud-init` `gpu-passthrough` `virtualization` `hypervisor`
+`kubernetes` `terraform` `docker` `ansible` `archlinux` `cachyos` `pacman` `paru` `aur` `systemd` `nixos` `nix` `flakes` `home-manager` `nix-darwin` `helm` `argocd` `ci-cd` `github-actions` `gitlab-ci` `postgresql` `mongodb` `mysql` `networking` `dns` `wireguard` `tailscale` `vpn` `nftables` `opnsense` `pfsense` `mcp` `model-context-protocol` `security-audit` `owasp` `pentesting` `privilege-escalation` `ctf` `code-review` `git` `shell` `zsh` `bash` `prompt-engineering` `pci-dss` `compliance` `devops` `infrastructure-as-code` `iac` `containers` `podman` `buildah` `sealed-secrets` `haproxy` `caddy` `traefik` `nginx` `autoresearch` `self-improving` `llm` `rag` `embedding` `vector-store` `langchain` `langgraph` `openai-sdk` `anthropic-sdk` `agents` `fine-tuning` `ollama` `vllm` `promptfoo` `vitest` `jest` `playwright` `pytest` `tdd` `e2e` `accessibility` `axe-core` `load-testing` `k6` `proxmox` `qemu` `kvm` `libvirt` `packer` `cloud-init` `gpu-passthrough` `virtualization` `hypervisor`
 
 ---
 
@@ -69,7 +69,7 @@ The loop: **Score -> Improve -> Verify -> Keep or Revert -> Repeat.**
 
 ## What's in the box
 
-36 production-tested skills covering:
+37 production-tested skills covering:
 
 ### Infrastructure & Operations
 
@@ -80,6 +80,7 @@ The loop: **Score -> Improve -> Verify -> Keep or Revert -> Repeat.**
 | **debian-ubuntu** | Debian and Debian-family administration - apt, dpkg, PPAs, snaps, systemd, GRUB, AppArmor, HWE, and distro-specific quirks |
 | **rhel-fedora** | Fedora and RHEL-family administration - dnf, yum, SELinux, firewalld, dracut, subscription-manager, and clone-specific quirks |
 | **kali-linux** | Kali Linux administration - branches, metapackages, live USB persistence, offensive tool families, NetHunter, and lab-safe distro workflow |
+| **nixos-btw** | NixOS, Nix, home-manager, nix-darwin, and flakes - declarative config, generations and rollbacks, channels vs flakes, modules, overlays, nix-store GC, disko, impermanence, nixos-anywhere, Determinate Nix and Lix |
 | **docker** | Dockerfiles, Compose, Podman, Buildah, multi-stage builds, image signing, container hardening |
 | **kubernetes** | Manifests, Helm charts, Gateway API, Kustomize, ArgoCD, sealed secrets, PCI-DSS compliance |
 | **terraform** | Terraform/OpenTofu - HCL patterns, module design, state management, policy-as-code, compliance |

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: nixos-btw
+description: >
+  · Administer NixOS, Nix, home-manager, nix-darwin, and flakes - declarative config,
+  generations and rollbacks, channels vs flakes, modules, overlays, nix-store GC, disko,
+  impermanence, nixos-anywhere, Determinate Nix, Lix. Triggers: 'nixos', 'nix', 'flake',
+  'home-manager', 'nix-darwin', 'configuration.nix', 'nixpkgs', 'nixos-rebuild',
+  'nix-shell', 'nix develop', 'overlay', 'disko', 'impermanence', 'determinate nix',
+  'lix'. Not for Arch (**arch-btw**), Debian (**debian-ubuntu**), Fedora
+  (**rhel-fedora**), Kali (**kali-linux**), shell (**command-prompt**).
+license: MIT
+compatibility: "Requires NixOS, or Nix/Determinate Nix/Lix on Linux/macOS/WSL"
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-04-23"
+  effort: high
+  argument_hint: "[issue-or-subsystem]"
+---
+
+# NixOS BTW: NixOS, Nix, and Flakes Administration
+
+Administer NixOS without falling back into imperative distro muscle memory. NixOS is
+declarative, functional, and atomic: the system is a value computed from a configuration,
+every change becomes a new immutable generation in `/nix/store`, and rollbacks are a
+bootloader entry away. This skill keeps that model intact, then layers in the practical
+stack: channels vs flakes, `nixos-rebuild` vs `nix` CLI, home-manager, nix-darwin, store
+hygiene, overlays, module writing, secrets, and the Determinate Nix and Lix lanes.
+
+The places NixOS breaks are NixOS-shaped: channel drift, flake input staleness, garbage
+collection that nukes a needed derivation, overlays fighting, `nix-env -i` poisoning the
+user profile, hardware modules missing, or people treating `/etc/nixos/configuration.nix`
+like a normal Linux config file.
+
+**Why people run it.** Atomic upgrades and rollbacks, bit-for-bit reproducible systems,
+disposable dev shells, fleet-wide configuration without a separate config-management tool,
+and a single language for a workstation, a server, a container image, a NixOS VM, and a
+macOS laptop via nix-darwin.
+
+**Versions worth pinning** (verified April 2026):
+
+Pin versions only when they shape compatibility or troubleshooting. For ordinary package
+work, trust the live channel or flake lock over a stale table.
+
+| Component | Version or date | Why it matters |
+|-----------|-----------------|----------------|
+| NixOS stable | 25.11 "Xantusia" (Nov 2025) | current stable, maintained until 2026-06-30 |
+| NixOS upcoming | 26.05 "Yarara" (May 2026) | next release; do not target yet for production |
+| Nix (CLI / daemon) | 2.33 (Dec 2025) | stable upstream; 2.32 introduced skip-substitutable-downloads |
+| `nixos-rebuild-ng` | default in 25.11 | Python rewrite of nixos-rebuild, default for new installs |
+| home-manager | release-25.11 (Nov 2025) | matches NixOS 25.11; unstable tracks nixos-unstable |
+| nix-darwin | tracks nixpkgs 25.11 and master | active macOS module system (Intel + Apple Silicon) |
+| Determinate Nix | downstream, flakes-on by default | validated distribution; parallel eval, lazy trees |
+| Lix | fork of Nix | compatibility-focused fork; Meson build, improved errors |
+| Kernel default for 25.11 | Linux 6.12 LTS | default `linuxPackages`; `linuxPackages_latest` tracks mainline (6.17 at 25.11 release, not LTS) |
+
+## When to use
+
+- NixOS system administration: `configuration.nix`, modules, options, imports, and `/etc/nixos` workflow
+- Flake work: `flake.nix`, `flake.lock`, inputs, outputs, `nix flake update`, `nix flake check`
+- `nixos-rebuild` flow: `switch`, `test`, `boot`, `dry-activate`, `build-vm`, and rollback
+- Channels, pinning, and input management: `nix-channel`, `nix registry`, `npins`, `niv`, flake inputs
+- home-manager (standalone, NixOS module, or nix-darwin module) for user-level declarative config
+- nix-darwin on macOS: declarative system config, Homebrew integration, LaunchDaemons
+- Nix store and derivations: `nix-store`, `nix store`, GC roots, `nix-collect-garbage`, optimise-store
+- Dev environments: `nix-shell`, `nix develop`, `shell.nix`, `default.nix`, direnv with `nix-direnv`
+- Overlays, overrides, and package customisation: overlays, `overrideAttrs`, `override`, pin patches
+- Writing NixOS modules: options, config, assertions, conditionals, imports, `mkMerge`, `mkForce`
+- Secrets management: sops-nix, agenix, nix-sops, ragenix, activation-time decryption
+- Declarative disks and filesystems: disko, btrfs layouts, LUKS, ZFS, impermanence patterns
+- Remote installs and imaging: nixos-anywhere, `nixos-install`, `nixos-generate`, SD images, ISO images
+- Hardware enablement: nixos-hardware profiles, firmware, kernel choice, GPU drivers
+- Unfree and insecure packages: `allowUnfree`, `permittedInsecurePackages`, `NIXPKGS_ALLOW_*`
+- Boot and generations: systemd-boot vs GRUB, kernel selection, `nix-env --list-generations`, boot entries
+- Garbage collection strategy: retention, GC roots, `nix.gc.automatic`, auto-optimise-store
+- Determinate Nix lane: Determinate installer, flakes-on-by-default, enterprise backports
+- Lix lane: fork-specific behavior, coexistence, and migration notes
+- Integration with Docker, Kubernetes, and CI: `nix build`, image outputs, cachix, attic
+
+## When NOT to use
+
+- Arch or CachyOS administration - use **arch-btw**
+- Debian, Ubuntu, Mint, or Pop!_OS administration - use **debian-ubuntu**
+- Fedora, RHEL, CentOS Stream, Rocky, or Alma administration - use **rhel-fedora**
+- Kali Linux and offensive-tool distros - use **kali-linux**
+- Shell syntax, quoting, or portability outside Nix expressions - use **command-prompt**
+- Docker, Podman, image builds, or container runtime issues - use **docker**
+- Kubernetes cluster or manifest work - use **kubernetes**
+- Fleet-wide non-Nix Linux configuration via playbooks - use **ansible**
+- Terraform or OpenTofu infrastructure code - use **terraform**
+- Offensive or privesc testing - use **lockpick**
+- Defensive hardening and vuln review - use **security-audit**
+- OPNsense or pfSense appliance work - use **firewall-appliance**
+
+---
+
+## AI Self-Check
+
+Before returning NixOS or Nix commands, verify:
+
+- [ ] **Lane identified**: NixOS install, Nix on non-NixOS Linux, Nix on macOS (nix-darwin or plain Nix), WSL, Determinate Nix, or Lix. Advice diverges fast.
+- [ ] **Channels vs flakes decided**: confirm which the user has before prescribing `nix-channel`, `nixos-rebuild --flake`, or `nix flake update`. Mixing without intent creates channel-lock drift.
+- [ ] **Flake status is current**: flakes remain nominally experimental on upstream Nix but are enabled by default on Determinate Nix; recommend enabling `experimental-features = nix-command flakes` where the user is already using flakes.
+- [ ] **`nix-env -i` is not the answer**: installing into the per-user profile hides state from `configuration.nix` and breaks reproducibility. Use declarative `environment.systemPackages`, `home.packages`, or an ad-hoc `nix shell` instead.
+- [ ] **No partial upgrade advice**: on flakes-based systems, do not bump a single input without running `nixos-rebuild --flake` after; on channels, do not change only `nixos` without updating dependent channels too.
+- [ ] **Rebuild verb is intentional**: `switch`, `test`, `boot`, `dry-activate`, `build-vm`, and `build` differ. `test` does not persist the boot entry; `boot` does not activate now; `switch` does both.
+- [ ] **Known-good generation preserved**: never remove the last known-good generation, and never `nix-collect-garbage -d` on a system that just booted a new generation without verifying the new one survives a reboot.
+- [ ] **GC roots respected**: dev shells, direnv caches, and CI artifacts often hold GC roots. Do not recommend aggressive GC without checking `nix-store --gc --print-roots` first.
+- [ ] **Unfree / insecure gates named explicitly**: set `nixpkgs.config.allowUnfree = true;` or `allowUnfreePredicate`, and list insecure packages under `permittedInsecurePackages`. Do not default to `NIXPKGS_ALLOW_UNFREE=1` as the permanent answer.
+- [ ] **Hardware module present**: for fresh installs, `hardware-configuration.nix` must be regenerated with `nixos-generate-config` and not hand-edited for filesystem UUIDs. For laptops, check nixos-hardware profile.
+- [ ] **Kernel and initrd coherence**: `boot.kernelPackages`, initrd modules, filesystems, and bootloader agree. Do not casually swap kernels on a system with ZFS, NVIDIA, or custom out-of-tree modules.
+- [ ] **Module fields real**: options named in advice exist in the version of nixpkgs the user has. `options` graveyards drift between 23.11, 24.05, 24.11, 25.05, and 25.11 - verify against the `nixpkgs` tag the user pinned.
+- [ ] **Secrets not put in the store**: anything under `./secret.age`, `./sops.yaml`, or similar must be decrypted at activation time by sops-nix or agenix, not embedded directly in a Nix string that ends up world-readable in `/nix/store`.
+- [ ] **disko / impermanence claims match the install**: declarative disk layouts change the recovery story. Confirm partition, filesystem, and subvolume layout before prescribing rollback or wipe steps.
+- [ ] **home-manager mode identified**: standalone, NixOS module, or nix-darwin module. `home-manager switch` vs `nixos-rebuild switch` vs `darwin-rebuild switch` is not interchangeable.
+- [ ] **Overlay placement sane**: overlays belong in `nixpkgs.overlays` (NixOS) or as a flake input overlay. Do not recommend global `~/.config/nixpkgs/overlays.nix` on a flakes system where that path is often ignored.
+- [ ] **Determinate / Lix advice scoped**: Determinate's `determinate-nixd` and Lix's CLI diverge from upstream in subtle places. Name the lane before suggesting daemon or CLI flags.
+- [ ] **Diagnostic errors are not silenced**: do not hide useful output with `2>/dev/null` when the error text is the evidence. Use `2>&1 || true` when gathering.
+- [ ] **Version pins justified**: if a pinned `system.stateVersion` is suggested, explain why; do not change `stateVersion` on an existing system casually - it controls migration semantics.
+
+---
+
+## Workflow
+
+### Step 1: Identify the Nix lane first
+
+| Lane | Default stance | What changes |
+|------|----------------|--------------|
+| **NixOS installed (stable 25.11)** | configuration.nix or flake.nix drives everything | full system is Nix-managed; rollbacks via bootloader |
+| **NixOS unstable / 26.05 pre-release** | treat as rolling-ish | expect breakage; verify options still exist |
+| **Nix on non-NixOS Linux** | user-level only | host distro still owns services and boot; no `nixos-rebuild` |
+| **nix-darwin on macOS** | declarative macOS config | `darwin-rebuild switch`; host owns kernel and firmware |
+| **Plain Nix on macOS (no darwin)** | package manager only | `nix profile` or `nix shell` for user tooling |
+| **WSL2 with NixOS** | full NixOS in WSL | boot and init differ; host owns kernel |
+| **Determinate Nix** | flakes on by default, daemon differs | `determinate-nixd`, parallel eval, lazy trees |
+| **Lix** | upstream-compatible fork | CLI mostly matches; internals, error messages, and Meson build diverge |
+
+### Step 2: Gather current system state
+
+Start narrow. Widen only when the failing layer is still unclear.
+
+Baseline checks for every NixOS or Nix case:
+
+```bash
+# Identify OS and Nix lane
+cat /etc/os-release 2>&1 || true
+nix --version
+command -v nixos-version >/dev/null 2>&1 && nixos-version
+command -v darwin-version >/dev/null 2>&1 && darwin-version
+command -v determinate-nixd >/dev/null 2>&1 && determinate-nixd status
+uname -a
+
+# Nix config and features
+nix config show 2>&1 | grep -E 'experimental-features|extra-experimental|substituters|trusted-users' || true
+cat /etc/nix/nix.conf 2>&1 || true
+
+# NixOS-specific
+[[ -d /etc/nixos ]] && ls /etc/nixos
+[[ -f /etc/nixos/flake.nix ]] && echo "flakes system" || echo "channels system (or flake elsewhere)"
+command -v nix-channel >/dev/null 2>&1 && nix-channel --list 2>&1 || true
+command -v nixos-rebuild >/dev/null 2>&1 && nixos-rebuild --help 2>&1 | head -5
+
+# Generations and boot
+command -v nix-env >/dev/null 2>&1 && nix-env --list-generations -p /nix/var/nix/profiles/system 2>&1 | tail -5 || true
+[[ -d /boot/loader/entries ]] && ls /boot/loader/entries 2>&1 | tail -10
+command -v bootctl >/dev/null 2>&1 && bootctl status 2>&1 | head -20 || true
+
+# Store health and GC state
+df -h /nix/store
+du -sh /nix/store 2>&1 || true
+nix-store --gc --print-roots 2>&1 | wc -l
+```
+
+Add subsystem probes only when the task needs them:
+
+```bash
+# home-manager
+command -v home-manager >/dev/null 2>&1 && home-manager generations | head -5
+
+# flake state
+[[ -f flake.nix ]] && nix flake metadata 2>&1 | head -20
+[[ -f flake.lock ]] && nix flake check --no-build 2>&1 || true
+
+# services and logs (NixOS)
+systemctl --failed 2>&1 || true
+journalctl -b -p warning..alert 2>&1 | tail -30 || true
+
+# hardware (NixOS)
+lspci -k 2>&1 | grep -Ei 'vga|3d|display|network' || true
+journalctl -b 2>&1 | grep -Ei 'nvrm|nvidia|amdgpu|i915|xe|drm|firmware' || true
+```
+
+### Step 3: Load only the relevant reference
+
+| Task type | Reference |
+|-----------|-----------|
+| configuration.nix, modules, options, assertions, `mkForce`/`mkMerge` | `references/configuration-and-modules.md` |
+| flakes, inputs, lockfile, `nix flake`, registry, input follows | `references/flakes-and-channels.md` |
+| `nixos-rebuild` verbs, generations, rollback, boot entries, dry-activate | `references/rebuild-generations-and-rollback.md` |
+| home-manager (standalone, NixOS module, nix-darwin module) | `references/home-manager-and-darwin.md` |
+| overlays, `overrideAttrs`, `override`, packaging, `mkDerivation`, patching | `references/overlays-packaging-and-overrides.md` |
+| Nix store, `nix-store`, GC roots, `nix-collect-garbage`, optimise-store, CAS | `references/store-gc-and-builders.md` |
+| dev shells, `nix develop`, `shell.nix`, direnv with `nix-direnv` | `references/dev-shells-and-direnv.md` |
+| disko, impermanence, nixos-anywhere, SD/ISO images, nixos-generators | `references/disko-impermanence-and-imaging.md` |
+| hardware, firmware, kernels, nixos-hardware, GPU drivers, Wayland desktop | `references/hardware-desktop-and-kernel.md` |
+| secrets: sops-nix, agenix, activation decryption, keyrings | `references/secrets-sops-and-agenix.md` |
+| Determinate Nix, Lix, lane-specific behavior, migration notes | `references/determinate-lix-and-lanes.md` |
+| recurring NixOS and Nix footguns, edge cases, upgrade breakage | `references/gotchas-and-special-situations.md` |
+
+Do not load every reference by default. Pick the one that matches the failure mode.
+
+### Step 3.5: Stay here or hand off
+
+| Request shape | Route |
+|---------------|-------|
+| NixOS install, module, flake, rebuild, rollback, store, overlay, disko, secrets | stay in **nixos-btw** |
+| Build a Docker or OCI image from Nix (`dockerTools`, `nix2container`) | stay here for the Nix build, hand to **docker** for runtime |
+| Deploy a NixOS box into K8s (`nixos-in-kube`, custom images) | start here, hand to **kubernetes** for the cluster side |
+| Review Nix-produced container for OWASP / supply chain issues | stay for the Nix build; use **security-audit** for the audit |
+| Write a bash one-liner or zsh function that wraps `nix` calls | use **command-prompt** |
+
+### Step 4: Change one layer at a time
+
+- Fix flake or channel state before blaming `nixos-rebuild`.
+- Run `nixos-rebuild dry-activate --flake .#host` before `switch` when the risk is nonzero.
+- Prefer `test` over `switch` when the change might break login; `test` does not persist the boot entry, so a reboot returns to a known-good generation.
+- Fix option-name drift before blaming module logic: `nix repl -f '<nixpkgs/nixos>' -I ...` and `:p config.services.foo` beat guessing.
+- On home-manager, run `home-manager switch` separately if it is standalone; otherwise `nixos-rebuild switch` picks it up when it is wired as a module.
+- Avoid touching `system.stateVersion`. It anchors migration semantics.
+- Keep overlays composable: scope to `final: prev: { ... }`, not mutating `pkgs` in-place.
+- Validate before GC: `nix-store --gc --print-roots | grep <path>` before deleting.
+
+### Step 5: Validate before closing
+
+```bash
+# System state
+nixos-version 2>&1 || true
+nix-env --list-generations -p /nix/var/nix/profiles/system | tail -5
+systemctl --failed 2>&1 || true
+
+# Flake sanity
+[[ -f flake.nix ]] && nix flake check --no-build
+
+# Store sanity
+nix-store --verify --check-contents 2>&1 | tail -20
+df -h /nix/store
+```
+
+Reboot only when the boot path is understood and at least one known-good generation remains.
+
+---
+
+## Troubleshooting Pattern
+
+Keep triage cross-layer and boring:
+
+1. Confirm the Nix lane (NixOS vs Nix-on-host, flakes vs channels, Determinate vs upstream vs Lix).
+2. Identify the failing layer: input state, evaluation, build, activation, or runtime service.
+3. Pull the right logs before changing config.
+4. Change one layer at a time and retest.
+5. Prefer rollback to reinstall. Generations are the whole point.
+
+Core log sweep on NixOS:
+
+```bash
+journalctl -b -p warning..alert
+journalctl --user -b
+dmesg --level=err,warn
+journalctl -u nix-daemon -b
+journalctl -u nixos-rebuild -b 2>&1 || true
+```
+
+Build and eval failures are loudest in the rebuild output itself; pipe through `--show-trace`
+and, for opaque errors, `--print-build-logs`:
+
+```bash
+nixos-rebuild switch --flake .#host --show-trace --print-build-logs 2>&1 | tail -200
+```
+
+When a problem looks "flake-only," compare one clean baseline:
+
+- delete `flake.lock` and re-lock, or
+- roll one input back to its previous rev via `nix flake lock --override-input`, or
+- build the same output on another machine with the same `flake.lock` to isolate hardware vs config.
+
+---
+
+## Default Decisions
+
+- **Declarative first.** `nix-env -i`, `nix profile install`, and one-off `nixpkgs.config` tweaks are escape hatches, not workflows. If it survives across rebuilds, it belongs in the config.
+- **Flakes when the user already has them.** Do not migrate users off channels mid-troubleshoot. Do not migrate users onto flakes without naming tradeoffs (still experimental upstream, lockfile commits become a habit, registry overrides differ).
+- **Generations are the rollback.** Before debugging, confirm the previous generation boots. That is cheaper than chasing ghosts.
+- **Store hygiene is boring and scheduled.** Enable `nix.gc.automatic` and `nix.settings.auto-optimise-store = true;` rather than manual sweeps.
+- **home-manager has three modes.** Standalone, NixOS module, nix-darwin module. Pick one per host and stay there.
+- **nix-darwin is opinionated.** macOS system settings, LaunchDaemons, and Homebrew coexistence are what it owns. Do not treat it like NixOS with a different kernel.
+- **Disko and impermanence are declarative recovery.** They shine on fresh installs and nixos-anywhere deploys; retrofitting them onto a live system is a different, harder problem.
+- **Secrets never go in the store.** Use sops-nix or agenix with activation-time decryption.
+- **Pick Determinate or Lix intentionally.** Both are fine; both add behavior that diverges from upstream Nix in small but real ways. Name the lane.
+- **Kernel changes are cross-layer.** ZFS, NVIDIA, hardened kernel, and custom initrd modules all interact. Do not swap `boot.kernelPackages` casually.
+
+---
+
+## Quick Triage Checklist
+
+| Symptom | First checks |
+|---------|-------------|
+| `nixos-rebuild` evaluation error | `--show-trace`, check option name against the current nixpkgs tag, check `imports` paths |
+| Build fails mid-derivation | `--print-build-logs`, check sandbox violations, check unfree or insecure gates |
+| Boot drops to emergency shell | previous generation from bootloader menu, check `hardware-configuration.nix`, LUKS, kernel modules |
+| Flake input won't update | `nix flake lock --update-input <name>`, check `inputs.<x>.follows`, check registry override |
+| System is huge, `/nix/store` fills disk | `nix-collect-garbage -d`, `nix-store --optimise`, prune generations, check direnv GC roots |
+| `nix-env -i` installed something that won't stick | user profile vs system config; move to `environment.systemPackages` or `home.packages` |
+| home-manager drift vs NixOS | standalone vs module mode, which one owns the file, `home-manager switch` vs `nixos-rebuild switch` |
+| Unfree package refuses to build | `nixpkgs.config.allowUnfree = true;` or predicate, or `NIXPKGS_ALLOW_UNFREE=1 nix-build --impure` for one-off |
+| Secrets in a module show up world-readable | moved to sops-nix/agenix and re-deploy; rotate the exposed secrets |
+| ZFS or NVIDIA breaks after kernel bump | `boot.kernelPackages = pkgs.linuxPackages_<pin>;` or wait for out-of-tree module to rebuild |
+| nix-darwin change did not apply | `darwin-rebuild switch`, not `nixos-rebuild`; check `users.users.<name>.home` and `nix.enable` |
+| Nothing makes sense | check gotchas reference - channel vs flake mixing, stale lock, overlay collisions, GC of an active dev shell |
+
+---
+
+## Reference Files
+
+- `references/configuration-and-modules.md` - `/etc/nixos/configuration.nix`, modules, options, assertions, `mkMerge` and `mkForce`, NixOS module system
+- `references/flakes-and-channels.md` - flakes, `flake.nix` anatomy, inputs and outputs, `flake.lock`, `nix flake` verbs, channels vs flakes vs npins
+- `references/rebuild-generations-and-rollback.md` - `nixos-rebuild` verbs, generations, `nix-env --list-generations`, bootloader entries, rollback flow
+- `references/home-manager-and-darwin.md` - home-manager (standalone, NixOS module, nix-darwin module), nix-darwin system configuration on macOS
+- `references/overlays-packaging-and-overrides.md` - overlays, `overrideAttrs`, `override`, `callPackage`, writing derivations, patching upstream
+- `references/store-gc-and-builders.md` - Nix store, `nix-store` vs `nix store`, GC roots, `nix-collect-garbage`, optimise-store, remote builders, Cachix and attic
+- `references/dev-shells-and-direnv.md` - `nix-shell`, `nix develop`, `shell.nix`, `default.nix`, flake dev shells, `nix-direnv`, per-project env
+- `references/disko-impermanence-and-imaging.md` - disko partitioning, impermanence, nixos-anywhere, SD/ISO images with nixos-generators
+- `references/hardware-desktop-and-kernel.md` - nixos-hardware, kernel selection, firmware, GPU drivers, Wayland and X11, display managers
+- `references/secrets-sops-and-agenix.md` - sops-nix, agenix, activation-time decryption, age key management, avoiding store-world-readable secrets
+- `references/determinate-lix-and-lanes.md` - Determinate Nix (enterprise lane, daemon differences, flakes-on-by-default), Lix (compat-focused fork), coexistence
+- `references/gotchas-and-special-situations.md` - recurring NixOS and Nix failure patterns and edge cases
+
+---
+
+## Related Skills
+
+- **arch-btw** - Arch and CachyOS administration. Use it when the host is Arch-family and Nix is a side tool, not the system.
+- **debian-ubuntu** - Debian-family administration. Use it when Nix runs on Debian/Ubuntu as a user-level package manager only.
+- **rhel-fedora** - RHEL-family administration. Use it when Nix runs on Fedora/RHEL as a user-level package manager only.
+- **kali-linux** - Kali distro workflow. Use it for Kali, not for Nix inside Kali.
+- **command-prompt** - shell syntax, aliases, and one-liners outside Nix expressions.
+- **docker** - container runtime and image concerns. This skill builds images with `dockerTools`; **docker** runs them.
+- **kubernetes** - cluster workloads once the build output leaves Nix.
+- **ansible** - fleet config management when Nix is not the chosen tool for the job.
+- **terraform** - IaC for cloud resources that host NixOS VMs; this skill owns the guest.
+- **security-audit** - defensive review of a Nix-built artifact.
+- **update-docs** - sync docs after substantial module or flake restructuring.
+
+---
+
+## Rules
+
+1. **Identify the Nix lane before prescribing commands.** NixOS vs Nix-on-host, channels vs flakes, Determinate vs upstream vs Lix, standalone vs module home-manager - all change the answer.
+2. **Declarative beats imperative.** If the fix is `nix-env -i`, reach for `environment.systemPackages`, `home.packages`, or `nix shell` instead. Hidden profile state is a footgun.
+3. **Know the rebuild verb.** `switch`, `test`, `boot`, `dry-activate`, `build-vm`, and `build` are not interchangeable. `test` does not persist across reboot; `boot` does not activate now.
+4. **Preserve a known-good generation.** Never GC aggressively right after a rebuild. Boot the new generation twice before pruning.
+5. **Flakes are intentional.** Enable `nix-command flakes` where the user already uses them; do not push migration during troubleshooting.
+6. **GC roots are real state.** Dev shells, direnv caches, and CI pins hold them. Check before mass deletion.
+7. **Secrets never in the store.** Use sops-nix or agenix with activation-time decryption; anything else ends up world-readable in `/nix/store`.
+8. **Module options must exist in the user's nixpkgs tag.** 23.11/24.05/24.11/25.05/25.11 drift is real; confirm with `nix repl` or the options search before recommending.
+9. **Overlays compose, not mutate.** `final: prev: { ... }` scope. Do not recommend global profile-level overlays on flake systems.
+10. **Kernel and initrd agree.** Do not flip `boot.kernelPackages` on ZFS, NVIDIA, or custom-module systems without a fallback.
+11. **Do not touch `system.stateVersion` casually.** It controls migration semantics and is not a "version bump" field.
+12. **Disko and impermanence are install-time decisions.** Retrofit is a different, harder conversation.
+13. **home-manager mode is sticky.** Pick standalone, NixOS module, or darwin module per host and stay there.
+14. **Determinate and Lix diverge at the edges.** Name the lane before suggesting daemon or CLI flags.
+15. **Reach for common Nix failure patterns before exotic explanations.** Channel/flake mixing, stale lock, overlay collision, option drift, GC of an active dev shell, and unfree/insecure gates explain a large share of the chaos.

--- a/skills/nixos-btw/references/configuration-and-modules.md
+++ b/skills/nixos-btw/references/configuration-and-modules.md
@@ -1,0 +1,204 @@
+# configuration.nix and the NixOS module system
+
+NixOS is a module system written in Nix. `configuration.nix` is one module; everything you
+import is one too. A module has three things that matter: `imports`, `options`, and `config`.
+
+## /etc/nixos layout
+
+A traditional channel-based install:
+
+```
+/etc/nixos/
+├── configuration.nix       # entry module
+└── hardware-configuration.nix  # generated, do not hand-edit
+```
+
+A flake-based install:
+
+```
+/etc/nixos/
+├── flake.nix
+├── flake.lock
+├── configuration.nix
+├── hardware-configuration.nix
+└── modules/
+    ├── desktop.nix
+    ├── networking.nix
+    └── users.nix
+```
+
+Keep `hardware-configuration.nix` as-generated. Regenerate with
+`nixos-generate-config --root /mnt` during install or `nixos-generate-config` in place.
+
+## Minimal configuration.nix
+
+```nix
+{ config, pkgs, lib, ... }:
+
+{
+  imports = [ ./hardware-configuration.nix ];
+
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  networking.hostName = "box";
+  networking.networkmanager.enable = true;
+
+  time.timeZone = "Europe/Amsterdam";
+  i18n.defaultLocale = "en_US.UTF-8";
+
+  services.openssh.enable = true;
+  services.openssh.settings.PasswordAuthentication = false;
+
+  users.users.alice = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" "networkmanager" ];
+    openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAA..." ];
+  };
+
+  environment.systemPackages = with pkgs; [
+    git vim ripgrep fd jq htop
+  ];
+
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+  nix.settings.auto-optimise-store = true;
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 30d";
+  };
+
+  system.stateVersion = "25.11";  # do not change after first install
+}
+```
+
+## Module anatomy
+
+Every NixOS module conforms to:
+
+```nix
+{ config, pkgs, lib, ... }:
+
+{
+  imports = [ ];           # other modules to import
+  options = { ... };       # options this module declares
+  config  = { ... };       # option values this module sets
+
+  # sugar: if the module sets config and nothing else, drop "config = {}" and inline it.
+}
+```
+
+Declare your own option for a reusable module:
+
+```nix
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.my.services.status;
+in {
+  options.my.services.status = {
+    enable = mkEnableOption "custom status service";
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      description = "Port to listen on.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.status = {
+      description = "Status";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.my-status}/bin/status --port ${toString cfg.port}";
+        DynamicUser = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+      };
+    };
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+  };
+}
+```
+
+## mkMerge, mkForce, mkDefault, mkIf, mkOverride
+
+- `mkDefault value` - lowest precedence; loses to any explicit set
+- normal assignment - standard precedence
+- `mkForce value` - overrides other modules' values
+- `mkOverride prio value` - numeric precedence (lower wins; `mkForce` is 50, `mkDefault` is 1000)
+- `mkIf cond attrs` - include the block only when `cond` is true
+- `mkMerge [ ... ]` - combine multiple partial config blocks
+
+```nix
+{
+  services.nginx.enable = mkDefault true;           # caller may override
+  services.nginx.package = mkForce pkgs.nginxMainline; # caller may not override
+  environment.systemPackages = mkMerge [
+    [ pkgs.git ]
+    (mkIf config.services.postgresql.enable [ pkgs.postgresql ])
+  ];
+}
+```
+
+## Assertions and warnings
+
+Fail fast at eval time instead of producing a broken system:
+
+```nix
+{
+  assertions = [
+    {
+      assertion = config.services.openssh.enable ->
+                  !config.services.openssh.settings.PasswordAuthentication;
+      message = "SSH password auth must be disabled when openssh is enabled.";
+    }
+  ];
+
+  warnings = lib.optional (config.networking.hostName == "nixos")
+    "hostname is the install default 'nixos' - consider changing.";
+}
+```
+
+## Option types
+
+The common ones:
+
+| Type | Example |
+|------|---------|
+| `bool` | `true` or `false` |
+| `int`, `port` | `8080` |
+| `str`, `path` | `"/var/lib/app"` or `./config.toml` |
+| `enum [ "a" "b" ]` | one of the listed strings |
+| `listOf <type>` | `[ "x" "y" ]` |
+| `attrsOf <type>` | `{ key = value; ... }` |
+| `submodule { options = { ... }; }` | structured nested options |
+| `nullOr <type>` | the type or `null` |
+| `either a b` | `a` or `b` |
+
+## Exploring options
+
+The fastest lookups:
+
+```bash
+# Web: https://search.nixos.org/options
+nix repl
+> :lf /etc/nixos  # load a flake
+> :p config.services.nginx.enable
+
+# Option docs from the CLI (slow but offline)
+nixos-option services.openssh.enable 2>&1 || true
+nix-instantiate --eval -E '(import <nixpkgs/nixos> { configuration = ./configuration.nix; }).options.services.openssh.enable.description'
+```
+
+## Common mistakes
+
+- Editing `hardware-configuration.nix` by hand. Regenerate instead.
+- Using `mkForce` when `mkDefault` in the other module would be the right fix.
+- Putting secrets directly in module strings; they land in `/nix/store` world-readable. Use
+  sops-nix or agenix.
+- Setting `system.stateVersion` to the current release on an existing system. It locks
+  migration behavior; leave the first-install value alone.
+- Writing circular `imports` - the module system resolves lazily but circular references on
+  `config.<x>` still deadlock evaluation.

--- a/skills/nixos-btw/references/determinate-lix-and-lanes.md
+++ b/skills/nixos-btw/references/determinate-lix-and-lanes.md
@@ -1,0 +1,172 @@
+# Determinate Nix, Lix, and lanes
+
+Three Nix CLI/daemon implementations coexist: upstream Nix (NixOS/nix), Determinate Nix
+(DeterminateSystems/nix), and Lix (lix-project/lix). They are API-compatible for most
+workflows but diverge at the edges. Name the lane before suggesting daemon flags, daemon
+service names, or CLI behaviors that differ.
+
+## Upstream Nix
+
+- Repo: [NixOS/nix](https://github.com/NixOS/nix)
+- Maintainers: NixOS Foundation contributors
+- Flakes: behind `experimental-features = nix-command flakes`
+- Latest stable: 2.33 (Dec 2025), 2.32 (Oct 2025)
+- Release cadence: roughly 6 weeks
+
+This is what ships in `nixos` for every standard NixOS release.
+
+## Determinate Nix
+
+- Repo: [DeterminateSystems/nix-installer](https://github.com/DeterminateSystems/nix-installer)
+- Docs: [docs.determinate.systems](https://docs.determinate.systems/determinate-nix/)
+- Downstream distribution of upstream Nix with validated backports and feature work
+- Flakes and `nix-command` enabled by default
+- Daemon: `determinate-nixd` (not `nix-daemon`)
+- Features: parallel evaluation, lazy trees, native Linux builder for macOS
+- SOC 2 Type II-validated release process; defined CVE process
+
+Install path: Determinate Installer. Works on Linux, macOS, and WSL. On NixOS, you
+typically do not swap the in-system Nix for Determinate; Determinate shines on non-NixOS
+hosts and developer machines.
+
+### Determinate-specific commands
+
+```bash
+determinate-nixd status           # daemon health
+determinate-nixd version
+determinate-nixd upgrade          # updates Determinate Nix
+```
+
+On macOS, the Determinate installer manages the daemon via a LaunchDaemon rather than the
+upstream Nix daemon.
+
+### When to recommend Determinate
+
+- macOS daily driver wanting flakes-on-by-default without editing `nix.conf`
+- Enterprise environments that need a validated CVE response path
+- Teams needing cross-compilation macOS <-> Linux without a separate Linux build box
+
+### When to stay with upstream
+
+- Inside NixOS, upstream is the integrated path
+- CI that already has a working upstream pipeline
+- Tooling that expects `nix-daemon` by name
+
+## Lix
+
+- Repo: [lix-project/lix](https://git.lix.systems/lix-project/lix)
+- Fork of Nix focused on correctness, compatibility, and a healthier community governance
+  model
+- Build system: Meson (upstream Nix still uses autotools)
+- Community-driven; independent of both the NixOS Foundation and Determinate Systems
+- Mostly CLI- and daemon-compatible with upstream Nix
+
+### Notable Lix traits
+
+- Improved error messages, especially for eval traces
+- Backported fixes and performance improvements that stalled upstream
+- Uses `nix-daemon` like upstream (unlike Determinate's `determinate-nixd`)
+- Co-installable with upstream for experimentation in most cases
+
+### When to recommend Lix
+
+- Dissatisfaction with upstream governance and community direction
+- Better error messages during heavy module development
+- A desire for backward-compatibility focus over feature experimentation
+
+### When to stay with upstream or Determinate
+
+- Paid support or enterprise compliance (Determinate)
+- Default NixOS install experience (upstream)
+- Tooling strictly tested against one of the other two
+
+## Coexistence and switching
+
+### Installer collisions
+
+If you ran the Determinate Installer and later want to switch to Lix, uninstall
+Determinate first:
+
+```bash
+/nix/nix-installer uninstall
+```
+
+Then run the Lix installer or the upstream install script. Mixing installers rarely ends
+well.
+
+### On NixOS
+
+NixOS installs upstream Nix by default. Some users switch to Lix with:
+
+```nix
+{
+  nix.package = pkgs.lix;
+}
+```
+
+(Only when the `lix` package exists in the user's nixpkgs; check with
+`nix search nixpkgs lix`.)
+
+Switching to Determinate on NixOS is less common - Determinate targets non-NixOS hosts.
+
+### On macOS (nix-darwin)
+
+```nix
+# pick one
+{ nix.package = pkgs.nix; }         # upstream
+{ nix.package = pkgs.lix; }         # Lix
+# Determinate: use the Determinate installer, skip nix-darwin's nix management
+```
+
+## Lane-specific gotchas
+
+### Determinate
+
+- Some documentation and tooling assumes `nix-daemon` as the service name. On Determinate,
+  the daemon is `determinate-nixd`.
+- The Determinate store may be initialized with options that upstream does not set; reading
+  `nix config show` before assuming defaults is wise.
+- `determinate-nixd upgrade` is separate from a NixOS `nixos-rebuild switch`; it upgrades
+  the Determinate binary itself.
+- On macOS after a system upgrade, macOS may block the daemon. Reinstall via the
+  Determinate installer or run the repair command.
+
+### Lix
+
+- Some packaged tools hardcode `/nix/var/nix/daemon-socket/socket` expectations; Lix keeps
+  the same path so most work.
+- Eval differences from upstream are rare but real; when a flake evaluates on upstream but
+  fails on Lix (or vice versa), the trace is the quickest path to the cause.
+- Binary caches signed with upstream keys still work on Lix.
+
+### Upstream
+
+- Flakes default to experimental; users must opt in.
+- Release cadence is slower than Determinate's feature velocity.
+- Community-driven issue response; no defined SLA.
+
+## Checking which lane you are on
+
+```bash
+nix --version
+# upstream prints "nix (Nix) 2.33.x"
+# Lix prints "nix (Lix, like Nix) 2.93.x" (Lix versioning is independent)
+# Determinate prints a Determinate-specific version string
+
+command -v determinate-nixd >/dev/null && echo "Determinate present"
+
+# daemon check (Linux)
+systemctl status nix-daemon 2>&1 || true
+systemctl status determinate-nixd 2>&1 || true
+```
+
+## Common mistakes
+
+- Recommending `nix-daemon` restart commands on a Determinate system (wrong service name).
+- Assuming Lix has a flake behavior difference it does not. Lix and upstream agree on
+  flake semantics; start troubleshooting elsewhere.
+- Mixing installers. Pick one, uninstall cleanly, then install the other.
+- Using Determinate on NixOS expecting nix-darwin-style benefits. Determinate's value is
+  loudest on macOS and non-NixOS Linux.
+- Conflating "Lix is a fork" with "Lix is incompatible." It is largely compatible; the
+  divergence is in governance, build system, and feature prioritization.

--- a/skills/nixos-btw/references/dev-shells-and-direnv.md
+++ b/skills/nixos-btw/references/dev-shells-and-direnv.md
@@ -1,0 +1,214 @@
+# Dev shells and direnv
+
+Per-project reproducible environments are one of Nix's practical wins. The old way is
+`shell.nix`; the new way is `flake.nix` dev shells. Pair either with `nix-direnv` for
+transparent `cd`-to-activate behavior.
+
+## Classic shell.nix
+
+```nix
+# shell.nix
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  packages = with pkgs; [
+    go_1_24
+    golangci-lint
+    protobuf
+    sqlite
+  ];
+
+  shellHook = ''
+    export CGO_ENABLED=0
+    echo "go dev shell ready"
+  '';
+}
+```
+
+```bash
+nix-shell            # enter the shell
+nix-shell --run make # run a command inside it
+nix-shell -p ripgrep # ad-hoc one-off
+```
+
+`nix-shell -p <pkg>` is the fastest "install this for this terminal only" - no profile
+pollution, no state.
+
+## Flake dev shells
+
+```nix
+{
+  description = "my project";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+  outputs = { self, nixpkgs }:
+  let
+    forAllSystems = f: nixpkgs.lib.genAttrs
+      [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]
+      (system: f (import nixpkgs { inherit system; }));
+  in {
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [ rustup cargo pkg-config openssl ];
+        RUST_BACKTRACE = "1";
+      };
+      python = pkgs.mkShell {
+        packages = with pkgs; [ python3 python3.pkgs.pip python3.pkgs.ruff ];
+      };
+    });
+  };
+}
+```
+
+```bash
+nix develop            # enter default dev shell
+nix develop .#python   # alternate
+nix develop --command make  # run inside without a subshell
+```
+
+### Flake dev shells with flake-utils or flake-parts
+
+To avoid the per-system boilerplate, use `flake-utils.lib.eachDefaultSystem` or
+`flake-parts`. Both shrink the outputs block substantially.
+
+```nix
+# flake-utils
+inputs.flake-utils.url = "github:numtide/flake-utils";
+outputs = { nixpkgs, flake-utils, ... }:
+  flake-utils.lib.eachDefaultSystem (system:
+  let pkgs = nixpkgs.legacyPackages.${system}; in {
+    devShells.default = pkgs.mkShell { packages = [ pkgs.go ]; };
+  });
+```
+
+## direnv + nix-direnv
+
+`direnv` loads a per-directory shell env on `cd`. `nix-direnv` teaches direnv about Nix dev
+shells and caches them so repeated `cd` is instant and survives garbage collection via GC
+roots.
+
+### Install (NixOS)
+
+```nix
+{
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;  # caches nix-shell / nix develop output
+  };
+}
+```
+
+### Install (home-manager)
+
+```nix
+{
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+    enableZshIntegration = true;    # or bash/fish equivalents
+  };
+}
+```
+
+### Per-project `.envrc`
+
+For classic shell.nix:
+
+```bash
+# .envrc
+use nix
+```
+
+For a flake dev shell:
+
+```bash
+# .envrc
+use flake
+# or a specific shell
+use flake .#python
+```
+
+Enable the env once per new directory:
+
+```bash
+direnv allow
+```
+
+### direnv cache
+
+`nix-direnv` caches the result in `.direnv/`. That directory holds GC roots so the cached
+closure does not disappear on `nix-collect-garbage`. Add `.direnv/` to `.gitignore`.
+
+If a cache becomes stale (you changed `shell.nix` or a flake input):
+
+```bash
+direnv reload
+```
+
+## Dev-shell hygiene
+
+- Pin inputs. Channels-based `<nixpkgs>` drifts silently.
+- Do not mutate `result` symlinks from `nix build` inside a dev shell; the shell tracks
+  its own closure.
+- Prefer `nix develop` inside a project with a flake. `nix-shell` still works but it relies
+  on `NIX_PATH`.
+- Separate build tooling from runtime config: `nativeBuildInputs` vs `packages` / env.
+- For language-specific workflows, stay close to the language's real tooling:
+  - Rust: `rustup` inside a shell is fine. `fenix` or `rust-overlay` gives per-project
+    pinned toolchains.
+  - Python: `poetry2nix` or `uv2nix` convert lockfiles to flakes; otherwise `mkShell` with
+    a Python interpreter and overrides.
+  - Node: `buildNpmPackage` needs a hash; for dev shells, `nodePackages` + local
+    `package.json` via `npm ci` is often simpler.
+  - Go: `buildGoModule` for shipping; dev shell just needs `go` and tooling.
+
+## Patterns
+
+### Multi-language project
+
+```nix
+devShells.default = pkgs.mkShell {
+  packages = with pkgs; [
+    go_1_24
+    nodejs_22
+    python3
+    python3.pkgs.pip
+    postgresql_17
+    docker-compose
+    jq fd ripgrep
+  ];
+  shellHook = ''
+    export PGDATA=$PWD/.pgdata
+    [[ -d $PGDATA ]] || initdb -D $PGDATA
+  '';
+};
+```
+
+### Project-specific overlays in the dev shell
+
+```nix
+let
+  overlays = [ (import ./overlays/dev.nix) ];
+  pkgs = import nixpkgs { inherit system overlays; };
+in {
+  devShells.default = pkgs.mkShell { packages = [ pkgs.my-patched-tool ]; };
+}
+```
+
+### `nix run` and `nix shell`
+
+- `nix run nixpkgs#ripgrep -- pattern file` - fetch, run, done
+- `nix shell nixpkgs#{ripgrep,fd,bat}` - ephemeral multi-tool shell
+- `nix run .#` - run the flake's default app
+
+## Common mistakes
+
+- Forgetting `direnv allow`; the `.envrc` will be silently skipped.
+- `.direnv/` committed to git. Add it to `.gitignore`.
+- Using `nix-shell` on a flakes-first project where `nix develop` is the intended path.
+- Baking secrets into `shellHook`. Use `.envrc` or a secrets manager (sops-nix for shared
+  project state).
+- Forgetting to add `pkg-config` and language-specific header packages (`openssl.dev`, etc.)
+  when a native extension build fails.
+- Expecting the dev shell's packages to be on `PATH` outside the shell. They are scoped to
+  the shell session (or direnv-loaded directory).

--- a/skills/nixos-btw/references/disko-impermanence-and-imaging.md
+++ b/skills/nixos-btw/references/disko-impermanence-and-imaging.md
@@ -1,0 +1,277 @@
+# Disko, impermanence, nixos-anywhere, and imaging
+
+NixOS can own the disk layout, the persistence model, and the install process
+declaratively. This reference covers disko (declarative partitioning), impermanence
+(root-on-tmpfs), nixos-anywhere (remote install over SSH), and image generators.
+
+## disko
+
+[disko](https://github.com/nix-community/disko) describes disks as a Nix expression and
+applies them via a single command. Replaces the imperative `parted`/`mkfs` dance.
+
+### Minimal LUKS + btrfs example
+
+```nix
+# disko-config.nix
+{ ... }:
+
+{
+  disko.devices = {
+    disk.main = {
+      device = "/dev/nvme0n1";
+      type = "disk";
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            size = "1G";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              mountOptions = [ "umask=0077" ];
+            };
+          };
+          luks = {
+            size = "100%";
+            content = {
+              type = "luks";
+              name = "cryptroot";
+              settings.allowDiscards = true;
+              content = {
+                type = "btrfs";
+                extraArgs = [ "-L" "nixos" ];
+                subvolumes = {
+                  "/root"     = { mountpoint = "/";      mountOptions = [ "compress=zstd" "noatime" ]; };
+                  "/home"     = { mountpoint = "/home";  mountOptions = [ "compress=zstd" "noatime" ]; };
+                  "/nix"      = { mountpoint = "/nix";   mountOptions = [ "compress=zstd" "noatime" ]; };
+                  "/persist"  = { mountpoint = "/persist"; mountOptions = [ "compress=zstd" "noatime" ]; };
+                  "/log"      = { mountpoint = "/var/log"; mountOptions = [ "compress=zstd" "noatime" ]; };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}
+```
+
+### Apply on a live ISO
+
+```bash
+# from a NixOS installer or live image
+nix --experimental-features "nix-command flakes" run github:nix-community/disko -- \
+  --mode destroy,format,mount \
+  --flake .#box
+nixos-install --flake .#box
+reboot
+```
+
+`--mode destroy,format,mount` wipes and applies; use `--mode mount` for re-mount-only after
+an existing disk is already formatted to disko spec.
+
+Wire the disko config into the NixOS config:
+
+```nix
+# flake.nix
+nixosConfigurations.box = nixpkgs.lib.nixosSystem {
+  modules = [
+    disko.nixosModules.disko
+    ./disko-config.nix
+    ./configuration.nix
+  ];
+};
+```
+
+## Impermanence
+
+Root-on-tmpfs: wipe `/` on every boot, keep only what you explicitly persist. Makes the
+system stateless-by-default, forces state to be declared.
+
+Two popular approaches:
+
+1. **tmpfs root** - `/` is `tmpfs`; every boot starts clean. `/nix` and `/persist` are real
+   filesystems that survive.
+2. **btrfs snapshot-on-boot** - `/` is a real btrfs subvolume, wiped to a blank snapshot at
+   boot by an early-stage unit. Survives more gracefully when things go wrong mid-boot.
+
+### btrfs snapshot-wipe example
+
+```nix
+# early in initrd
+boot.initrd.postDeviceCommands = lib.mkAfter ''
+  mkdir -p /mnt
+  mount -o subvol=/ /dev/mapper/cryptroot /mnt
+  btrfs subvolume list -o /mnt/root | cut -f9 -d' ' | \
+    while read sub; do btrfs subvolume delete "/mnt/$sub"; done
+  btrfs subvolume delete /mnt/root
+  btrfs subvolume snapshot /mnt/root-blank /mnt/root
+  umount /mnt
+'';
+```
+
+(Create `/root-blank` once after the first install:
+`btrfs subvolume snapshot -r /mnt/root /mnt/root-blank`.)
+
+### impermanence module
+
+[nix-community/impermanence](https://github.com/nix-community/impermanence) declares which
+directories and files must persist across the wipe:
+
+```nix
+{
+  environment.persistence."/persist" = {
+    hideMounts = true;
+    directories = [
+      "/etc/NetworkManager/system-connections"
+      "/var/lib/bluetooth"
+      "/var/lib/systemd/coredump"
+      "/var/log"
+      { directory = "/var/lib/colord"; user = "colord"; group = "colord"; mode = "u=rwx,g=rx,o="; }
+    ];
+    files = [
+      "/etc/machine-id"
+      "/etc/ssh/ssh_host_ed25519_key"
+      "/etc/ssh/ssh_host_ed25519_key.pub"
+      "/etc/ssh/ssh_host_rsa_key"
+      "/etc/ssh/ssh_host_rsa_key.pub"
+    ];
+    users.alice = {
+      directories = [ ".ssh" ".config/foo" "Documents" "Downloads" ];
+      files = [ ".zsh_history" ];
+    };
+  };
+}
+```
+
+### What to persist
+
+- SSH host keys (else clients get a key-change warning every boot)
+- Machine ID (`/etc/machine-id` - some systemd services key off it)
+- Network state if NetworkManager
+- Bluetooth pairings
+- Printer config if CUPS/colord is used
+- User home bits that actually need to persist
+
+### Gotchas
+
+- Forgetting to persist SSH host keys makes every boot look like a MITM from the client
+  side. Persist them or regenerate and redistribute.
+- TimeSync state on fresh boot: `/var/lib/systemd/timers` and `/var/lib/chrony` may need to
+  persist.
+- docker / podman state under `/var/lib/docker` - persist if containers matter.
+- Persist too much and you lose the point; persist too little and apps break every boot.
+
+## nixos-anywhere
+
+Installs NixOS on a remote machine over SSH, including disk formatting via disko.
+
+**Preconditions:**
+
+1. Target booted into something with SSH access (vendor rescue, live ISO, or an existing
+   Linux) and `kexec` available - nixos-anywhere reboots into a kexec'd installer.
+2. Flake wired with `disko.nixosModules.disko`, a `./disko-config.nix` matching the target
+   disk, and a working `nixosConfigurations.<host>`.
+3. SSH reachability from workstation to target with a key that reaches root (directly or
+   via `sudo`). Local `.ssh/config` entry saves typing.
+
+Then:
+
+```bash
+nix run github:nix-community/nixos-anywhere -- \
+  --flake .#box \
+  --target-host root@1.2.3.4
+```
+
+What it does:
+
+1. SSHes in, boots the remote into a kexec'd NixOS installer
+2. Runs disko to partition and format
+3. Runs `nixos-install` with the flake
+4. Reboots into the new system
+
+Cheap replace-in-place for cloud hosts, VPS, or bare metal with kexec support. Pair with
+sops-nix or agenix so secrets land on first boot.
+
+### When to use
+
+- Cloud VMs where disko controls the layout
+- Bare metal with remote KVM access, kexec available
+- Fleet installs driven by CI
+
+### When not to use
+
+- Machines without kexec support
+- Windows-booted machines you cannot safely wipe
+- First time with disko; iterate locally in a VM first
+
+## Image generators
+
+[nixos-generators](https://github.com/nix-community/nixos-generators) builds a single
+system image for a target format:
+
+```bash
+nix run github:nix-community/nixos-generators -- \
+  --format iso \
+  --configuration ./configuration.nix \
+  --out-link result
+```
+
+Common formats:
+
+| Format | Output | Use |
+|--------|--------|-----|
+| `iso` | live ISO | install media, rescue |
+| `sd-aarch64` | raw SD image | Raspberry Pi |
+| `qcow` | QEMU qcow2 | libvirt VMs |
+| `virtualbox` | OVA | VirtualBox |
+| `vmware` | VMDK | VMware |
+| `amazon` | AMI | EC2 |
+| `gce` | tarball | GCE |
+| `azure` | VHD | Azure |
+| `docker` | image | containers |
+| `install-iso` | installer ISO with custom config | one-shot installs |
+
+### SD images for ARM
+
+```bash
+nix build ./#nixosConfigurations.rpi4.config.system.build.sdImage
+zstd -d result/sd-image/nixos-sd-image-*.img.zst
+sudo dd if=nixos-sd-image-*.img of=/dev/sdX bs=4M status=progress conv=fsync
+```
+
+### Docker images from Nix
+
+`dockerTools.buildLayeredImage` produces an OCI tarball with minimal layers:
+
+```nix
+{ pkgs, ... }:
+
+pkgs.dockerTools.buildLayeredImage {
+  name = "my-app";
+  tag = "latest";
+  contents = [ pkgs.cacert pkgs.myApp ];
+  config = {
+    Cmd = [ "/bin/my-app" ];
+    ExposedPorts."8080/tcp" = {};
+  };
+}
+```
+
+`nix build .#dockerImage && docker load < result` uploads it into your local daemon. For
+K8s or registry use, push the tarball directly.
+
+## Common mistakes
+
+- Running disko on the wrong device. Double-check `lsblk` and device names before running
+  with `--mode destroy`.
+- Impermanence without persisting SSH host keys - breaks client trust.
+- Impermanence persisting `/var` wholesale - defeats the point; persist specific paths.
+- nixos-anywhere on a machine without kexec support - it fails at step one.
+- Image generators silently producing a working image with stale inputs because flakes were
+  not committed. Commit before building.
+- Building a Docker image from Nix but forgetting `cacert` in `contents` - the container
+  then cannot validate TLS.

--- a/skills/nixos-btw/references/flakes-and-channels.md
+++ b/skills/nixos-btw/references/flakes-and-channels.md
@@ -1,0 +1,240 @@
+# Flakes and channels
+
+Two ways to point a NixOS system at a specific `nixpkgs`. Flakes pin explicitly via a
+lockfile; channels pin implicitly via whatever `nix-channel --update` last fetched.
+
+## Channels (the older way)
+
+```bash
+sudo nix-channel --list
+sudo nix-channel --add https://nixos.org/channels/nixos-25.11 nixos
+sudo nix-channel --update
+sudo nixos-rebuild switch
+```
+
+- `nixos` - system channel used by `nixos-rebuild`
+- `nixpkgs` - user-level channel for `nix-env`, `nix-shell`
+- `home-manager` - if using standalone home-manager
+
+`nixos-rebuild` reads `<nixpkgs>` from the system channel. Mixing stable and unstable
+channels without intent causes version drift that is hard to trace.
+
+## Flakes (the newer, de-facto standard)
+
+Flakes require `experimental-features = nix-command flakes` in `nix.conf`. Determinate Nix
+enables this by default; upstream Nix does not.
+
+### Minimal flake.nix for a NixOS host
+
+```nix
+{
+  description = "box";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager/release-25.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, home-manager, ... }@inputs:
+  {
+    nixosConfigurations.box = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      specialArgs = { inherit inputs; };
+      modules = [
+        ./configuration.nix
+        home-manager.nixosModules.home-manager
+        {
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          home-manager.users.alice = import ./home.nix;
+        }
+      ];
+    };
+  };
+}
+```
+
+### Rebuild from a flake
+
+```bash
+sudo nixos-rebuild switch --flake /etc/nixos#box
+# or from inside the flake directory:
+sudo nixos-rebuild switch --flake .#box
+```
+
+### Package outputs, multi-host, and `perSystem`
+
+Adding package outputs alongside `nixosConfigurations` - `nix build .#my-tool` consumes
+these directly:
+
+```nix
+outputs = { self, nixpkgs, ... }:
+let
+  forAllSystems = f: nixpkgs.lib.genAttrs
+    [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]
+    (system: f (import nixpkgs { inherit system; }));
+in {
+  packages = forAllSystems (pkgs: {
+    my-tool = pkgs.callPackage ./pkgs/my-tool { };
+    default = self.packages.${pkgs.system}.my-tool;
+  });
+
+  nixosConfigurations = nixpkgs.lib.genAttrs [ "web1" "web2" "db1" ] (host:
+    nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      specialArgs = { inherit inputs; };
+      modules = [
+        ./modules/common.nix        # shared across all hosts
+        ./hosts/${host}             # host-specific directory
+      ];
+    });
+};
+```
+
+The fleet layout pairs with this:
+
+```
+.
+|-- flake.nix
+|-- modules/common.nix
+`-- hosts/
+    |-- web1/{default.nix,hardware-configuration.nix}
+    |-- web2/{default.nix,hardware-configuration.nix}
+    `-- db1/{default.nix,hardware-configuration.nix}
+```
+
+For less boilerplate, `flake-parts` exposes `perSystem` for package outputs and
+`flake.nixosConfigurations` for systems in the same outputs block.
+
+### Channels to flakes migration
+
+Migrating a working channel-based NixOS install to flakes without breaking it:
+
+1. Back up `/etc/nixos`: `sudo cp -a /etc/nixos /etc/nixos.bak`.
+2. Enable experimental features system-wide in the current `configuration.nix`:
+   `nix.settings.experimental-features = [ "nix-command" "flakes" ];`, then
+   `sudo nixos-rebuild switch` once on the channel path so the daemon picks them up.
+3. Initialize git in `/etc/nixos` (flakes evaluate only tracked files):
+   `sudo git -C /etc/nixos init && sudo git -C /etc/nixos add .`.
+4. Write `flake.nix` wrapping the existing module:
+   ```nix
+   {
+     inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+     outputs = { self, nixpkgs }: {
+       nixosConfigurations.box = nixpkgs.lib.nixosSystem {
+         system = "x86_64-linux";
+         modules = [ ./configuration.nix ];
+       };
+     };
+   }
+   ```
+5. Commit the flake: `sudo git -C /etc/nixos add flake.nix && sudo git -C /etc/nixos commit -m init`.
+6. Apply safely - `boot` stages for next boot without activating now:
+   `sudo nixos-rebuild boot --flake /etc/nixos#box`. Reboot.
+7. Verify: `nixos-version`, `systemctl --failed`, and test logins. If broken, pick the
+   previous generation in the bootloader menu.
+8. Once stable, remove the channel to prevent drift:
+   `sudo nix-channel --remove nixos && sudo nix-channel --update`.
+
+### Common flake verbs
+
+```bash
+nix flake metadata                 # show input URLs and revs from flake.lock
+nix flake update                   # update all inputs and write flake.lock
+nix flake lock --update-input nixpkgs  # update one input
+nix flake check                    # eval all outputs, run checks
+nix flake check --no-build         # eval without building - fast sanity check
+nix flake show                     # show outputs tree
+```
+
+### Input follows
+
+Use `follows` to deduplicate transitive `nixpkgs` copies:
+
+```nix
+inputs = {
+  nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  home-manager = {
+    url = "github:nix-community/home-manager/release-25.11";
+    inputs.nixpkgs.follows = "nixpkgs";    # use our nixpkgs, not theirs
+  };
+  sops-nix = {
+    url = "github:Mic92/sops-nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+};
+```
+
+Without `follows`, each input drags its own `nixpkgs`. Your closure bloats and cache hits
+drop.
+
+### flake.lock
+
+`flake.lock` is JSON, committed to git. Every input has a locked `rev` and `narHash`. It is
+not a lockfile of packages; it is a lockfile of input trees. Builds are reproducible because
+every evaluation starts from locked input trees.
+
+## Channels vs flakes, practical tradeoffs
+
+| Property | Channels | Flakes |
+|----------|----------|--------|
+| Pinning | implicit, per `nix-channel --update` | explicit via `flake.lock` |
+| Reproducibility across machines | weak | strong |
+| CI story | requires pinning tools (niv, npins) | native |
+| Stability upstream | stable | still experimental (default-on in Determinate) |
+| `NIX_PATH` required | yes | no |
+| Registry | irrelevant | central via `nix registry` |
+| Migration cost | low | moderate, new mental model |
+
+If the user already has flakes, keep them. If they are on channels and content, do not push
+migration during a troubleshooting session.
+
+## Alternatives to flakes without flakes
+
+- **[npins](https://github.com/andir/npins)** - lock file for channel users without enabling
+  flakes. Pins git sources declaratively.
+- **[niv](https://github.com/nmattia/niv)** - predecessor to npins, still widely seen in
+  older projects.
+
+Both produce a JSON file with locked revs and hashes, read via a small Nix helper.
+
+## Registry
+
+Flakes support a user and system registry of short names. `nixpkgs` resolves to the pinned
+flake by default:
+
+```bash
+nix registry list            # show active entries
+nix registry add foo github:org/repo
+nix registry pin foo         # pin to current resolved rev
+nix registry remove foo
+```
+
+## Pure vs impure evaluation
+
+Flakes default to **pure evaluation**: no access to env vars, `NIX_PATH`, or the user's home
+without `--impure`. Some patterns need impurity:
+
+```bash
+NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#vscode
+```
+
+Prefer setting `nixpkgs.config.allowUnfree = true;` in the flake output instead of reaching
+for `--impure` every time.
+
+## Common footguns
+
+- Forgetting to `git add flake.nix` and `flake.lock` before `nixos-rebuild --flake .#host`.
+  Flakes evaluate inside a pure sandbox that only sees tracked files.
+- Running `nix flake update` alongside an unrelated change and committing both together -
+  hard to review. Keep input bumps in their own commit.
+- Enabling flakes on the Nix daemon but not also on the user - missing
+  `experimental-features` in `~/.config/nix/nix.conf`.
+- Mixing `nixos-unstable` and `nixos-25.11` inputs without `follows` - you get two
+  `nixpkgs` trees and surprising collisions.
+- Assuming `nix flake check` builds everything. Use `nix flake check --keep-going` to see
+  all failures and `--no-build` for a fast eval-only sanity pass.

--- a/skills/nixos-btw/references/gotchas-and-special-situations.md
+++ b/skills/nixos-btw/references/gotchas-and-special-situations.md
@@ -1,0 +1,247 @@
+# Recurring NixOS and Nix gotchas
+
+The failures that explain most "why is this broken?" sessions. Work through the top of the
+list first; exotic causes come after the boring ones are ruled out.
+
+## Channels vs flakes drift
+
+Symptom: `nixos-rebuild switch` uses an older `nixpkgs` than the user expects, or vice
+versa.
+
+Cause: the system is on channels but the user thinks they are on flakes, or `flake.nix`
+exists but `nixos-rebuild` is run without `--flake`.
+
+Fix:
+- Confirm by `cat /etc/nixos/flake.nix` and `nix-channel --list`.
+- If flakes: always use `nixos-rebuild --flake .#host`.
+- If channels: `sudo nix-channel --update` before rebuild.
+- Do not run both paths on the same machine unless you know why.
+
+## Stale flake.lock
+
+Symptom: upstream shipped a fix; a rebuild still produces the old behavior.
+
+Cause: `flake.lock` pins the input at the old rev.
+
+Fix:
+```bash
+nix flake update                               # update all inputs
+nix flake lock --update-input nixpkgs          # just one
+nix flake metadata                             # confirm revs
+```
+
+Commit the lock change in its own commit.
+
+## `nix-env -i` polluting the user profile
+
+Symptom: a tool is installed, it works, but it does not appear in `configuration.nix` and
+survives `nixos-rebuild switch --rollback`.
+
+Cause: `nix-env -i` installs into `~/.nix-profile`, which is separate state from system
+generations.
+
+Fix:
+```bash
+nix-env -q                       # what is there
+nix-env -e '*'                   # wipe the user profile
+# Then add the packages to environment.systemPackages or home.packages.
+```
+
+## Options that no longer exist
+
+Symptom: `error: The option 'services.foo.bar' does not exist.`
+
+Cause: option was renamed or removed between NixOS releases.
+
+Fix:
+```bash
+# Search the current release
+nix repl
+> :lf nixpkgs
+> options.services.foo.<TAB>
+
+# Check release notes for renames
+# https://nixos.org/manual/nixos/stable/release-notes.html
+```
+
+Many renames provide a deprecation warning for one release, then fail outright in the next.
+
+## Overlay collision
+
+Symptom: two overlays both redefine the same package; the second wins but silently, and the
+first overlay's intent is lost.
+
+Cause: overlays run left-to-right. A later overlay's `final: prev: { pkg = ... }` replaces
+earlier definitions unless it composes via `prev.pkg`.
+
+Fix: if both overlays should layer, call `prev.pkg.overrideAttrs` in the later overlay so
+it sees the earlier changes.
+
+## `hardware-configuration.nix` out of sync
+
+Symptom: after moving a disk, rebuilding with a new SSD, or switching filesystems, the
+system boots to emergency shell or cannot find root.
+
+Fix:
+```bash
+sudo nixos-generate-config --root /   # regenerates hardware-configuration.nix
+```
+
+Never hand-edit UUIDs in `hardware-configuration.nix`. Regenerate.
+
+## Kernel swap killed out-of-tree modules
+
+Symptom: after `boot.kernelPackages = pkgs.linuxPackages_latest;`, NVIDIA or ZFS fails.
+
+Cause: the new kernel's module set in nixpkgs does not include (yet) a build for NVIDIA or
+ZFS.
+
+Fix:
+- Roll back the generation.
+- Pin to `linuxPackages_<version>` that has module coverage.
+- For ZFS, use `boot.zfs.package.latestCompatibleLinuxPackages` as a safer source (the attribute path has moved across releases - verify with `nix repl` against your nixpkgs tag).
+
+## GC nuked a dev shell
+
+Symptom: `direnv reload` triggers a long rebuild of a previously cached shell.
+
+Cause: `nix-collect-garbage -d` removed paths whose GC root had been cleaned (e.g., the
+`.direnv/` symlinks rotated or the `result` symlink got deleted).
+
+Fix:
+- Re-enter the shell; it rebuilds or re-fetches.
+- For projects you care about, keep the dev shell registered: `nix develop --profile
+  .direnv/nix-profile` or rely on `nix-direnv` which registers GC roots under `.direnv/`.
+
+## `--impure` creep
+
+Symptom: something only builds with `--impure`. A week later, five commands need it.
+
+Cause: the config is reading env vars, `NIX_PATH`, or host files that flakes' pure eval
+disallows.
+
+Fix:
+- Identify the impure read; move its value into `specialArgs` or a flake input.
+- For unfree packages, set `nixpkgs.config.allowUnfree = true;` rather than relying on
+  `NIXPKGS_ALLOW_UNFREE=1 nix ... --impure`.
+
+## Secrets ended up in the store
+
+Symptom: `/nix/store/<hash>-config.json` contains a password in plaintext.
+
+Cause: `environment.etc."foo.json".text = ''{...}''` with a secret interpolated, or
+`builtins.readFile ./secret.txt`.
+
+Fix:
+- Rotate the secret immediately.
+- Move to sops-nix or agenix; reference `config.sops.secrets.<name>.path` instead of
+  interpolating the value.
+
+## `nix flake check` passes, `nixos-rebuild` fails
+
+Symptom: flake check green, rebuild red.
+
+Cause: `nix flake check` builds default system outputs but may skip complex targets; or a
+system-level activation script fails at `switch-to-configuration`, not at build.
+
+Fix:
+- Run `nixos-rebuild dry-activate --flake .#host --show-trace` to see the activation step.
+- Inspect `journalctl -b` from a previous attempt for failing systemd units.
+
+## systemd-boot entry spam
+
+Symptom: the bootloader menu has 50 entries.
+
+Fix:
+```nix
+boot.loader.systemd-boot.configurationLimit = 20;
+```
+
+Then `sudo nix-collect-garbage -d` removes the underlying generations and their entries.
+
+## `sops-nix` or `agenix` not decrypting on first boot
+
+Symptom: services that need a secret fail to start.
+
+Cause: the host's age key is missing (first install) or the secret was not re-keyed after
+a host key rotation.
+
+Fix:
+- Confirm `/etc/ssh/ssh_host_ed25519_key` exists.
+- `sops updatekeys` or `agenix -r` if keys rotated.
+- Verify the decrypted file appears in `/run/secrets/<name>` or `/run/agenix/<name>`
+  after activation.
+
+## Determinate `nix-daemon` commands fail
+
+Symptom: `systemctl restart nix-daemon` says "unit not found" on a Determinate install.
+
+Cause: the daemon is `determinate-nixd`, not `nix-daemon`.
+
+Fix:
+```bash
+sudo systemctl restart determinate-nixd
+determinate-nixd status
+```
+
+## Home-manager file already exists
+
+Symptom: `home-manager switch` fails with "cannot overwrite existing file".
+
+Cause: a real file exists at a path home-manager wants to manage.
+
+Fix:
+- Set `home-manager.backupFileExtension = "hm-bak";` (NixOS module) to auto-backup.
+- Or delete the conflicting file and rerun.
+
+## nix-darwin: macOS defaults not applied
+
+Symptom: `system.defaults.dock.autohide = true;` set, but Dock still shows.
+
+Fix:
+- Run `killall Dock` or log out and back in; some defaults need the consuming service
+  restart.
+- Confirm `darwin-rebuild switch` (not `nixos-rebuild`) ran and reported success.
+- Some settings are per-user; scope to the right `users.users.<name>` block.
+
+## Rebuild succeeds, service fails to start
+
+Symptom: build green, boot entry created, unit crashes post-activation.
+
+Fix:
+```bash
+journalctl -u <unit> -b --no-pager | tail -100
+systemd-analyze verify /etc/systemd/system/<unit>.service 2>&1 || true
+```
+
+Common causes: missing env var, wrong user, read-only filesystem assumption, service
+running in sandbox that blocks a path.
+
+## Cache miss cascade
+
+Symptom: every rebuild is slow; builds from source that you thought would substitute.
+
+Cause: a substituter is unreachable, a public key is missing, or the user is a non-trusted
+user invoking builds the daemon cannot substitute.
+
+Fix:
+```bash
+nix config show | grep -E 'substituters|trusted'
+curl -sSf https://cache.nixos.org/nix-cache-info | head
+nix store ping --store https://cache.nixos.org
+```
+
+Add the user to `nix.settings.trusted-users` if they run flakes with untrusted
+substituters.
+
+## Things that look broken but are not
+
+- `/etc/resolv.conf` is a symlink into `/run/NetworkManager/...` or systemd-resolved. Do
+  not hand-edit; configure via the NixOS module instead.
+- `/home/<user>` not owned by the user after adding them to `configuration.nix` - user
+  creation copies default files; home contents still need migration from the previous
+  user.
+- `ls /etc` looks sparse compared to other distros. Most `/etc` paths are symlinks into
+  `/nix/store`.
+- `sudo` asks for your password even after editing sudoers in Nix - it works, `/etc/sudoers`
+  is regenerated each rebuild.

--- a/skills/nixos-btw/references/hardware-desktop-and-kernel.md
+++ b/skills/nixos-btw/references/hardware-desktop-and-kernel.md
@@ -1,0 +1,318 @@
+# Hardware, desktop, and kernels
+
+NixOS ships more kernel choices than most distros and needs explicit modules for some
+hardware paths. `nixos-hardware` carries community profiles; the bundled modules handle
+common cases.
+
+## Picking a kernel
+
+`boot.kernelPackages` is the knob. Defaults to the latest LTS that nixpkgs tracks at the
+release's branch point. NixOS 25.11 defaults to Linux 6.12 LTS; `pkgs.linuxPackages_latest`
+tracks mainline (6.17 at the 25.11 branch, bumped in-branch as mainline advances - Linux
+6.18 is an LTS tagged late 2025 and lands under explicit `pkgs.linuxPackages_6_18` once it
+is backported to the release branch).
+
+```nix
+{
+  # latest stable (tracks nixpkgs, moves with rebuilds)
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  # specific version (pin for stability)
+  boot.kernelPackages = pkgs.linuxPackages_6_12;   # LTS
+
+  # hardened kernel variant
+  boot.kernelPackages = pkgs.linuxPackages_hardened;
+
+  # zen / liquorix / custom - use overlays or nixpkgs options
+  boot.kernelPackages = pkgs.linuxPackages_zen;
+}
+```
+
+Kernel changes drag every out-of-tree module with them: NVIDIA, ZFS, `v4l2loopback`, DKMS
+in general. Before flipping kernels, confirm the modules build against the new kernel in
+the nixpkgs tag you are on.
+
+### Kernel modules and parameters
+
+```nix
+{
+  boot.kernelModules = [ "kvm-amd" "vfio-pci" ];
+  boot.blacklistedKernelModules = [ "nouveau" ];
+  boot.extraModprobeConfig = ''
+    options kvm_amd nested=1
+    options snd-hda-intel power_save=1
+  '';
+  boot.kernelParams = [ "mitigations=auto" "nvidia-drm.modeset=1" ];
+}
+```
+
+### initrd modules
+
+```nix
+{
+  boot.initrd.availableKernelModules = [ "nvme" "ahci" "xhci_pci" "usb_storage" ];
+  boot.initrd.kernelModules = [ "dm_mod" "btrfs" ];
+}
+```
+
+Needed for LUKS, ZFS, rare storage controllers, or unusual root filesystems. Regenerate
+`hardware-configuration.nix` via `nixos-generate-config` after changing hardware.
+
+## nixos-hardware
+
+[nixos-hardware](https://github.com/NixOS/nixos-hardware) carries vendor-specific modules
+for laptops and SBCs. Import the profile that matches the hardware:
+
+```nix
+# flake.nix
+inputs.nixos-hardware.url = "github:NixOS/nixos-hardware/master";
+
+# configuration.nix
+{ inputs, ... }:
+{
+  imports = [
+    inputs.nixos-hardware.nixosModules.framework-13-7040-amd
+    # or: lenovo-thinkpad-x1-extreme
+    # or: dell-xps-13-9310
+    # or: raspberry-pi-4
+  ];
+}
+```
+
+Profiles cover firmware, kernel params, power management, GPU quirks, and occasionally
+audio routing or sensors.
+
+## Firmware
+
+Non-Redistributable firmware is under `linux-firmware` but requires `allowUnfree`:
+
+```nix
+{
+  nixpkgs.config.allowUnfree = true;
+  hardware.enableAllFirmware = true;
+  hardware.enableRedistributableFirmware = true;
+  services.fwupd.enable = true;  # vendor firmware updates via fwupd
+}
+```
+
+## GPU
+
+### Intel
+
+```nix
+{
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;           # for Steam, older apps
+    extraPackages = with pkgs; [ intel-media-driver intel-vaapi-driver vpl-gpu-rt ];
+  };
+}
+```
+
+### AMD
+
+Modern AMDGPU "just works" with Mesa:
+
+```nix
+{
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;
+    extraPackages = with pkgs; [ rocmPackages.clr.icd amdvlk ];
+  };
+  services.xserver.videoDrivers = [ "amdgpu" ];   # if using X
+}
+```
+
+### NVIDIA
+
+Proprietary driver path. Tricky but well-documented:
+
+```nix
+{
+  services.xserver.videoDrivers = [ "nvidia" ];
+  hardware.nvidia = {
+    modesetting.enable = true;
+    open = false;                     # set true for open-source kernel modules on supported GPUs
+    nvidiaSettings = true;
+    package = config.boot.kernelPackages.nvidiaPackages.stable;
+    powerManagement.enable = true;
+    powerManagement.finegrained = false;
+  };
+  hardware.graphics.enable = true;
+  hardware.graphics.enable32Bit = true;
+}
+```
+
+Driver branches: `stable`, `beta`, `production`, `legacy_*`, `vulkan_beta`. Pick the branch
+that matches the card. Tesla-era cards need legacy; Turing+ use stable or production.
+
+### Hybrid graphics (laptops)
+
+```nix
+{
+  hardware.nvidia.prime = {
+    offload.enable = true;
+    offload.enableOffloadCmd = true;
+    intelBusId = "PCI:0:2:0";     # check lspci
+    nvidiaBusId = "PCI:1:0:0";
+  };
+}
+```
+
+Or `sync.enable = true;` for always-on dGPU, or `reverseSync.enable = true;` for the
+external-displays-off-dGPU pattern.
+
+## Desktop: Wayland vs X11
+
+NixOS carries both. Pick by session type and compositor.
+
+### GNOME (Wayland default)
+
+```nix
+{
+  services.xserver.enable = true;
+  services.xserver.displayManager.gdm.enable = true;
+  services.xserver.desktopManager.gnome.enable = true;
+}
+```
+
+### KDE Plasma 6
+
+```nix
+{
+  services.xserver.enable = true;
+  services.displayManager.sddm.enable = true;
+  services.desktopManager.plasma6.enable = true;
+}
+```
+
+### Hyprland
+
+```nix
+{
+  programs.hyprland.enable = true;
+  xdg.portal = {
+    enable = true;
+    extraPortals = [ pkgs.xdg-desktop-portal-hyprland pkgs.xdg-desktop-portal-gtk ];
+  };
+}
+```
+
+### niri, sway, river
+
+Each has a top-level `programs.<name>` option. Enable the compositor and an appropriate
+portal.
+
+## Steam, Gamescope, and gaming
+
+```nix
+{
+  programs.steam = {
+    enable = true;
+    remotePlay.openFirewall = true;
+    dedicatedServer.openFirewall = false;
+    gamescopeSession.enable = true;
+    extraCompatPackages = with pkgs; [ proton-ge-bin ];
+  };
+  programs.gamescope.enable = true;
+  programs.gamemode.enable = true;
+
+  # 32-bit graphics userspace is required for most Steam titles
+  hardware.graphics.enable32Bit = true;
+}
+```
+
+Proton lives in Steam; DXVK and VKD3D ride with Proton. For Proton-GE or custom runners,
+`extraCompatPackages` or `protonup` via home-manager handles the install.
+
+## Screen capture on Wayland
+
+Wayland screen capture on Hyprland, Plasma 6, or GNOME uses the
+`xdg-desktop-portal` + PipeWire screencast path - not X11 window capture. OBS reads the
+portal via `pipewire` source, and browsers use `xdg-desktop-portal`'s screencast prompt.
+
+```nix
+{
+  xdg.portal = {
+    enable = true;
+    extraPortals = [ pkgs.xdg-desktop-portal-hyprland pkgs.xdg-desktop-portal-gtk ];
+  };
+  services.pipewire.enable = true;   # must be true; see PipeWire block below
+
+  environment.systemPackages = with pkgs; [
+    obs-studio
+    (obs-studio.override { plugins = [ obs-studio-plugins.obs-pipewire-audio-capture ]; })
+  ];
+}
+```
+
+If OBS only shows a black screen, confirm `XDG_SESSION_TYPE=wayland`,
+`xdg-desktop-portal-hyprland` is installed, and the capture source in OBS is "Screen
+Capture (PipeWire)" - not "Screen Capture (X11)".
+
+## PipeWire (audio, capture)
+
+```nix
+{
+  security.rtkit.enable = true;
+  services.pipewire = {
+    enable = true;
+    alsa.enable = true;
+    alsa.support32Bit = true;
+    pulse.enable = true;
+    jack.enable = true;            # if you need JACK apps
+    wireplumber.enable = true;
+  };
+  services.pulseaudio.enable = false;  # ensure PA is off when PW is on
+}
+```
+
+## Fonts
+
+```nix
+{
+  fonts.packages = with pkgs; [
+    noto-fonts noto-fonts-cjk-sans noto-fonts-emoji
+    liberation_ttf
+    jetbrains-mono
+    fira-code fira-code-symbols
+  ];
+  fonts.fontDir.enable = true;
+}
+```
+
+## Input
+
+```nix
+{
+  services.libinput.enable = true;
+  services.libinput.touchpad.tapping = true;
+  services.libinput.touchpad.naturalScrolling = true;
+
+  console.keyMap = "us";
+  services.xserver.xkb.layout = "us";
+}
+```
+
+## Bluetooth
+
+```nix
+{
+  hardware.bluetooth.enable = true;
+  hardware.bluetooth.powerOnBoot = true;
+  services.blueman.enable = true;   # GUI manager on non-GNOME/KDE
+}
+```
+
+## Common mistakes
+
+- Changing `boot.kernelPackages` on ZFS or NVIDIA systems without checking module
+  availability in the new kernel. Out-of-tree modules lag.
+- Editing `hardware-configuration.nix` by hand to tweak UUIDs. Regenerate instead.
+- Forgetting `hardware.graphics.enable32Bit = true;` for Steam and 32-bit Vulkan.
+- NVIDIA on Wayland without `modesetting.enable = true;`. The session may come up but
+  compositors will struggle.
+- Enabling PulseAudio *and* PipeWire's pulse shim at once. Disable PA explicitly.
+- Importing a `nixos-hardware` laptop profile that does not match your exact SKU. Profiles
+  are specific; the wrong one sets kernel params that break other SKUs.

--- a/skills/nixos-btw/references/home-manager-and-darwin.md
+++ b/skills/nixos-btw/references/home-manager-and-darwin.md
@@ -1,0 +1,245 @@
+# home-manager and nix-darwin
+
+home-manager manages user-level configuration declaratively. nix-darwin does the same for
+macOS system settings. Both compose with NixOS or run standalone.
+
+## home-manager: three modes
+
+| Mode | Activated by | Rebuild command | When to pick |
+|------|--------------|-----------------|--------------|
+| **Standalone** | user runs `home-manager switch` | `home-manager switch` | host is not NixOS, or user wants decoupled lifecycle |
+| **NixOS module** | wired into `configuration.nix` | `nixos-rebuild switch` | host is NixOS; user wants single deploy |
+| **nix-darwin module** | wired into `darwin-configuration.nix` | `darwin-rebuild switch` | host is macOS with nix-darwin |
+
+Pick one per host and stay there. Mixing standalone and module mode on the same user
+produces silent overwrites.
+
+### Standalone home-manager (channels)
+
+```bash
+nix-channel --add https://github.com/nix-community/home-manager/archive/release-25.11.tar.gz home-manager
+nix-channel --update
+nix-shell '<home-manager>' -A install
+```
+
+Then `~/.config/home-manager/home.nix`:
+
+```nix
+{ config, pkgs, ... }:
+
+{
+  home.username = "alice";
+  home.homeDirectory = "/home/alice";
+  home.stateVersion = "25.11";
+
+  home.packages = with pkgs; [
+    ripgrep fd bat eza jq htop
+  ];
+
+  programs.git = {
+    enable = true;
+    userName = "Alice";
+    userEmail = "alice@example.com";
+    extraConfig.pull.rebase = true;
+  };
+
+  programs.zsh = {
+    enable = true;
+    autosuggestion.enable = true;
+    syntaxHighlighting.enable = true;
+  };
+
+  home.file.".config/foo/config.toml".text = ''
+    bar = "baz"
+  '';
+}
+```
+
+Rebuild:
+
+```bash
+home-manager switch
+home-manager generations
+home-manager switch --rollback
+```
+
+### Standalone home-manager (flakes)
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    home-manager = {
+      url = "github:nix-community/home-manager/release-25.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, ... }: {
+    homeConfigurations."alice@box" = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      modules = [ ./home.nix ];
+    };
+  };
+}
+```
+
+```bash
+home-manager switch --flake .#alice@box
+```
+
+### home-manager as NixOS module
+
+In `configuration.nix` or one of its imports:
+
+```nix
+{ home-manager, ... }:
+
+{
+  imports = [ home-manager.nixosModules.home-manager ];
+
+  home-manager.useGlobalPkgs = true;
+  home-manager.useUserPackages = true;
+  home-manager.backupFileExtension = "hm-bak";
+
+  home-manager.users.alice = { config, pkgs, ... }: {
+    home.stateVersion = "25.11";
+    programs.zsh.enable = true;
+    home.packages = with pkgs; [ ripgrep fd ];
+  };
+}
+```
+
+Then `nixos-rebuild switch` applies both system and home.
+
+`useGlobalPkgs = true` reuses the NixOS nixpkgs instance instead of instantiating another.
+
+### home-manager as nix-darwin module
+
+Identical shape, different entry point:
+
+```nix
+{
+  imports = [ home-manager.darwinModules.home-manager ];
+  home-manager.users.alice = { pkgs, ... }: {
+    home.stateVersion = "25.11";
+    home.packages = with pkgs; [ ripgrep fd bat jq python312 ];
+    programs.direnv = {
+      enable = true;
+      nix-direnv.enable = true;
+      enableZshIntegration = true;
+    };
+    programs.starship.enable = true;
+    programs.git = {
+      enable = true;
+      userName = "Alice";
+      userEmail = "alice@example.com";
+    };
+  };
+}
+```
+
+Then `darwin-rebuild switch`. Pair with a per-project `flake.nix` dev shell (see
+`references/dev-shells-and-direnv.md`) and a `.envrc` containing `use flake` so direnv
+loads the shell on `cd`.
+
+## nix-darwin: declarative macOS
+
+nix-darwin brings NixOS-style modules to macOS. It manages packages, LaunchDaemons, macOS
+defaults, fonts, and some system services. It does not replace macOS or the kernel.
+
+### Install (flakes)
+
+```bash
+sudo nix run nix-darwin/nix-darwin-25.11#darwin-rebuild -- switch --flake ~/.config/nix-darwin
+```
+
+### Minimal darwin flake
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nix-darwin.url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nix-darwin, nixpkgs }: {
+    darwinConfigurations."mbp" = nix-darwin.lib.darwinSystem {
+      system = "aarch64-darwin";
+      modules = [ ./configuration.nix ];
+    };
+  };
+}
+```
+
+### Darwin configuration.nix highlights
+
+```nix
+{ config, pkgs, ... }:
+
+{
+  environment.systemPackages = with pkgs; [ git coreutils jq ];
+
+  # enable the nix-darwin-managed nix daemon
+  nix.enable = true;
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+  # macOS defaults, declaratively
+  system.defaults.dock.autohide = true;
+  system.defaults.finder.AppleShowAllExtensions = true;
+  system.defaults.NSGlobalDomain.AppleInterfaceStyle = "Dark";
+
+  # Homebrew coexists via nix-darwin's brew integration
+  homebrew = {
+    enable = true;
+    onActivation.cleanup = "zap";
+    brews = [ "mas" ];
+    casks = [ "firefox" "raycast" ];
+  };
+
+  # required
+  system.stateVersion = 6;
+  programs.zsh.enable = true;
+}
+```
+
+`darwin-rebuild switch --flake ~/.config/nix-darwin#mbp` applies.
+
+## nix-darwin gotchas
+
+- Apple Silicon is `aarch64-darwin`; Intel is `x86_64-darwin`. Rosetta is available but
+  costs rebuilds.
+- `nix.enable = true` (newer) replaces `services.nix-daemon.enable = true` (older). Pick
+  one; the release notes tell you which.
+- macOS security occasionally blocks the Nix daemon after an OS upgrade. Reinstall the
+  Determinate installer or re-run the uninstall/reinstall dance if `nix` goes missing.
+- Homebrew via `homebrew = { enable = true; ... }` uses the actual Homebrew binary; nix-darwin
+  only orchestrates it. Casks are not sandboxed by Nix.
+- macOS defaults written by nix-darwin apply on next login for some keys; `killall cfprefsd`
+  nudges them.
+- `system.stateVersion` on darwin is an integer, unlike NixOS.
+
+## Picking a mode by scenario
+
+| Scenario | Mode |
+|----------|------|
+| NixOS workstation, one user owns the box | home-manager as NixOS module |
+| NixOS workstation with many users, each self-managing | standalone home-manager per user |
+| macOS daily driver, declarative dotfiles | nix-darwin + home-manager as darwin module |
+| macOS laptop, just want Nix for packages | plain Nix + `nix profile`, no nix-darwin |
+| Non-NixOS Linux host, Nix as user tool | standalone home-manager |
+| WSL2 NixOS | home-manager as NixOS module, same as NixOS |
+
+## Common mistakes
+
+- Running `home-manager switch` on a system where home-manager is wired as a NixOS module.
+  The module mode overwrites the standalone state on the next `nixos-rebuild switch`.
+- Putting machine-level concerns (boot, kernel, systemd system units) in home-manager. Those
+  belong in `configuration.nix`.
+- Forgetting `backupFileExtension` on the NixOS module - without it, activation fails when a
+  file it would manage already exists.
+- Nix-darwin `launchd` units that assume Linux paths. macOS has its own service paths and
+  environment.
+- Treating nix-darwin like NixOS with a different kernel. It is a shim over macOS, not a
+  replacement.

--- a/skills/nixos-btw/references/overlays-packaging-and-overrides.md
+++ b/skills/nixos-btw/references/overlays-packaging-and-overrides.md
@@ -1,0 +1,256 @@
+# Overlays, overrides, and writing packages
+
+When you need a package that nixpkgs does not carry, a different version than what is
+cached, or a patch upstream will not take - overlays, overrides, and hand-written
+derivations are the toolbox.
+
+## `override` vs `overrideAttrs`
+
+- **`override { ... }`** - changes the *arguments* passed to a package's function (build
+  inputs, flags, boolean features)
+- **`overrideAttrs (old: { ... })`** - changes the *attributes* of the resulting derivation
+  (src, patches, postPatch, doCheck, env vars)
+
+```nix
+# override: swap the curl backend
+pkgs.curl.override { opensslSupport = false; gnutlsSupport = true; }
+
+# overrideAttrs: patch and re-version
+pkgs.htop.overrideAttrs (old: {
+  version = "3.4.2";
+  src = pkgs.fetchFromGitHub {
+    owner = "htop-dev";
+    repo = "htop";
+    rev = "v3.4.2";
+    hash = "sha256-AAAA...";
+  };
+  patches = (old.patches or []) ++ [ ./fix-ioctl.patch ];
+})
+```
+
+Rule of thumb: if the change is a boolean or input, use `override`; if the change is source,
+patches, or phases, use `overrideAttrs`.
+
+## Overlays
+
+An overlay is a function `final: prev: { ... }`. `final` is the overlaid package set
+(post-overlay); `prev` is the package set as it existed before this overlay applied. Use
+`final` to refer to other (possibly overlaid) packages; use `prev` to fall back to upstream.
+
+```nix
+# overlays/my-overlay.nix
+final: prev: {
+  htop = prev.htop.overrideAttrs (old: {
+    patches = (old.patches or []) ++ [ ./htop-fix.patch ];
+  });
+
+  myTool = prev.callPackage ./pkgs/my-tool { };
+
+  python3 = prev.python3.override {
+    packageOverrides = pyFinal: pyPrev: {
+      requests = pyPrev.requests.overrideAttrs (o: {
+        doCheck = false;
+      });
+    };
+  };
+}
+```
+
+Wire into a flake-based NixOS system:
+
+```nix
+# flake.nix outputs
+nixosConfigurations.box = nixpkgs.lib.nixosSystem {
+  system = "x86_64-linux";
+  modules = [
+    ./configuration.nix
+    ({ ... }: { nixpkgs.overlays = [ (import ./overlays/my-overlay.nix) ]; })
+  ];
+};
+```
+
+Or as a flake input:
+
+```nix
+inputs.my-overlay.url = "github:me/my-overlay";
+...
+modules = [ ({ ... }: { nixpkgs.overlays = [ inputs.my-overlay.overlay ]; }) ];
+```
+
+Wire into a channels-based system:
+
+```nix
+# configuration.nix
+{
+  nixpkgs.overlays = [ (import /etc/nixos/overlays/my-overlay.nix) ];
+}
+```
+
+### Overlay placement on flakes
+
+`~/.config/nixpkgs/overlays.nix` is often **ignored** on pure flakes because the flake
+sandbox does not read arbitrary user files. Put overlays in the flake inputs or as files
+the flake tracks.
+
+### Overlay composition
+
+Multiple overlays apply left-to-right. Later overlays see the earlier ones via `final`:
+
+```nix
+nixpkgs.overlays = [
+  (import ./overlays/first.nix)
+  (import ./overlays/second.nix)  # sees outputs of first via final.<pkg>
+];
+```
+
+## Writing a derivation
+
+The canonical function is `stdenv.mkDerivation`. Put packages in `pkgs/<name>/default.nix`
+and call with `callPackage`.
+
+```nix
+# pkgs/my-tool/default.nix
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "my-tool";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "me";
+    repo = "my-tool";
+    rev = "v${version}";
+    hash = "sha256-AAAA...";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ openssl ];
+
+  cmakeFlags = [ "-DBUILD_TESTS=OFF" ];
+
+  meta = with lib; {
+    description = "My tool";
+    homepage = "https://github.com/me/my-tool";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ ];
+    mainProgram = "my-tool";
+  };
+}
+```
+
+Called from an overlay:
+
+```nix
+final: prev: {
+  my-tool = prev.callPackage ./pkgs/my-tool { };
+}
+```
+
+## Language-specific helpers
+
+| Language | Helper | Typical file |
+|----------|--------|--------------|
+| Rust | `rustPlatform.buildRustPackage` | `default.nix` with `cargoHash` |
+| Go | `buildGoModule` | `default.nix` with `vendorHash` |
+| Python | `python3.pkgs.buildPythonApplication` | `default.nix` with `propagatedBuildInputs` |
+| Node | `buildNpmPackage` or `buildYarnPackage` | with lock hash |
+| Haskell | `haskellPackages.callCabal2nix` | Cabal-derived |
+
+Example Rust:
+
+```nix
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "my-cli";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "me"; repo = "my-cli"; rev = "v${version}";
+    hash = "sha256-...";
+  };
+
+  cargoHash = "sha256-...";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  meta.mainProgram = "my-cli";
+}
+```
+
+First build fails with a hash mismatch; copy the "got:" hash into `cargoHash` and rebuild.
+
+Example Go:
+
+```nix
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "my-cli";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "me"; repo = "my-cli"; rev = "v${version}";
+    hash = "sha256-...";
+  };
+
+  vendorHash = "sha256-...";      # set to lib.fakeHash first, copy "got:" on rebuild
+  # vendorHash = null;              # if go.mod has no dependencies
+
+  subPackages = [ "cmd/my-cli" ];  # limit to specific main packages
+  ldflags = [ "-s" "-w" "-X main.version=${version}" ];
+  env.CGO_ENABLED = 0;
+
+  meta.mainProgram = "my-cli";
+}
+```
+
+Same hash-dance as Rust: set `vendorHash = lib.fakeHash;`, build, copy the reported "got:"
+hash into the attribute.
+
+## Fetchers
+
+- `fetchFromGitHub { owner; repo; rev; hash; }`
+- `fetchFromGitLab`, `fetchFromSourcehut`, `fetchFromCodeberg`
+- `fetchurl { url; hash; }`
+- `fetchgit { url; rev; hash; }` - for arbitrary git remotes
+- `fetchTarball { url; sha256; }` - last resort for single tarballs
+
+Use `sha256` only when a tool explicitly requires it; prefer `hash` in SRI format
+(`sha256-...`).
+
+## Unfree and insecure gates
+
+```nix
+# System-wide, declarative
+nixpkgs.config.allowUnfree = true;
+
+# Or an allowlist predicate
+nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+  "vscode" "nvidia-x11" "steam-unwrapped"
+];
+
+# Insecure packages that are still used on purpose
+nixpkgs.config.permittedInsecurePackages = [ "openssl-1.1.1w" ];
+```
+
+One-off impure escape hatch:
+
+```bash
+NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#vscode
+```
+
+## Common mistakes
+
+- Using `override` where `overrideAttrs` is needed (or vice versa). Error messages are
+  cryptic; the distinction matters.
+- Forgetting to bump `hash` / `cargoHash` / `vendorHash` after changing `src`. The derivation
+  will either rebuild from stale fetch or fail with a mismatch.
+- Writing `final: prev:` overlays that mutate `prev.<x>` in-place instead of returning
+  new values. Nix attrsets are immutable; you add keys to the returned set.
+- Scoping overlays in the wrong place on flakes - user-level `~/.config/nixpkgs/overlays.nix`
+  is often ignored.
+- Over-using `overrideAttrs` for things a plain option would fix. Check nixpkgs options
+  first; many packages expose flags.

--- a/skills/nixos-btw/references/rebuild-generations-and-rollback.md
+++ b/skills/nixos-btw/references/rebuild-generations-and-rollback.md
@@ -1,0 +1,173 @@
+# nixos-rebuild, generations, and rollback
+
+Every `nixos-rebuild switch` produces a **generation**: an immutable snapshot in
+`/nix/var/nix/profiles/system-<N>-link`. Previous generations stay around until GC. This is
+the whole safety model.
+
+## Rebuild verbs
+
+| Verb | Builds | Activates now | Adds boot entry | Use when |
+|------|--------|---------------|-----------------|----------|
+| `build` | yes | no | no | CI or dry-run without touching the system |
+| `dry-activate` | yes | no | no | preview what would change on activation |
+| `test` | yes | yes | **no** | risky change; reboot returns to previous gen |
+| `switch` | yes | yes | yes | standard apply |
+| `boot` | yes | no | yes | apply on next boot (good for remote work) |
+| `build-vm` | yes | no | no | build a QEMU VM you can `run` to test |
+| `build-vm-with-bootloader` | yes | no | no | same, with bootloader |
+
+`test` is the underused verb. A bad login manager config in `test` mode survives a reboot;
+in `switch` mode it does not.
+
+### Flake forms
+
+```bash
+sudo nixos-rebuild switch --flake /etc/nixos#box
+sudo nixos-rebuild test --flake .#box --show-trace
+sudo nixos-rebuild boot --flake .#box --target-host root@other  # remote build on local
+sudo nixos-rebuild switch --flake .#box --build-host builder.lan
+```
+
+### nixos-rebuild-ng
+
+NixOS 25.11 made **`nixos-rebuild-ng`** the default. It is a Python rewrite of
+`nixos-rebuild` with the same verbs and flags. Older guides reference the Perl version; the
+behavior is the same for 95% of workflows, but internal tracing and some edge flags differ.
+
+## Useful flags
+
+```bash
+--show-trace               # full Nix eval trace on error
+--print-build-logs         # stream builder stdout/stderr live
+--keep-going               # continue after a failed derivation
+--cores 4                  # parallelism per build
+--max-jobs 2               # parallel derivations
+--no-reexec                # do not reexec into the new nixos-rebuild
+--rollback                 # revert to previous generation (then reboot for boot changes)
+--upgrade                  # bump channels before rebuild (channels only)
+--fast                     # skip nix channel update and some sanity checks
+--target-host user@host    # deploy to a remote machine (SSH)
+--build-host user@host     # build on a remote, activate locally
+```
+
+## Generations
+
+List system generations:
+
+```bash
+sudo nix-env --list-generations -p /nix/var/nix/profiles/system
+```
+
+User profile generations (per `$USER`):
+
+```bash
+nix-env --list-generations
+```
+
+Switch to a specific generation (activation; reboot for bootloader changes):
+
+```bash
+sudo nix-env --switch-generation 42 -p /nix/var/nix/profiles/system
+sudo /nix/var/nix/profiles/system/bin/switch-to-configuration switch
+```
+
+Roll back to the previous generation:
+
+```bash
+sudo nixos-rebuild switch --rollback
+```
+
+Delete old generations (but keep the current one and its immediate predecessor):
+
+```bash
+sudo nix-env --delete-generations +5 -p /nix/var/nix/profiles/system
+sudo nix-collect-garbage -d   # also removes unreachable store paths
+```
+
+## Boot entries
+
+Every generation produces a boot entry. Bootloader varies:
+
+- **systemd-boot** (default for UEFI installs): entries in `/boot/loader/entries/*.conf`.
+  `sudo bootctl status` shows what is active and what is known.
+- **GRUB**: entries regenerated on every rebuild; Nix manages them.
+- **EFI / UKI**: UKIs produced on newer setups bake kernel+initrd together.
+
+Do not hand-edit entries. They regenerate on every rebuild.
+
+Limit the number of visible boot entries:
+
+```nix
+boot.loader.systemd-boot.configurationLimit = 20;
+boot.loader.grub.configurationLimit = 20;
+```
+
+GC does not remove the entries themselves until the underlying generation is gone.
+
+## Rollback flow when things break
+
+From a running system:
+
+```bash
+sudo nixos-rebuild switch --rollback
+```
+
+From the bootloader menu at boot time: pick a previous entry. The menu shows timestamps and
+kernel versions. Boot one, then `nixos-rebuild switch --rollback` from userspace to persist.
+
+From a rescue shell (single-user or initramfs emergency):
+
+```bash
+# Find the generation
+ls -l /nix/var/nix/profiles/
+# Activate it manually
+/nix/var/nix/profiles/system-41-link/bin/switch-to-configuration boot
+reboot
+```
+
+## `dry-activate` before big changes
+
+```bash
+sudo nixos-rebuild dry-activate --flake .#box
+```
+
+Prints the activation steps that **would** run: units that start/stop, users that change,
+file tree changes. No reboot, no switch. Cheap to run; expensive to skip before a change
+that touches login, users, or SSH.
+
+## build-vm
+
+Builds a QEMU VM booting the exact config you are about to switch to:
+
+```bash
+nixos-rebuild build-vm --flake .#box
+./result/bin/run-box-vm
+```
+
+Great for testing login manager changes, new users, or boot-level tweaks without
+risking the actual host.
+
+## Remote deploys
+
+`--target-host` and `--build-host` let you build locally and apply remotely:
+
+```bash
+sudo nixos-rebuild switch \
+  --flake .#prod \
+  --target-host root@prod.lan \
+  --build-host localhost
+```
+
+For fleet-level deploys, consider tools built on top: `deploy-rs`, `colmena`, or `nixops4`.
+
+## Common mistakes
+
+- Running `nix-collect-garbage -d` immediately after a switch and before a reboot confirms
+  the new generation works. Keep at least the last known-good generation.
+- Using `switch` for changes you suspect might break login. `test` is safer; a reboot
+  recovers the last switched generation.
+- Confusing `nixos-rebuild --rollback` with `switch-to-configuration`. The former goes back
+  one generation; the latter activates a specific generation you name.
+- Hand-editing `/boot/loader/entries/*.conf`. Regenerated on every rebuild.
+- Forgetting to commit `flake.nix` and `flake.lock` before a flake-based rebuild. The pure
+  sandbox only sees tracked files.

--- a/skills/nixos-btw/references/secrets-sops-and-agenix.md
+++ b/skills/nixos-btw/references/secrets-sops-and-agenix.md
@@ -1,0 +1,257 @@
+# Secrets: sops-nix and agenix
+
+Nix puts every build input into `/nix/store`, and the store is world-readable. Anything you
+interpolate into a module string ends up there. Secrets need to be decrypted at **activation
+time**, not build time, and read from a path outside the store.
+
+Two common options:
+
+- **sops-nix** - encrypts with age, PGP, or cloud KMS; edits with `sops`; decrypts at
+  activation into `/run/secrets/`.
+- **agenix** - encrypts with age only; edits with `agenix`; decrypts at activation into
+  `/run/agenix/` (configurable).
+
+Both integrate with home-manager and nix-darwin via their own modules.
+
+## sops-nix
+
+### Install
+
+```nix
+# flake.nix
+inputs.sops-nix = {
+  url = "github:Mic92/sops-nix";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+
+# configuration.nix
+{ inputs, ... }:
+{
+  imports = [ inputs.sops-nix.nixosModules.sops ];
+}
+```
+
+### Age key for the host
+
+Generate on the host once (or derive from SSH host key):
+
+```bash
+# From existing SSH host key (no new material to manage)
+sudo nix-shell -p ssh-to-age --run \
+  'ssh-keyscan -t ed25519 localhost | ssh-to-age'
+
+# Or a fresh age key
+sudo mkdir -p /var/lib/sops-nix
+sudo nix-shell -p age --run 'age-keygen -o /var/lib/sops-nix/key.txt'
+sudo chmod 600 /var/lib/sops-nix/key.txt
+```
+
+### .sops.yaml (single-host)
+
+```yaml
+keys:
+  - &alice age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  - &host_box age1yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+creation_rules:
+  - path_regex: secrets/[^/]+\.yaml$
+    key_groups:
+      - age:
+          - *alice
+          - *host_box
+```
+
+### .sops.yaml (multi-host fleet)
+
+Scope each host's secrets to that host's key so each server only decrypts its own:
+
+```yaml
+keys:
+  - &alice   age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  - &web1    age1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  - &web2    age1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  - &db1     age1cccccccccccccccccccccccccccccccccccccccccccccccccccc
+creation_rules:
+  # Shared secrets readable by every host + admin
+  - path_regex: secrets/shared/.*\.yaml$
+    key_groups:
+      - age: [*alice, *web1, *web2, *db1]
+  # Per-host secrets readable only by that host + admin
+  - path_regex: secrets/hosts/web1/.*\.yaml$
+    key_groups:
+      - age: [*alice, *web1]
+  - path_regex: secrets/hosts/web2/.*\.yaml$
+    key_groups:
+      - age: [*alice, *web2]
+  - path_regex: secrets/hosts/db1/.*\.yaml$
+    key_groups:
+      - age: [*alice, *db1]
+```
+
+### Adding a new host
+
+1. Boot the host (live ISO or nixos-anywhere target) and capture its ed25519 SSH host key,
+   or generate a dedicated age key you copy into `/var/lib/sops-nix/key.txt` before
+   activation.
+2. Derive its age public key:
+   `ssh-keyscan -t ed25519 <host> | ssh-to-age`.
+3. Add the key to `.sops.yaml` under `keys:` with an anchor.
+4. Add a `creation_rules` entry scoped to `secrets/hosts/<new>/.*\.yaml$` listing the
+   new anchor and any shared admins.
+5. `sops updatekeys secrets/hosts/<new>/*.yaml` to re-key any existing secrets that now
+   need the new host added.
+6. Add `nixosConfigurations.<new>` to the flake and deploy with `nixos-anywhere` or a
+   normal `nixos-rebuild --flake .#<new> --target-host`.
+
+### Encrypting a secret
+
+```bash
+# Creates or edits, opening your $EDITOR
+sops secrets/prod.yaml
+```
+
+### Consuming in NixOS
+
+```nix
+{
+  sops = {
+    defaultSopsFile = ./secrets/prod.yaml;
+    defaultSopsFormat = "yaml";
+    age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    # or age.keyFile = "/var/lib/sops-nix/key.txt";
+
+    secrets = {
+      "db/password" = {
+        owner = "postgres";
+        group = "postgres";
+        mode = "0400";
+        restartUnits = [ "postgresql.service" ];
+      };
+      "wg/privateKey" = {
+        owner = "root";
+        mode = "0400";
+      };
+    };
+  };
+
+  services.postgresql.enable = true;
+  systemd.services.postgresql.serviceConfig.EnvironmentFile =
+    config.sops.secrets."db/password".path;
+}
+```
+
+The decrypted file path is `config.sops.secrets."db/password".path` - typically
+`/run/secrets/db/password`. Modules reference the path, not the value.
+
+## agenix
+
+Lighter option; age-only, fewer moving parts.
+
+### Install
+
+```nix
+inputs.agenix.url = "github:ryantm/agenix";
+
+# configuration.nix
+{ inputs, ... }:
+{
+  imports = [ inputs.agenix.nixosModules.default ];
+  environment.systemPackages = [ inputs.agenix.packages.${pkgs.system}.default ];
+}
+```
+
+### secrets.nix (declares recipients per secret)
+
+```nix
+let
+  alice = "ssh-ed25519 AAAA... alice";
+  hostBox = "ssh-ed25519 AAAA... root@box";
+
+  users = [ alice ];
+  systems = [ hostBox ];
+in
+{
+  "db-password.age".publicKeys = users ++ systems;
+  "wg-private.age".publicKeys = users ++ [ hostBox ];
+}
+```
+
+### Encrypt
+
+```bash
+agenix -e db-password.age
+```
+
+### Consume
+
+```nix
+{
+  age.secrets.db-password = {
+    file = ./secrets/db-password.age;
+    owner = "postgres";
+    group = "postgres";
+    mode = "0400";
+  };
+
+  systemd.services.postgresql.serviceConfig.EnvironmentFile =
+    config.age.secrets.db-password.path;
+}
+```
+
+Decrypted path is `config.age.secrets.<name>.path`, typically `/run/agenix/<name>`.
+
+## Picking between them
+
+| Concern | sops-nix | agenix |
+|---------|----------|--------|
+| Encryption backends | age, PGP, AWS KMS, GCP KMS, Azure KV | age only |
+| Edit UX | `sops` (industry tool) | `agenix -e` |
+| File format | YAML/JSON/.env/binary | binary blobs per secret |
+| Granularity | fields inside a file | one secret per file |
+| Team workflow | broader tooling | minimal deps |
+| nix-darwin / home-manager | both support | both support |
+
+Most new hobbyist NixOS setups land on agenix. Most team / fleet setups land on sops-nix.
+
+## Home-manager module
+
+sops-nix and agenix both have home-manager modules. Decrypted paths live under
+`$XDG_RUNTIME_DIR/secrets/` or the configured prefix. Useful for per-user git credentials,
+API tokens for user services.
+
+## What not to do
+
+- Do not put secrets in `builtins.readFile ./path-to-plaintext`. That path gets copied into
+  the store at eval time.
+- Do not pass secrets via `environment.etc."foo".text = "..."`. Same issue.
+- Do not echo secrets into systemd unit `Environment=` lines. Use `EnvironmentFile=` that
+  points to an agenix/sops-decrypted path.
+- Do not check in `/var/lib/sops-nix/key.txt` or the host age private key. They must stay on
+  the host.
+- Do not forget to add new hosts' public keys to `.sops.yaml` or `secrets.nix` and re-key
+  existing secrets (`sops updatekeys` or `agenix -r`) when rotating.
+
+## Rotation
+
+```bash
+# sops: update keys listed in .sops.yaml for existing files
+sops updatekeys secrets/prod.yaml
+
+# agenix: re-encrypt all declared secrets
+agenix -r
+```
+
+Rotate host age keys on machine replacement; rotate the underlying secret whenever it may
+have been exposed (e.g., accidentally committed unencrypted).
+
+## Common mistakes
+
+- Assuming `/run/secrets/` is backed by disk. It is a tmpfs by default - contents vanish on
+  reboot, and are re-decrypted at activation.
+- Forgetting `restartUnits = [ ... ]` when a secret changes. Without it, the consuming
+  service keeps its old env.
+- Putting the age key under `/nix/store` by accident (e.g., `age.keyFile =
+  ./key.txt`). The path gets copied into the store. Use an absolute path outside the store.
+- Using agenix with hosts whose ed25519 SSH key has not been converted to age format; the
+  host cannot decrypt.
+- Committing secrets unencrypted. git log keeps them forever; rotate immediately and use
+  `git filter-repo` to rewrite if the exposure is severe.

--- a/skills/nixos-btw/references/store-gc-and-builders.md
+++ b/skills/nixos-btw/references/store-gc-and-builders.md
@@ -1,0 +1,215 @@
+# Nix store, GC, and remote builders
+
+The Nix store (`/nix/store`) is an append-only content-addressed tree of immutable
+derivations. Every system, user profile, dev shell, and direnv cache registers GC roots
+that protect store paths from collection.
+
+## Store layout
+
+```
+/nix/store/<hash>-<name>-<version>/
+/nix/var/nix/profiles/system-<N>-link -> /nix/store/<hash>-nixos-system-...
+/nix/var/nix/profiles/per-user/<user>/profile-<N>-link -> ...
+/nix/var/nix/gcroots/auto/<symlink> -> somewhere
+~/.nix-profile -> /nix/var/nix/profiles/per-user/<user>/profile
+```
+
+Never write into `/nix/store` directly. Every path there is immutable by design.
+
+## `nix-store` vs `nix store`
+
+`nix-store` is the older CLI; `nix store` is the newer subcommand under the unified `nix`
+CLI. Both coexist. Rough mapping:
+
+| Task | old | new |
+|------|-----|-----|
+| Query path info | `nix-store -q --references /path` | `nix store references /path` |
+| Verify a path | `nix-store --verify-path /path` | `nix store verify /path` |
+| Garbage collect | `nix-store --gc` | `nix store gc` |
+| Optimise (dedup) | `nix-store --optimise` | `nix store optimise` |
+| Add to store | `nix-store --add file` | `nix store add-file file` |
+| Print GC roots | `nix-store --gc --print-roots` | `nix store gc --print-roots` |
+| Dump / restore | `nix-store --dump`, `--restore` | `nix store dump`, `restore` |
+| Copy between stores | `nix-copy-closure`, `nix-store --export` | `nix copy` |
+
+The new CLI is cleaner and works better with flakes. It is under `experimental-features`.
+
+## Garbage collection
+
+### What gets deleted
+
+`nix-store --gc` (alias: `nix-collect-garbage`) deletes any path in `/nix/store` that is
+not reachable from a GC root. GC roots include:
+
+- The current and previous system generations
+- All user profile generations
+- Active dev shells (via `.direnv` symlinks, `result` symlinks from `nix build`)
+- `$HOME/.nix-defexpr/channels` entries
+- Arbitrary symlinks into `/nix/store` under `/nix/var/nix/gcroots/auto/`
+
+### Commands
+
+```bash
+# Delete unreachable paths
+nix-collect-garbage                       # keep all generations
+sudo nix-collect-garbage -d               # also delete old generations of all profiles
+sudo nix-collect-garbage --delete-older-than 30d
+
+# See what would be deleted without deleting
+nix-store --gc --print-dead
+
+# See roots that protect paths
+nix-store --gc --print-roots
+
+# Dedup identical files across the store
+sudo nix-store --optimise
+```
+
+### Scheduled GC
+
+Declare it in `configuration.nix`:
+
+```nix
+{
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 30d";
+    persistent = true;  # catch up on missed runs
+  };
+  nix.settings.auto-optimise-store = true;
+}
+```
+
+`auto-optimise-store = true` dedupes after each build. Cheap on modern SSDs; can slow bulk
+imports on spinning disks.
+
+### GC root footguns
+
+- Deleting a `result` symlink in a project directory removes its GC root. The dev shell's
+  build products then become eligible for GC. Your next `nix build` will re-fetch.
+- `direnv` with `nix-direnv` creates GC roots under `.direnv/`; aggressive project cleanup
+  also removes them.
+- CI runners that share a Nix store should register roots for artifacts they care about or
+  disable GC during the build.
+
+## Substituters and binary caches
+
+Nix prefers to download pre-built store paths (substitutes) rather than build from source.
+
+Default substituter: `https://cache.nixos.org` with the public key published upstream.
+
+Declare additional substituters:
+
+```nix
+{
+  nix.settings.substituters = [
+    "https://cache.nixos.org"
+    "https://nix-community.cachix.org"
+    "https://numtide.cachix.org"
+  ];
+  nix.settings.trusted-public-keys = [
+    "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE="
+  ];
+}
+```
+
+### cachix and attic
+
+- **[cachix](https://www.cachix.org/)** - hosted binary cache. Fast to set up; per-org cache
+  and signing keys. `cachix use <name>` adds the substituter.
+- **[attic](https://github.com/zhaofengli/attic)** - self-hosted binary cache with S3
+  backend. Sign with `attic push <cache> <path>` from CI.
+
+For a CI pattern, push every successful build to a shared cache so subsequent runs and
+developers hit substitutes instead of rebuilding.
+
+## Remote builders
+
+Offload builds to bigger or differently-arch'd machines:
+
+```nix
+{
+  nix.buildMachines = [
+    {
+      hostName = "builder.lan";
+      system = "x86_64-linux";
+      sshUser = "nix-build";
+      sshKey = "/root/.ssh/nix-build";
+      maxJobs = 8;
+      speedFactor = 2;
+      supportedFeatures = [ "nixos-test" "benchmark" "big-parallel" "kvm" ];
+    }
+    {
+      hostName = "mbp.lan";
+      system = "aarch64-darwin";
+      sshUser = "builder";
+      sshKey = "/root/.ssh/nix-build";
+      maxJobs = 4;
+    }
+  ];
+  nix.distributedBuilds = true;
+  nix.extraOptions = ''
+    builders-use-substitutes = true
+  '';
+}
+```
+
+Remote macOS builds cover the `aarch64-darwin` gap for teams on NixOS that need to produce
+Darwin artifacts. Determinate Nix introduced a native Linux builder for macOS that reduces
+the need for a separate Linux box.
+
+## Signing and verification
+
+```bash
+# Generate a signing key pair
+nix key generate-secret --key-name mycache-1 > mycache.sec
+nix key convert-secret-to-public < mycache.sec > mycache.pub
+
+# Sign paths
+nix store sign --key-file mycache.sec <store-path>
+
+# Verify
+nix store verify --trusted-public-keys "$(cat mycache.pub)" <store-path>
+```
+
+`trusted-substituters` and `trusted-public-keys` control what an untrusted user may
+instruct the daemon to fetch.
+
+## Store too big
+
+```bash
+# What is taking space
+nix path-info --all --size --human-readable | sort -h | tail -30
+
+# Heavy dependents of a path
+nix why-depends /run/current-system /nix/store/<hash>-foo
+
+# Older generations you are keeping on purpose?
+nix-env --list-generations -p /nix/var/nix/profiles/system
+nix-env --delete-generations +5 -p /nix/var/nix/profiles/system
+
+# User-profile closures often dominate after system GC
+home-manager expire-generations '-30 days' 2>&1 || true
+nix profile wipe-history --older-than 30d 2>&1 || true
+
+sudo nix-collect-garbage -d
+```
+
+`nix store optimise` (dedup) and `nix.settings.auto-optimise-store = true;` help on big
+stores. Results vary by filesystem - btrfs and XFS benefit most.
+
+## Common mistakes
+
+- Running `nix-collect-garbage -d` moments after a `nixos-rebuild switch`, before
+  confirming the new generation boots clean. Keep at least the last known-good generation.
+- Pruning generations without also pruning user profiles - user-level closures still hold
+  large trees.
+- Disabling a substituter without also checking `trusted-substituters` - you get slow
+  rebuilds but no clear error.
+- Ignoring `--substitute-on-destination` on `nix copy` when deploying to a remote - the
+  remote may silently rebuild.
+- Treating `/nix/store` as diskful cache. It is authoritative state; backup strategies that
+  skip it lose rollback history.


### PR DESCRIPTION
## Summary

Adds **nixos-btw** - a high-effort skill covering the full NixOS and Nix ecosystem, matching the depth and shape of arch-btw and kali-linux.

- **SKILL.md** (370 lines) - lane-detection workflow, AI self-check, triage table, and declarative-first mental model
- **12 reference files** (~2800 lines total) covering:
  - configuration.nix + modules
  - Flakes vs channels (with a channel-to-flake migration recipe)
  - \`nixos-rebuild\` generations and rollback
  - home-manager (3 modes) + nix-darwin on Apple Silicon
  - Overlays, overrides, packaging (Rust + Go examples)
  - Nix store + GC strategy
  - Dev shells and \`nix-direnv\`
  - disko + impermanence + nixos-anywhere + image generators
  - Hardware, kernels, Wayland, Steam, OBS screencast
  - sops-nix + agenix (single-host and multi-host fleet layouts)
  - Determinate Nix and Lix lane differences
  - Recurring gotchas

## Versions pinned (April 2026)

- NixOS 25.11 "Xantusia" stable; 26.05 "Yarara" upcoming
- Nix 2.33, home-manager release-25.11, nix-darwin 25.11
- Linux 6.12 LTS default; 6.17 mainline via \`linuxPackages_latest\`

## Validation

- 5 **skill-creator** review iterations fixed: \`2>/dev/null\` abuse, duplicate \`nix.enable\`, wrong \`nix-store add-file\` form, kernel-default claim, stale ZFS attribute path
- 5 **behavioral test** iterations (parallel agents) covering Go packaging, channels-to-flakes migration, NVIDIA+Hyprland+Steam+OBS, multi-host sops-nix fleet, and nix-darwin dev setup on Apple Silicon
- All findings applied; \`lint-skills.sh\` and \`validate-spec.sh\` pass

## Test plan

- [ ] CI green on lint and spec validators
- [ ] Activation: \"nixos-rebuild fails with flake error\" routes to nixos-btw
- [ ] Activation: \"arch bluetooth broke\" routes to arch-btw (no false positive)
- [ ] Activation: \"home-manager won't switch\" routes to nixos-btw
- [ ] README skill count bumped to 37 and NixOS mentioned in description