### PR TITLE
fix(routing): wire new distro and routine skills into reference matrix

### DIFF
--- a/skills/arch-btw/SKILL.md
+++ b/skills/arch-btw/SKILL.md
@@ -5,8 +5,9 @@ description: >
   desktop (Hyprland, GNOME, KDE), PipeWire, GPU drivers, gaming (Steam, Proton), and media
   (OBS, WebRTC). Triggers: 'arch linux', 'cachyos', 'pacman', 'paru', 'aur', 'systemd',
   'mkinitcpio', 'bootctl', 'hyprland', 'pipewire', 'nvidia', 'steam', 'proton', 'obs',
-  'pacnew'. Not for shell syntax (command-prompt), networking (networking), or config
-  management (ansible).
+  'pacnew'. Not for Debian/Ubuntu (**debian-ubuntu**), Fedora/RHEL (**rhel-fedora**),
+  Kali (**kali-linux**), NixOS (**nixos-btw**), shell syntax (**command-prompt**),
+  networking (**networking**), or config management (**ansible**).
 license: MIT
 compatibility: Requires Arch Linux, CachyOS, or Arch-based distro with pacman
 metadata:

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -5,7 +5,9 @@ description: >
   Actions, and Woodpecker. Covers pipeline security (SHA pinning, SBOM), self-hosted runners,
   dependency updates, linting, scanning, and review gates. Triggers: 'ci/cd', 'pipeline',
   'github actions', 'gitlab ci', 'forgejo', 'gitea', 'woodpecker', 'runner', 'dependabot',
-  'renovate', 'trivy', 'gitleaks', 'merge queue', 'codeowners'.
+  'renovate', 'trivy', 'gitleaks', 'merge queue', 'codeowners'. Not for Claude Code cloud
+  routines (**routine-writer**), container image builds outside CI (**docker**), or git
+  workflows (**git**).
 license: MIT
 compatibility: "Optional: gh (GitHub CLI), glab (GitLab CLI), fj (Forgejo CLI)"
 paths:

--- a/skills/lockpick/SKILL.md
+++ b/skills/lockpick/SKILL.md
@@ -5,8 +5,9 @@ description: >
   containers, and K8s. Covers lateral movement, pivoting, credential extraction, and IaC
   secrets exposure. Triggers: 'privesc', 'CTF', 'pentest', 'post-exploitation', 'container
   escape', 'SUID', 'sudo abuse', 'RBAC abuse', 'reverse shell', 'GTFOBins', 'LinPEAS',
-  'lateral movement'. Not for defensive hardening (use security-audit) or firewall config
-  (use firewall-appliance).
+  'lateral movement'. Not for defensive hardening (**security-audit**), firewall config
+  (**firewall-appliance**), Kali distro admin (**kali-linux**), or vulnerability research
+  (**zero-day**).
 license: MIT
 compatibility: Requires authorized access to target Linux systems and bash/python
 metadata:

--- a/skills/prompt-generator/SKILL.md
+++ b/skills/prompt-generator/SKILL.md
@@ -3,8 +3,8 @@ name: prompt-generator
 description: >
   · Turn scattered ideas or rough notes into structured LLM prompts, or refine existing ones.
   Triggers: 'write a prompt', 'system prompt', 'prompt template', 'prompt engineering',
-  'improve this prompt'. Not for brainstorming features, writing code, or creating skills
-  (use skill-creator).
+  'improve this prompt'. Not for brainstorming features, writing code, creating skills
+  (**skill-creator**), or Claude Code cloud routines (**routine-writer**).
 license: MIT
 compatibility: "Model-agnostic. Optional: tailor output format to Claude, GPT, or Gemini when target is known"
 metadata:

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -5,7 +5,8 @@ description: >
   - dnf, yum, SELinux, systemd, GRUB, dracut, host firewalld, and desktop/GPU work.
   Triggers: 'rhel', 'fedora', 'centos stream', 'rocky', 'alma', 'almalinux',
   'oracle linux', 'amazon linux', 'dnf', 'yum', 'selinux', 'rpm fusion', 'akmods'.
-  Not for Arch/Debian, rpm-ostree/image-mode, containers, shell (**command-prompt**),
+  Not for Arch (**arch-btw**), Debian/Ubuntu (**debian-ubuntu**), Kali (**kali-linux**),
+  NixOS (**nixos-btw**), rpm-ostree/image-mode, containers, shell (**command-prompt**),
   network design (**networking**), or config management (**ansible**).
 license: MIT
 compatibility: Requires Fedora, RHEL, or RHEL-family distro with dnf, yum, or rpm

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -4,7 +4,9 @@ description: >
   · Audit code for security issues - OWASP, credential scans, auth review, supply chain
   hardening, and pre-release checks. Also trigger on self-hosted apps touching authentication
   or access control. Triggers: 'security audit', 'vulnerability scan', 'secret scan', 'OWASP',
-  'hardening', 'auth review'.
+  'hardening', 'auth review'. Not for offensive use (**lockpick**), vulnerability research
+  (**zero-day**), Kali distro admin (**kali-linux**), or firewall appliance config
+  (**firewall-appliance**).
 license: MIT
 compatibility: "Optional: betterleaks, gitleaks, trivy, semgrep, bandit, checkov, scorecard"
 metadata:

--- a/skills/zero-day/SKILL.md
+++ b/skills/zero-day/SKILL.md
@@ -5,8 +5,9 @@ description: >
   engineering, patch diffing, fuzzing, attack surface mapping, PoC development, and
   responsible disclosure. Triggers: 'zero-day', '0-day', 'vulnerability research',
   'variant analysis', 'patch diffing', 'fuzz', 'exploit dev', 'CVE', 'PoC', 'reverse
-  engineering'. Not for SAST scanning (use security-audit), post-exploitation (use lockpick),
-  or code correctness (use code-review).
+  engineering'. Not for SAST scanning (**security-audit**), post-exploitation
+  (**lockpick**), Kali tool administration (**kali-linux**), or code correctness
+  (**code-review**).
 license: MIT
 compatibility: "Optional: codeql, semgrep, joern, ghidra, radare2/rizin, afl++, gdb, pwntools, strace, ltrace, checksec"
 metadata:


### PR DESCRIPTION
## Summary
- Backfills "Not for X (**use Y**)" routing hints across 7 skills so the newer distro family (`debian-ubuntu`, `rhel-fedora`, `kali-linux`, `nixos-btw`) and `routine-writer` are properly reachable from their siblings' descriptions.
- No behavioral code changes - description metadata only.

## Changes
- **arch-btw** - route Debian/Fedora/Kali/NixOS to their siblings
- **rhel-fedora** - name Arch/Debian/Kali/NixOS targets explicitly (was "Arch/Debian" unlinked)
- **prompt-generator** - route Claude Code cloud routines to `routine-writer`
- **lockpick** - route Kali admin and research to `kali-linux`/`zero-day`
- **zero-day** - route Kali tool admin to `kali-linux`
- **security-audit** - route offensive, research, Kali admin, and firewall-appliance work
- **ci-cd** - adds first "Not for" hints (`routine-writer`, `docker`, `git`)

## Test plan
- [x] \`scripts/lint-skills.sh\` passes - 0 errors
- [x] \`scripts/validate-spec.sh\` passes - 0 spec violations, 7 soft description-length warnings (all under 600-char hard cap)
- [ ] CI green