### PR TITLE
feat(installer): add current agent targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ These skills follow the [Agent Skills open standard](https://agentskills.io/spec
 - **Continue** - native support
 - **Kiro CLI** - native support
 - **Warp** - native support
+- **OpenClaw** - native support
+- **Hermes Agent** - native support
+- **Qwen Code** - native support
+- **Crush** - native support
+- **Google Antigravity** - native support
+- **Augment** - native support
+- **OpenHands** - native support
+- **Trae** - native support
+- **Qoder** - native support
+- **Kimi Code CLI** - native support
 - Any other tool that implements the Agent Skills spec
 
 No conversion, no adapters. Drop the skill folder in your tool's skills directory and it works.
@@ -141,7 +151,7 @@ Each skill follows the [Agent Skills specification](https://agentskills.io/speci
 - **Compact body** (target under 500 lines, 600 hard max) - the core instructions that load into every conversation. Kept lean so it doesn't eat your context window.
 - **Reference files** (`references/` directory) - detailed pattern libraries, compliance checklists, manifest templates. The agent reads these on-demand when the task requires depth. You get expert-level detail without paying the token cost upfront.
 - **Argument hints** (`metadata.argument_hint`) - tells agents what arguments a skill expects when invoked (e.g., `<file-or-pattern>`, `[iterations]`). Angle brackets for required, square brackets for optional.
-- **Precise trigger descriptions** - optimized so the right tool activates the right skill at the right time. Descriptions target about 300 characters so startup skill lists stay compact in tools with tight context budgets.
+- **Precise trigger descriptions** - optimized so the right tool activates the right skill at the right time. Descriptions target about 200 characters, with warnings above 240, so startup skill lists stay compact in tools with tight context budgets.
 - **Cross-skill awareness** - skills know about each other. The security-audit skill knows not to step on lockpick's territory. Docker knows to defer to Kubernetes for cluster networking. No overlapping, no conflicts.
 
 ## Install
@@ -227,27 +237,39 @@ cp -r skills/kubernetes ~/.cursor/skills/kubernetes
 
 ### Supported tools
 
-The installer supports 15 targets:
+The installer supports 25 targets:
 
 | Tool | Flag | Default path |
 |------|------|-------------|
 | Claude Code | `claude` | `~/.claude/skills` |
 | OpenAI Codex | `codex` | `~/.codex/skills` |
 | Cursor | `cursor` | `~/.cursor/skills` |
-| Windsurf | `windsurf` | `~/.windsurf/skills` |
+| Windsurf | `windsurf` | `~/.codeium/windsurf/skills` |
 | OpenCode | `opencode` | `~/.config/opencode/skills` |
 | GitHub Copilot | `copilot` | `~/.copilot/skills` |
 | Gemini CLI | `gemini` | `~/.gemini/skills` |
 | Roo Code | `roo` | `~/.roo/skills` |
 | Goose | `goose` | `~/.config/goose/skills` |
-| Amp | `amp` | `~/.amp/skills` |
+| Amp | `amp` | `~/.config/agents/skills` |
 | Continue | `continue` | `~/.continue/skills` |
 | Kiro CLI | `kiro` | `~/.kiro/skills` |
-| Cline | `cline` | `~/.cline/skills` |
-| Warp | `warp` | `~/.warp/skills` |
+| Cline | `cline` | `~/.agents/skills` |
+| Warp | `warp` | `~/.agents/skills` |
+| OpenClaw | `openclaw` | `~/.openclaw/skills` |
+| Hermes Agent | `hermes` | `~/.hermes/skills` |
+| Qwen Code | `qwen` | `~/.qwen/skills` |
+| Crush | `crush` | `~/.config/crush/skills` |
+| Google Antigravity | `antigravity` | `~/.gemini/antigravity/skills` |
+| Augment | `augment` | `~/.augment/skills` |
+| OpenHands | `openhands` | `~/.openhands/skills` |
+| Trae | `trae` | `~/.trae/skills` |
+| Qoder | `qoder` | `~/.qoder/skills` |
+| Kimi Code CLI | `kimi` | `~/.config/agents/skills` |
 | Portable | `portable` | `~/.skills` |
 
-All paths are overridable via `--dest` (single-tool mode) or environment variables (e.g., `CLAUDE_SKILLS_DIR`).
+Common aliases also work: `claude-code`, `openai-codex`, `github-copilot`, `gemini-cli`, `kiro-cli`, `qwen-code`, and `kimi-cli`.
+
+All paths are overridable via `--dest` (single-tool mode) or environment variables (e.g., `CLAUDE_SKILLS_DIR`). Some agent ecosystems prefer shared or project-local skill directories; for example, OpenClaw also scans `~/.agents/skills`, and Hermes can be configured to scan external directories such as `~/.agents/skills`. NanoClaw is intentionally not listed as a normal global target because its docs use project-local `.claude/skills` and `container/skills`; install to a NanoClaw checkout with `--tool portable --dest /path/to/NanoClaw/.claude/skills` or `--dest /path/to/NanoClaw/container/skills` as appropriate.
 
 ## Requirements
 

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,7 @@ ALL_SKILLS=()
 SUPPORTED_TOOLS=(
   claude codex cursor windsurf opencode
   copilot gemini roo goose amp continue kiro cline warp
+  openclaw hermes qwen crush antigravity augment openhands trae qoder kimi
   portable
 )
 
@@ -45,18 +46,38 @@ declare -A TOOL_PATHS=(
   [claude]="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
   [codex]="${CODEX_SKILLS_DIR:-$HOME/.codex/skills}"
   [cursor]="${CURSOR_SKILLS_DIR:-$HOME/.cursor/skills}"
-  [windsurf]="${WINDSURF_SKILLS_DIR:-$HOME/.windsurf/skills}"
+  [windsurf]="${WINDSURF_SKILLS_DIR:-$HOME/.codeium/windsurf/skills}"
   [opencode]="${OPENCODE_SKILLS_DIR:-$HOME/.config/opencode/skills}"
-  [copilot]="$HOME/.copilot/skills"
-  [gemini]="$HOME/.gemini/skills"
-  [roo]="$HOME/.roo/skills"
-  [goose]="$HOME/.config/goose/skills"
-  [amp]="$HOME/.amp/skills"
-  [continue]="$HOME/.continue/skills"
-  [kiro]="$HOME/.kiro/skills"
-  [cline]="$HOME/.cline/skills"
-  [warp]="$HOME/.warp/skills"
+  [copilot]="${COPILOT_SKILLS_DIR:-$HOME/.copilot/skills}"
+  [gemini]="${GEMINI_SKILLS_DIR:-$HOME/.gemini/skills}"
+  [roo]="${ROO_SKILLS_DIR:-$HOME/.roo/skills}"
+  [goose]="${GOOSE_SKILLS_DIR:-$HOME/.config/goose/skills}"
+  [amp]="${AMP_SKILLS_DIR:-$HOME/.config/agents/skills}"
+  [continue]="${CONTINUE_SKILLS_DIR:-$HOME/.continue/skills}"
+  [kiro]="${KIRO_SKILLS_DIR:-$HOME/.kiro/skills}"
+  [cline]="${CLINE_SKILLS_DIR:-$HOME/.agents/skills}"
+  [warp]="${WARP_SKILLS_DIR:-$HOME/.agents/skills}"
+  [openclaw]="${OPENCLAW_SKILLS_DIR:-$HOME/.openclaw/skills}"
+  [hermes]="${HERMES_SKILLS_DIR:-$HOME/.hermes/skills}"
+  [qwen]="${QWEN_SKILLS_DIR:-$HOME/.qwen/skills}"
+  [crush]="${CRUSH_SKILLS_DIR:-$HOME/.config/crush/skills}"
+  [antigravity]="${ANTIGRAVITY_SKILLS_DIR:-$HOME/.gemini/antigravity/skills}"
+  [augment]="${AUGMENT_SKILLS_DIR:-$HOME/.augment/skills}"
+  [openhands]="${OPENHANDS_SKILLS_DIR:-$HOME/.openhands/skills}"
+  [trae]="${TRAE_SKILLS_DIR:-$HOME/.trae/skills}"
+  [qoder]="${QODER_SKILLS_DIR:-$HOME/.qoder/skills}"
+  [kimi]="${KIMI_SKILLS_DIR:-$HOME/.config/agents/skills}"
   [portable]="${PORTABLE_SKILLS_DIR:-$HOME/.skills}"
+)
+
+declare -A TOOL_ALIASES=(
+  [claude-code]=claude
+  [openai-codex]=codex
+  [github-copilot]=copilot
+  [gemini-cli]=gemini
+  [kiro-cli]=kiro
+  [qwen-code]=qwen
+  [kimi-cli]=kimi
 )
 
 supported_tools_text() {
@@ -74,6 +95,7 @@ supported_tools_text() {
 # ── Agent path resolution ─────────────────────────────────────────────
 resolve_tool_path() {
   local tool="$1"
+  tool="${TOOL_ALIASES[$tool]:-$tool}"
   local path="${TOOL_PATHS[$tool]:-}"
 
   if [[ -z "$path" ]]; then
@@ -83,6 +105,11 @@ resolve_tool_path() {
   fi
 
   printf '%s\n' "$path"
+}
+
+canonical_tool_name() {
+  local tool="$1"
+  printf '%s\n' "${TOOL_ALIASES[$tool]:-$tool}"
 }
 
 # ── Usage ─────────────────────────────────────────────────────────────
@@ -368,8 +395,9 @@ main() {
   mapfile -t ALL_SKILLS < <(discover_skills "$include_internal")
 
   # Validate tool names
-  for tool in "${tools[@]}"; do
-    resolve_tool_path "$tool" > /dev/null
+  for i in "${!tools[@]}"; do
+    tools[i]="$(canonical_tool_name "${tools[i]}")"
+    resolve_tool_path "${tools[i]}" > /dev/null
   done
 
   # Build skill list (filter internal unless --include-internal)

--- a/scripts/validate-spec.sh
+++ b/scripts/validate-spec.sh
@@ -46,8 +46,8 @@ validate_description() {
   fi
   if [[ ${#desc} -gt 600 ]]; then
     error "$name: description exceeds 600 characters (${#desc})"
-  elif [[ ${#desc} -gt 300 ]]; then
-    warn "$name: description exceeds Codex-friendly 300 character target (${#desc})"
+  elif [[ ${#desc} -gt 240 ]]; then
+    warn "$name: description exceeds Codex-friendly 240 character target (${#desc})"
   fi
 }
 

--- a/skills/ai-ml/SKILL.md
+++ b/skills/ai-ml/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: ai-ml
 description: >
-  · Build, review, or architect AI/ML apps: LLMs, RAG, embeddings, agents, evals, local
-  inference, structured output, and tool use. Triggers: 'llm', 'rag', 'embedding',
-  'vector store', 'openai sdk', 'agent loop', 'fine-tune', 'ollama', 'vllm'. Not for MCP
-  servers (use mcp).
+  · Build/review AI apps: LLMs, RAG, embeddings, agents, evals, local inference. Triggers: 'llm', 'rag', 'embedding', 'openai sdk', 'agent loop', 'fine-tune', 'ollama', 'vllm'. Not for MCP (use mcp).
 license: MIT
 compatibility: "Varies by task. Common: Python 3.10+, Node.js 18+. Optional: GPU for local inference"
 metadata:

--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: ansible
 description: >
-  · Write, review, or architect Ansible playbooks, roles, collections, and config
-  management. Covers Molecule, Vault, AWX/AAP, CIS, and EEs. Triggers: 'ansible',
-  'playbook', 'role', 'inventory', 'molecule', 'ansible-lint', 'AWX', 'group_vars'. Not
-  for shell scripts (use command-prompt).
+  · Write/review Ansible playbooks, roles, inventories, Vault, Molecule, AWX/AAP. Triggers: 'ansible', 'playbook', 'role', 'inventory', 'group_vars', 'ansible-lint'. Not for shell scripts (use command-prompt).
 license: MIT
 compatibility: "Requires ansible-core and Python 3.9+. Optional: ansible-lint, molecule"
 metadata:

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: anti-ai-prose
 description: >
-  · Audit prose for AI tells in docs, READMEs, PRs, commits, emails, slides, and
-  docstrings. Checks vocabulary, syntax, tone, and formatting. Triggers: 'ai writing',
-  'sounds like chatgpt', 'ai slop prose', 'llm voice', 'sound human', 'prose review'.
-  Not for code (use anti-slop).
+  · Audit prose for AI tells in docs, PRs, emails, slides, docstrings. Triggers: 'ai writing', 'sounds like chatgpt', 'ai slop prose', 'llm voice', 'sound human'. Not for code (use anti-slop).
 license: MIT
 compatibility: "None - works on any prose or text input"
 metadata:

--- a/skills/anti-slop/SKILL.md
+++ b/skills/anti-slop/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: anti-slop
 description: >
-  · Audit code for AI slop: hallucinated APIs, over-abstraction, duplicate code, test
-  theater, redundant comments, and dependency creep. Triggers: 'slop', 'AI-generated
-  code', 'copy paste', 'hallucinated API', 'cleanup', 'overengineered', 'mock-heavy
-  tests'. Not for prose (use anti-ai-prose).
+  · Audit AI-generated code slop: hallucinated APIs, over-abstraction, duplicate code, test theater, noisy comments. Triggers: 'slop', 'AI-generated code', 'cleanup', 'overengineered'. Not for prose (use anti-ai-prose).
 license: MIT
 compatibility: "None - works on any codebase"
 metadata:

--- a/skills/arch-btw/SKILL.md
+++ b/skills/arch-btw/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: arch-btw
 description: >
-  · Administer Arch, CachyOS, and Arch-based distros: pacman, AUR, systemd, boot,
-  desktop, PipeWire, GPU, gaming, and media. Triggers: 'arch linux', 'cachyos',
-  'pacman', 'paru', 'aur', 'mkinitcpio', 'bootctl', 'hyprland', 'nvidia', 'pacnew'. Not
-  for Debian/Fedora/NixOS.
+  · Administer Arch/CachyOS: pacman, AUR, systemd, boot, desktop, GPU, gaming. Triggers: 'arch linux', 'cachyos', 'pacman', 'paru', 'mkinitcpio', 'hyprland'. Not for Debian/Fedora/NixOS.
 license: MIT
 compatibility: Requires Arch Linux, CachyOS, or Arch-based distro with pacman
 metadata:

--- a/skills/backend-api/SKILL.md
+++ b/skills/backend-api/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: backend-api
 description: >
-  · Design, review, or implement HTTP APIs for FastAPI, Express, and NestJS. Covers
-  REST/OpenAPI, versioning, pagination, idempotency, OAuth/OIDC, JWT, and BFFs.
-  Triggers: 'fastapi', 'express', 'nestjs', 'openapi', 'pagination', 'idempotency',
-  'oauth', 'jwt'. Not for schemas (use databases).
+  · Design/review HTTP APIs for FastAPI, Express, NestJS: REST, OpenAPI, pagination, OAuth/JWT. Triggers: 'fastapi', 'express', 'nestjs', 'openapi', 'pagination', 'idempotency'. Not for schemas (use databases).
 license: MIT
 compatibility: "Optional: Python or Node.js framework context. Optional: OpenAPI-capable framework/docs tooling"
 metadata:

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: browse
 description: >
-  · Browse, scrape, and interact with web pages using token-efficient tools: Lightpanda,
-  Playwright MCP, agent-browser, or fetch. Triggers: 'browse', 'scrape', 'headless',
-  'open url', 'read website', 'fill form', 'web automation', 'crawl', 'playwright'. Not
-  for E2E tests (use testing).
+  · Browse/scrape web pages with Lightpanda, Playwright MCP, agent-browser, or fetch. Triggers: 'browse', 'scrape', 'headless', 'open url', 'read website', 'fill form', 'crawl'. Not for E2E tests (use testing).
 license: MIT
 compatibility: "Optional: lightpanda, @playwright/mcp, agent-browser. Falls back to WebFetch or curl"
 metadata:

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: ci-cd
 description: >
-  · Write, review, or architect CI/CD for GitHub Actions, GitLab, Forgejo/Gitea, and
-  Woodpecker. Covers SHA pinning, SBOM, runners, scans, and review gates. Triggers:
-  'ci/cd', 'pipeline', 'github actions', 'gitlab ci', 'runner', 'renovate', 'trivy',
-  'gitleaks'. Not for git workflows (use git).
+  · Write/review CI/CD for GitHub Actions, GitLab, Forgejo/Gitea, Woodpecker. Triggers: 'ci/cd', 'pipeline', 'github actions', 'gitlab ci', 'runner', 'renovate', 'trivy'. Not for git workflows (use git).
 license: MIT
 compatibility: "Optional: gh (GitHub CLI), glab (GitLab CLI), fj (Forgejo CLI)"
 paths:

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: code-review
 description: >
-  · Review code for bugs, logic errors, edge cases, races, leaks, and convention issues.
-  Triggers: 'review', 'code review', 'find bugs', 'check this', 'spot check', 'what did
-  I miss', 'sanity check'. Not for style/slop audits (use anti-slop).
+  · Review code for bugs, edge cases, races, leaks, regressions, conventions. Triggers: 'review', 'code review', 'find bugs', 'check this', 'spot check', 'sanity check'. Not for style/slop audits (use anti-slop).
 license: MIT
 compatibility: "None - works on any codebase"
 metadata:

--- a/skills/command-prompt/SKILL.md
+++ b/skills/command-prompt/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: command-prompt
 description: >
-  · Write shell commands, scripts, dotfile config, completions, or debug shell issues.
-  Covers zsh, bash, POSIX sh, fish, and nushell. Triggers: 'shell', 'script', '.zshrc',
-  '.bashrc', 'dotfiles', 'completion', 'alias', 'zsh', 'bash', 'fish', 'heredoc',
-  'trap'. Not for CI blocks (use ci-cd).
+  · Write/debug shell commands, scripts, dotfiles, completions for zsh, bash, POSIX sh, fish. Triggers: 'shell', 'script', '.zshrc', '.bashrc', 'alias', 'completion', 'trap'. Not for CI blocks (use ci-cd).
 license: MIT
 compatibility: "Requires a POSIX-compatible shell. Zsh, bash, fish, or nushell for shell-specific features"
 metadata:

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: databases
 description: >
-  · Configure, tune, migrate, or review PostgreSQL, MongoDB, MySQL/MariaDB, and MSSQL.
-  Covers schemas, replication, pooling, backups, and performance. Triggers: 'database',
-  'postgres', 'mysql', 'mongodb', 'schema', 'migration', 'pgbouncer', 'EXPLAIN', 'slow
-  query', 'pg_dump'.
+  · Configure/tune/migrate PostgreSQL, MongoDB, MySQL/MariaDB, MSSQL. Triggers: 'database', 'postgres', 'mysql', 'mongodb', 'schema', 'migration', 'pgbouncer', 'EXPLAIN'.
 license: MIT
 compatibility: "Requires one or more of: psql, mongosh, mysql, or sqlcmd"
 metadata:

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: debian-ubuntu
 description: >
-  · Administer Debian, Ubuntu, and derivatives: apt, dpkg, PPAs, snaps, systemd, GRUB,
-  desktop, PipeWire, GPU, firmware, and upgrades. Triggers: 'debian', 'ubuntu', 'mint',
-  'popos', 'apt', 'dpkg', 'ppa', 'snap', 'grub', 'hwe', 'do-release-upgrade'. Not for
-  Arch/Fedora/NixOS.
+  · Administer Debian/Ubuntu/Mint/Pop: apt, dpkg, PPAs, snaps, systemd, GRUB, HWE, desktop. Triggers: 'debian', 'ubuntu', 'mint', 'popos', 'apt', 'dpkg', 'ppa'. Not for Arch/Fedora/NixOS.
 license: MIT
 compatibility: Requires Debian, Ubuntu, or Debian-based distro with apt
 metadata:

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: deep-audit
 description: >
-  · Orchestrate a 5-wave repo audit across many custom skills, persist findings, and
-  generate phased tasks. Triggers: 'deep audit', 'full audit', 'comprehensive review',
-  'audit report', 'audit everything', 'mega review', 'deep review'. Not for quick sweeps
-  (use full-review).
+  · Orchestrate a 5-wave repo audit across quality, security, docs, and domain skills. Triggers: 'deep audit', 'full audit', 'comprehensive review', 'audit report', 'audit everything'. Not for quick sweeps (use full-review).
 license: MIT
 compatibility: "Requires iuliandita/skills collection installed. Subagent support strongly recommended. Optional: a brainstorming or ideation skill in the host harness (matched by name pattern) for large-audit planning handoff."
 metadata:

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: dev-cycle
 description: >
-  · Run a start-to-finish dev workflow: branch, implement, lint/test, review, docs, PR,
-  CI, merge, and release when needed. Works across GitHub, GitLab, Forgejo/Gitea, and
-  plain git. Triggers: 'start working', 'kick off', 'wrap up', 'ship this', 'ready to
-  ship'. Not for single git ops.
+  · Run dev workflow: branch, implement, lint/test, review, docs, PR, merge, release. Triggers: 'start working', 'kick off', 'wrap up', 'ship this', 'ready to ship'. Not for single git ops.
 license: MIT
 compatibility: "Requires git. Optional forge CLIs by host: gh (GitHub), glab (GitLab), tea (Forgejo/Gitea). Bitbucket uses web UI or REST API. Bare git (no remote) works via format-patch/bundle. Delegates to git, testing, code-review, update-docs, and a brainstorming skill if installed."
 metadata:

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: docker
 description: >
-  · Write, review, or debug Dockerfiles, Compose stacks, and OCI workflows. Covers
-  Podman, BuildKit, signing, hardening, and multi-stage builds. Triggers: 'docker',
-  'dockerfile', 'compose', 'container', 'podman', 'buildkit', 'distroless', 'cosign'.
-  Not for Kubernetes manifests.
+  · Write/review Dockerfiles, Compose, OCI builds, Podman/BuildKit, signing, hardening. Triggers: 'docker', 'dockerfile', 'compose', 'container', 'podman', 'buildkit'. Not for Kubernetes manifests.
 license: MIT
 compatibility: "Requires docker or podman. Optional: docker compose, buildkit, cosign, trivy"
 paths:

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: firewall-appliance
 description: >
-  · Manage, troubleshoot, or harden OPNsense/pfSense via SSH: pfctl, pf rules, CARP,
-  CrowdSec, pfBlockerNG, and BSD appliances. Triggers: 'opnsense', 'pfsense', 'pfctl',
-  'CARP', 'CrowdSec', 'pfBlockerNG', 'configctl'. Not for Linux firewalls.
+  · Manage OPNsense/pfSense via SSH: pfctl, pf rules, CARP, CrowdSec, pfBlockerNG. Triggers: 'opnsense', 'pfsense', 'pfctl', 'CARP', 'configctl'. Not for Linux firewalls.
 license: MIT
 compatibility: "Requires SSH access to OPNsense or pfSense appliance"
 metadata:

--- a/skills/full-review/SKILL.md
+++ b/skills/full-review/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: full-review
 description: >
-  · Run a full repo review by combining code-review, anti-slop, security-audit, and
-  update-docs. Triggers: 'full review', 'review everything', 'audit this repo', 'full
-  check', 'run all checks'. Not for single-dimension audits.
+  · Run combined code-review, anti-slop, security-audit, and update-docs pass. Triggers: 'full review', 'review everything', 'audit this repo', 'full check', 'run all checks'. Not for single-dimension audits.
 license: MIT
 compatibility: "Requires code-review, anti-slop, security-audit, update-docs skills installed"
 metadata:

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: git
 description: >
-  · Handle git operations: branches, commits, remotes, conflicts, hooks, signing,
-  releases, PR/MR workflows, GitHub, GitLab, Forgejo, and Gitea. Triggers: 'git',
-  'commit', 'branch', 'merge', 'rebase', 'tag', 'push', 'PR', 'MR', 'release', 'gh',
-  'glab', 'forgejo'.
+  · Handle git branches, commits, remotes, conflicts, hooks, signing, releases, PR/MR workflows. Triggers: 'git', 'commit', 'branch', 'merge', 'rebase', 'tag', 'push', 'PR', 'MR', 'gh', 'glab'.
 license: MIT
 compatibility: "Requires git. Optional: gh (GitHub CLI), glab (GitLab CLI), fj (Forgejo CLI)"
 metadata:

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: kali-linux
 description: >
-  · Administer Kali Linux: apt, branches, metapackages, images, live USB persistence,
-  ARM/Purple images, NetHunter, wireless, GPU, and lab hygiene. Triggers: 'kali', 'kali
-  rolling', 'kali snapshot', 'kali-tweaks', 'nethunter', 'kali tools', 'kali live usb'.
-  Not for exploitation.
+  · Administer Kali: apt, branches, metapackages, images, live USB persistence, NetHunter, wireless/GPU. Triggers: 'kali', 'kali rolling', 'kali snapshot', 'kali-tweaks', 'nethunter'. Not for exploitation.
 license: MIT
 compatibility: Requires Kali Linux or Kali images with apt and Kali repositories
 metadata:

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: kubernetes
 description: >
-  · Write, review, or architect Kubernetes manifests, Helm charts, and cluster
-  infrastructure. Covers Gateway API, Kustomize, ArgoCD, sealed secrets, and supply
-  chain security. Triggers: 'kubernetes', 'k8s', 'helm', 'kubectl', 'deployment', 'pod',
-  'ingress', 'gateway', 'argocd', 'sealed-secrets'.
+  · Write/review Kubernetes manifests, Helm, Kustomize, Gateway API, ArgoCD, sealed secrets. Triggers: 'kubernetes', 'k8s', 'helm', 'kubectl', 'deployment', 'pod', 'ingress', 'gateway'.
 license: MIT
 compatibility: "Requires kubectl. Optional: helm, kustomize, kube-score, cosign"
 metadata:

--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: localize
 description: >
-  · Localize apps and audit i18n: hardcoded strings, locale catalogs, translations, and
-  completeness. Covers React, Next.js, Vue, Svelte, Angular, and JS/TS. Triggers:
-  'i18n', 'internationalization', 'localization', 'l10n', 'locale', 'hardcoded strings',
-  'next-intl'. Not for prose translation.
+  · Audit app i18n/l10n: hardcoded strings, locale catalogs, translations, fallback gaps. Triggers: 'i18n', 'internationalization', 'localization', 'locale', 'hardcoded strings', 'next-intl'. Not for prose translation.
 license: MIT
 compatibility: "Requires Node.js 20+. Optional: react-i18next, vue-i18n, next-intl, svelte-i18n, ngx-translate, i18next (per framework)"
 metadata:

--- a/skills/lockpick/SKILL.md
+++ b/skills/lockpick/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: lockpick
 description: >
-  · Handle authorized privesc, CTFs, and post-exploitation on Linux, containers, and
-  K8s. Covers pivoting, credential extraction, and IaC secrets. Triggers: 'privesc',
-  'CTF', 'pentest', 'post-exploitation', 'container escape', 'SUID', 'sudo abuse',
-  'reverse shell', 'GTFOBins'. Not for hardening.
+  · Handle authorized privesc, CTFs, post-exploitation on Linux, containers, K8s. Triggers: 'privesc', 'CTF', 'pentest', 'post-exploitation', 'container escape', 'SUID', 'GTFOBins'. Not for hardening.
 license: MIT
 compatibility: Requires authorized access to target Linux systems and bash/python
 metadata:

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: mcp
 description: >
-  · Build, review, or debug MCP servers, tools, resources, prompts, transports, OAuth
-  2.1 auth, and handlers. Triggers: 'mcp', 'model context protocol', 'mcp server', 'mcp
-  tool', 'tool handler', 'fastmcp', '@modelcontextprotocol/sdk', 'mcp inspector'. Not
-  for general APIs.
+  · Build/review MCP servers, tools, resources, prompts, transports, OAuth, handlers. Triggers: 'mcp', 'model context protocol', 'mcp server', 'tool handler', 'fastmcp', '@modelcontextprotocol/sdk'. Not for APIs.
 license: MIT
 compatibility: Requires Node.js or Python runtime
 metadata:

--- a/skills/networking/SKILL.md
+++ b/skills/networking/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: networking
 description: >
-  · Configure or troubleshoot Linux networking: DNS, proxies, VPNs, VLANs, nftables,
-  load balancing, overlays, routing, and performance. Triggers: 'dns', 'reverse proxy',
-  'vpn', 'wireguard', 'tailscale', 'vlan', 'nftables', 'nginx', 'mtr', 'tcpdump',
-  'bgp'. Not for OPNsense (use firewall-appliance).
+  · Configure/troubleshoot Linux networking: DNS, proxies, VPNs, VLANs, nftables, routing. Triggers: 'dns', 'reverse proxy', 'vpn', 'wireguard', 'tailscale', 'vlan', 'nftables', 'mtr'. Not for OPNsense.
 license: MIT
 compatibility: "Requires Linux. Tools vary by task: nftables, WireGuard, dig, mtr, tcpdump"
 metadata:

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: nixos-btw
 description: >
-  · Administer NixOS, Nix, home-manager, nix-darwin, flakes, generations, rollbacks,
-  overlays, disko, impermanence, Determinate Nix, and Lix. Triggers: 'nixos', 'nix',
-  'flake', 'home-manager', 'configuration.nix', 'nixos-rebuild', 'nix-shell', 'nix
-  develop', 'disko'. Not for other distros.
+  · Administer NixOS/Nix: flakes, home-manager, nix-darwin, generations, overlays, disko. Triggers: 'nixos', 'nix', 'flake', 'home-manager', 'configuration.nix', 'nixos-rebuild'. Not for other distros.
 license: MIT
 compatibility: "Requires NixOS, or Nix/Determinate Nix/Lix on Linux/macOS/WSL"
 metadata:

--- a/skills/prompt-generator/SKILL.md
+++ b/skills/prompt-generator/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: prompt-generator
 description: >
-  · Turn rough notes into structured LLM prompts, or refine existing prompts. Triggers:
-  'write a prompt', 'system prompt', 'prompt template', 'prompt engineering', 'rewrite
-  this prompt', 'improve this prompt'. Not for creating skills or cloud routines.
+  · Turn notes into structured LLM prompts or improve existing prompts. Triggers: 'write a prompt', 'system prompt', 'prompt template', 'prompt engineering', 'rewrite this prompt'. Not for skills or routines.
 license: MIT
 compatibility: "Model-agnostic. Optional: tailor output format to Claude, GPT, or Gemini when target is known"
 metadata:

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: rhel-fedora
 description: >
-  · Administer RHEL, Fedora, CentOS Stream, Rocky, Alma, Oracle, and Amazon Linux: dnf,
-  yum, SELinux, systemd, dracut, firewalld, and GPU. Triggers: 'rhel', 'fedora', 'centos
-  stream', 'rocky', 'alma', 'dnf', 'yum', 'selinux', 'rpm fusion', 'akmods'. Not for
-  other distros.
+  · Administer RHEL/Fedora/CentOS/Rocky/Alma/Amazon Linux: dnf, yum, SELinux, firewalld, dracut. Triggers: 'rhel', 'fedora', 'centos stream', 'rocky', 'dnf', 'selinux'. Not for other distros.
 license: MIT
 compatibility: Requires Fedora, RHEL, or RHEL-family distro with dnf, yum, or rpm
 metadata:

--- a/skills/roadmap/SKILL.md
+++ b/skills/roadmap/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: roadmap
 description: >
-  · Capture project ideas, track progress, scout competitors, and prioritize a
-  gitignored ROADMAP.md. Triggers: 'roadmap', 'ideas', 'feature ideas', 'competitive
-  analysis', 'what should I build', 'feature backlog'. Not for structured project
-  management or code review.
+  · Maintain a gitignored ROADMAP.md: ideas, shipped work, priorities, competitors. Triggers: 'roadmap', 'ideas', 'feature ideas', 'competitive analysis', 'what should I build'. Not for code review.
 license: MIT
 compatibility: "Requires git. Optional: gh (GitHub CLI) or glab (GitLab CLI) for PR tracking and competitive scanning"
 metadata:

--- a/skills/routine-writer/SKILL.md
+++ b/skills/routine-writer/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: routine-writer
 description: >
-  · Write Claude Code routine prompts for unattended cloud tasks via schedule, API, or
-  GitHub events. Emits routine text, /schedule commands, and /fire curl templates.
-  Triggers: 'routine', 'claude routine', 'scheduled claude task', 'unattended claude',
-  '/schedule'. Not for one-off prompts.
+  · Write Claude Code routine prompts for unattended schedules, APIs, GitHub events. Triggers: 'routine', 'claude routine', 'scheduled claude task', 'unattended claude', '/schedule', '/fire'. Not for one-off prompts.
 license: MIT
 compatibility: "Routines require a Pro, Max, Team, or Enterprise plan with Claude Code on the web. CLI automation requires the claude binary on PATH"
 metadata:

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: security-audit
 description: >
-  · Audit code for security issues: OWASP, credentials, auth, access control, supply
-  chain, and pre-release checks. Triggers: 'security audit', 'vulnerability scan',
-  'secret scan', 'OWASP', 'hardening', 'auth review'. Not for offensive work (use
-  lockpick).
+  · Audit code security: OWASP, credentials, auth, access control, supply chain, hardening. Triggers: 'security audit', 'vulnerability scan', 'secret scan', 'OWASP', 'auth review'. Not for offensive work.
 license: MIT
 compatibility: "Optional: betterleaks, gitleaks, trivy, semgrep, bandit, checkov, scorecard"
 metadata:

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: skill-creator
 description: >
-  · Create, review, audit, or improve skills: frontmatter, triggers, overlaps,
-  collection consistency, and descriptions. Triggers: 'skill creator', 'new skill',
-  'skill audit', 'skill review', 'skill quality', 'frontmatter', 'skill overlap'. Prefer
-  this for skill-file work.
+  · Create/review skills: frontmatter, triggers, overlaps, collection consistency, descriptions. Triggers: 'skill creator', 'new skill', 'skill audit', 'skill review', 'frontmatter', 'skill overlap'.
 license: MIT
 compatibility: "Optional: git (for freshness and gitignore filtering)"
 metadata:
@@ -54,7 +51,7 @@ Before returning any generated or modified skill, verify against this list:
 - [ ] **Name spec-valid**: lowercase alphanumeric + hyphens only, no leading/trailing/consecutive
   hyphens, no reserved words (`anthropic`, `claude`), matches directory name
 - [ ] **No XML tags** in `name` or `description` fields (Anthropic platform restriction)
-- [ ] **Description is trigger-optimized**: starts with action verbs, includes trigger keywords, mentions related contexts, stays near 300 chars for the collection (600 hard max in `validate-spec.sh`; platform truncation happens later)
+- [ ] **Description is trigger-optimized**: starts with action verbs, includes trigger keywords, mentions related contexts, stays near 200 chars for the collection (240 warn, 600 hard max in `validate-spec.sh`; platform truncation happens later)
 - [ ] **Compatibility field present** (when skill requires specific tools/platforms): quotes values containing colons
 - [ ] **Scope sections present**: "When to use" with concrete scenarios, "When NOT to use"
   cross-referencing related skills by **bold** name (e.g., `use **skill-name**`)
@@ -417,7 +414,7 @@ Follow these patterns from high-performing custom skill descriptions:
 - **Include specific trigger keywords**: list them inline, e.g., "Triggers: 'keyword1', 'keyword2'"
 - **Mention adjacent skills to avoid**: "Not for X (use Y instead)"
 - **Be slightly pushy**: many tools undertrigger skills by default. Include edge cases.
-- **Stay near 300 characters**: the collection warns above 300 and errors above 600. Codex loads every skill description at startup, so concise descriptions prevent startup truncation.
+- **Stay near 200 characters**: the collection warns above 240 and errors above 600. Codex loads every skill description at startup, so concise descriptions prevent startup truncation.
 - **Treat 1024 as the platform ceiling, not the collection target**: truncation happens there, but the repo convention is stricter
 
 #### Step 4: Validate

--- a/skills/skill-creator/references/conventions.md
+++ b/skills/skill-creator/references/conventions.md
@@ -85,7 +85,7 @@ succeeded" invites the agent to invent checks with wrong paths and service names
 ```yaml
 ---
 name: skill-name              # lowercase a-z, 0-9, hyphens; no leading/trailing/consecutive hyphens; max 64 chars; must match directory name; no reserved words (anthropic, claude)
-description: >                # target ~300 chars, 600 hard max in this collection; platform truncates later
+description: >                # target ~200 chars, warn above 240, 600 hard max; platform truncates later
   Use when... Also use for... Triggers: '...', '...'.
 license: MIT                  # Agent Skills spec field
 metadata:
@@ -130,7 +130,7 @@ user confirmation in steps that could run unattended.
 | Field | Values | Purpose |
 |-------|--------|---------|
 | `name` | `a-z`, `0-9`, hyphens; no leading/trailing/consecutive hyphens; max 64 chars; no reserved words (`anthropic`, `claude`) | identifier, must match directory name |
-| `description` | free text, target ~300 chars, 600 hard max in this collection, no XML tags | primary trigger mechanism - the agent scans this |
+| `description` | free text, target ~200 chars, warn above 240, 600 hard max, no XML tags | primary trigger mechanism - the agent scans this |
 | `license` | license name (e.g., `MIT`) | Agent Skills spec field |
 | `compatibility` | free text, <500 chars | environment requirements (optional) |
 | `metadata.source` | `owner/repo` or `custom` | identifies the publishing collection or an unpublished local skill |

--- a/skills/skill-refiner/SKILL.md
+++ b/skills/skill-refiner/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: skill-refiner
 description: >
-  · Batch-improve skill collections with adaptive evaluation loops, lint checks,
-  behavioral tests, and peer review. Triggers: 'skill refiner', 'improve skills',
-  'quality sweep', 'batch improve', 'skill loop'. Not for single skill work (use
-  skill-creator).
+  · Batch-improve skill collections with evaluation loops, lint checks, behavioral tests, peer review. Triggers: 'skill refiner', 'improve skills', 'quality sweep', 'batch improve', 'skill loop'. Not for one skill.
 license: MIT
 compatibility: "Requires: skill-creator skill, git. Optional: secondary AI harness (codex, claude, opencode) for cross-model review"
 metadata:

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: terraform
 description: >
-  · Write, review, or architect Terraform/OpenTofu IaC: HCL patterns, modules, state,
-  and policy-as-code. Triggers: 'terraform', 'opentofu', 'hcl', 'tfvars', 'tfstate',
-  'module', 'terraform plan', 'sentinel', 'checkov', 'tflint'.
+  · Write/review Terraform/OpenTofu HCL, modules, state, policy-as-code. Triggers: 'terraform', 'opentofu', 'hcl', 'tfvars', 'tfstate', 'module', 'terraform plan', 'tflint'.
 license: MIT
 compatibility: "Requires terraform or tofu CLI. Optional: tflint, checkov, conftest"
 metadata:

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: testing
 description: >
-  · Write, review, or debug tests: unit, integration, E2E, TDD, mocking, fixtures,
-  accessibility, visual regression, and perf. Triggers: 'test', 'spec', 'TDD',
-  'playwright', 'vitest', 'jest', 'pytest', 'cypress', 'coverage', 'flaky test',
-  'mock', 'a11y'. Not for security tests (use security-audit).
+  · Write/debug tests: unit, integration, E2E, TDD, mocks, fixtures, a11y, perf. Triggers: 'test', 'spec', 'TDD', 'playwright', 'vitest', 'jest', 'pytest', 'coverage', 'flaky'. Not for security tests.
 license: MIT
 compatibility: "Requires one or more of: vitest, jest, pytest, go test, cargo test, playwright"
 metadata:

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: update-docs
 description: >
-  · Sweep docs after changes: instructions, README, changelog, API docs, roadmaps,
-  feature docs, and runbooks. Triggers: 'update docs', 'refresh docs', 'sync docs',
-  'docs drift', 'merged PR', 'release cut', 'update changelog', 'update README'. Not for
-  PR text or roadmaps (use git/roadmap).
+  · Sweep docs after changes: README, changelog, API docs, runbooks, gotchas. Triggers: 'update docs', 'refresh docs', 'docs drift', 'update changelog', 'update README'. Not for PR text or roadmaps.
 license: MIT
 compatibility: "Requires git. Optional: wc (for size audits)"
 metadata:

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: virtualization
 description: >
-  · Create, configure, or troubleshoot VMs and hypervisors: Proxmox, libvirt/QEMU/KVM,
-  XCP-ng, and vSphere. Covers passthrough, storage, cloud-init, and Packer. Triggers:
-  'proxmox', 'qemu', 'kvm', 'libvirt', 'virsh', 'vm', 'vsphere', 'pci passthrough',
-  'cloud-init'. Not for containers.
+  · Create/troubleshoot VMs and hypervisors: Proxmox, QEMU/KVM, libvirt, XCP-ng, vSphere. Triggers: 'proxmox', 'qemu', 'kvm', 'libvirt', 'virsh', 'vm', 'cloud-init'. Not for containers.
 license: MIT
 compatibility: "Varies by hypervisor. Proxmox: pvesh, qm, pct. Libvirt: virsh, virt-install. Optional: packer, terraform"
 metadata:

--- a/skills/zero-day/SKILL.md
+++ b/skills/zero-day/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: zero-day
 description: >
-  · Hunt for novel vulnerabilities in source, binaries, or live systems: reversing,
-  patch diffing, fuzzing, attack surface mapping, PoCs, and disclosure. Triggers:
-  'zero-day', '0-day', 'vulnerability research', 'variant analysis', 'patch diffing',
-  'fuzz', 'exploit dev', 'CVE', 'PoC'. Not for SAST.
+  · Hunt novel vulnerabilities: reversing, patch diffing, fuzzing, attack surface, PoCs. Triggers: 'zero-day', '0-day', 'vulnerability research', 'variant analysis', 'fuzz', 'exploit dev', 'CVE'. Not for SAST.
 license: MIT
 compatibility: "Optional: codeql, semgrep, joern, ghidra, radare2/rizin, afl++, gdb, pwntools, strace, ltrace, checksec"
 metadata:


### PR DESCRIPTION
## Summary
- add installer targets for OpenClaw, Hermes, Qwen Code, Crush, Antigravity, Augment, OpenHands, Trae, Qoder, and Kimi
- document NanoClaw as project-local via --dest instead of a global target
- lower the public skill description target and compact descriptions for Codex startup budgets

## Test plan
- bash -n install.sh
- ./scripts/validate-spec.sh
- ./scripts/lint-skills.sh
- installer target smoke test for new targets and aliases
- git diff --cached --check
- cached diff secret-pattern scan