### PR TITLE
feat(ai-ml): llama.cpp CPU inference + collection-wide quality sweep

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -12,5 +12,6 @@ exclude = [
   "^http://169\\.254\\.169\\.254",
   "^https?://(?:[A-Za-z0-9-]+\\.)?example\\.(?:com|org)",
   "^https?://example-store\\.com",
-  "^https?://internal\\.example\\.com"
+  "^https?://internal\\.example\\.com",
+  "^https?://claude\\.ai"
 ]

--- a/skills/.refiner-runs.json
+++ b/skills/.refiner-runs.json
@@ -22,7 +22,10 @@
       "plateau": 2
     },
     "pool_size": 23,
-    "excluded": ["skill-creator", "skill-refiner"],
+    "excluded": [
+      "skill-creator",
+      "skill-refiner"
+    ],
     "terminated": "iteration-cap",
     "iterations_completed": 5,
     "cross_model_flags": {
@@ -32,7 +35,11 @@
     },
     "scores": {
       "before": {
-        "aggregate": { "avg": 83.5, "min": 76.7, "max": 87.6 },
+        "aggregate": {
+          "avg": 83.5,
+          "min": 76.7,
+          "max": 87.6
+        },
         "per_skill": {
           "ai-ml": 78.8,
           "ansible": 85.2,
@@ -60,7 +67,11 @@
         }
       },
       "after": {
-        "aggregate": { "avg": 85.1, "min": 79.7, "max": 87.6 },
+        "aggregate": {
+          "avg": 85.1,
+          "min": 79.7,
+          "max": 87.6
+        },
         "per_skill": {
           "ai-ml": 81.6,
           "ansible": 85.2,
@@ -101,5 +112,54 @@
       "command-prompt: compatibility field",
       "skill-refiner: Phase 3 summary template with run provenance"
     ]
+  },
+  {
+    "run_id": "2026-04-25-194814",
+    "branch": "chore/skills-quality-sweep",
+    "date": "2026-04-25",
+    "primary": {
+      "harness": "claude-code",
+      "version": "2.1.119",
+      "model": "claude-opus-4-7-1m",
+      "effort": "high"
+    },
+    "secondary": {
+      "harness": "codex-cli",
+      "version": "0.125.0",
+      "model": "gpt-5.4",
+      "effort": "high"
+    },
+    "config": {
+      "iterations": 8,
+      "threshold": 95,
+      "mode": "circuit-breaker",
+      "plateau": 2
+    },
+    "pool_size": 36,
+    "excluded": [
+      "skill-creator",
+      "skill-refiner"
+    ],
+    "terminated": "all-clean",
+    "iterations_completed": 8,
+    "cross_model_flags": {
+      "minor": 0,
+      "major": 1,
+      "contested": 0,
+      "agreed": 1,
+      "disputed": 1
+    },
+    "changes_summary": [
+      "description trims: cluster-health, roadmap, deep-audit, update-docs (length warnings cleared)",
+      "fancy arrow -> ASCII in 4 reference files (CLAUDE.md compliance)",
+      "routing hints added: dev-cycle, docker, kali-linux, lockpick, networking, routine-writer, security-audit, skill-refiner, virtualization, zero-day (10 skills)",
+      "Not for X (use Y) clarifications: mcp, testing",
+      "restored audit report trigger (deep-audit, codex flag agreed)",
+      "version freshness sweep: ci-cd, docker, kubernetes, networking, firewall-appliance, ai-ml, security-audit, git, mcp, terraform, ansible, command-prompt (12 skills, web-verified Apr 2026)",
+      "LTS annotations: kubernetes (1.32 LTS), docker (containerd 2.3 LTS), ansible (2.20.x LTS), networking (OpenVPN 2.6 LTS), helm 3.20.x LTS",
+      "ai-ml: added CPU-only llama.cpp section + benchmarking; expanded references/local-inference.md (179 lines) with build walkthrough, NUMA, mlock"
+    ],
+    "lint_status": "PASSED 0/0",
+    "spec_status": "PASSED 0/0"
   }
 ]

--- a/skills/ai-ml/SKILL.md
+++ b/skills/ai-ml/SKILL.md
@@ -23,16 +23,16 @@ cost-effective, and don't hallucinate their way into an incident.
 |-----------|---------|-------|
 | Anthropic Python SDK | 0.87.0 | Claude models, streaming, tool use, structured output |
 | Anthropic TS SDK | 0.81.0 | Same capabilities, TypeScript-first |
-| Claude Agent SDK (TS) | 0.2.90 | Programmatic agent building with Claude Code capabilities |
-| OpenAI Python SDK | 2.30.0 | GPT/o-series models, Responses API |
+| Claude Agent SDK (TS) | 0.2.117 | Programmatic agent building with Claude Code capabilities |
+| OpenAI Python SDK | 2.32.0 | GPT/o-series models, Responses API |
 | OpenAI Agents SDK | 0.13.3 | Multi-agent orchestration, tracing, sessions |
 | Vercel AI SDK | 6.0.142 | Unified provider interface, ToolLoopAgent, streaming |
-| LangChain | 1.2.14 | Orchestration framework, langchain-core 1.2.24 |
-| LangGraph | 1.1.0 | Stateful agent graphs, cycles, persistence |
-| LlamaIndex | 0.14.19 | RAG framework, 300+ integrations |
+| LangChain | 1.2.15 | Orchestration framework, langchain-core 1.2.24 |
+| LangGraph | 1.1.8 | Stateful agent graphs, cycles, persistence |
+| LlamaIndex | 0.14.21 | RAG framework, 300+ integrations |
 | Transformers | 5.4.0 | Model inference, fine-tuning, PyTorch 2.4+ required |
 | vLLM | 0.18.1 | High-throughput serving, continuous batching |
-| Ollama | 0.19.0 | Local inference, MLX backend on Apple Silicon |
+| Ollama | 0.20.0 | Local inference, MLX backend on Apple Silicon |
 | pgvector | 0.8.2 | PostgreSQL extension, HNSW + IVFFlat |
 | Qdrant | 1.17.1 | Self-hosted vector DB, hybrid search |
 | Pinecone (Python) | 8.1.0 | Managed vector DB |
@@ -356,11 +356,38 @@ training, and when to use full fine-tuning vs parameter-efficient methods.
 |------|----------|-------------|
 | Ollama | Dev, prototyping, Mac (MLX) | No (CPU/MLX), optional GPU |
 | vLLM | Production serving, high throughput | Yes |
-| llama.cpp / llama-cpp-python | Minimal deps, quantized models | No (CPU), optional GPU |
+| llama.cpp / llama-cpp-python | Minimal deps, quantized models, CPU-only | No (CPU), optional GPU |
 | TGI (HF Text Generation Inference) | HF model hub integration | Yes |
 
-Read `references/local-inference.md` for quantization choices, model selection, GPU memory
-estimation, and production serving configuration.
+### CPU-only inference with llama.cpp
+
+CPU inference is viable - sometimes preferable - for: dense models that fit in RAM (7-13B
+at Q4 hits 5-10 t/s on modern x86), **MoE models with low active params** (Qwen3-30B-A3B
+at Q4 reaches 13+ t/s even on a 2013-era Xeon - active params dominate decode), and
+air-gapped or compliance-bound environments. Key gotchas:
+
+- **ISA cliff**: pre-Haswell CPUs lack AVX2/FMA/BMI2. PyTorch >= 2.1, TF >= 2.8, JAX, and
+  Ollama prebuilts SIGILL. llama.cpp from source with `-DGGML_AVX2=OFF -DGGML_FMA=OFF
+  -DGGML_BMI2=OFF` works.
+- **GGUF quants**: `Q4_K_M` is the default sweet spot. `Q5_K_M` for +25% memory and quality.
+  `IQ4_XS` for tighter budgets. Avoid Q2/Q3 - quality cliff is real.
+- **Reproducible models**: pin both filename and HF commit SHA. Bare repo+filename pulls
+  "whatever the author serves now" - silent runtime changes on rebase.
+- **`--mlock`** page-faults the GGUF into RAM at start. Sum GGUF sizes for capacity planning.
+- **Threading**: `-t = physical_cores - 4` (decode, memory-bandwidth-bound), `-tb = logical`
+  (prefill, compute-bound).
+- **API keys**: `--api-key-file <path>`, never `--api-key <value>` on the command line - leaks
+  into `/proc/<pid>/cmdline` via systemd env expansion.
+
+### Benchmarking
+
+Fixed prompt suite (chat-short, chat-long, code-simple, code-complex, reasoning), warmup pass,
+record latency + decode t/s at fixed `max_tokens` and temperature. Re-run after model swaps,
+llama.cpp version bumps, or build-flag changes. Compare **decode t/s**, not raw latency.
+
+Read `references/local-inference.md` for the full llama.cpp build walkthrough (per-CPU-generation
+flags), HF SHA-pinned model download, systemd-per-model deployment, NUMA tuning, mlock memory
+budgeting, benchmark methodology, and production serving configuration.
 
 ---
 

--- a/skills/ai-ml/references/local-inference.md
+++ b/skills/ai-ml/references/local-inference.md
@@ -1,7 +1,8 @@
 # Local Inference
 
 Running models locally with Ollama, vLLM, llama.cpp, and HF Text Generation Inference.
-Covers model selection, quantization, GPU memory estimation, and production serving.
+Covers model selection, quantization, GPU memory estimation, CPU-only deployments, and
+production serving.
 
 ---
 
@@ -15,6 +16,9 @@ Covers model selection, quantization, GPU memory estimation, and production serv
 6. Model Selection
 7. GPU Memory Estimation
 8. Production Serving
+9. llama.cpp from source (CPU-only)
+10. Benchmarking methodology
+11. NUMA, threading, mlock
 
 ---
 
@@ -308,3 +312,178 @@ curl http://localhost:8000/v1/models
 - **Model caching**: keep models loaded in memory. Cold starts take minutes for large models.
 - **Request routing**: route requests by model to dedicated instances. Don't serve multiple
   models on the same GPU unless they're small.
+
+---
+
+## 9. llama.cpp from source (CPU-only)
+
+When `pip install llama-cpp-python` or `ollama` prebuilts crash with SIGILL, you're hitting
+the AVX2 cliff. Build from source with the right cmake flags for your CPU generation.
+
+### Detect ISA support
+
+```bash
+grep -o 'avx[2]*\|fma\|bmi2\|f16c' /proc/cpuinfo | sort -u
+```
+
+### Build flags by CPU generation
+
+| Generation | AVX | AVX2 | FMA | BMI2 | F16C | AVX-512 |
+|---|---|---|---|---|---|---|
+| Sandy/Ivy Bridge (2011-2013) | yes | NO | NO | NO | yes (Ivy+) | NO |
+| Haswell/Broadwell (2013-2015) | yes | yes | yes | yes | yes | NO |
+| Skylake-X / Cascade Lake (2017+) | yes | yes | yes | yes | yes | yes |
+| Zen 1/2 (2017-2019) | yes | yes | yes | yes | yes | NO |
+| Zen 3+ (2020+) | yes | yes | yes | yes | yes | yes (Zen 4+) |
+
+Set `-DGGML_<feature>=OFF` for any feature your CPU lacks. Setting one wrong produces a
+binary that links cleanly and SIGILLs on the first matrix multiply.
+
+### Full build for pre-Haswell
+
+```bash
+sudo apt install -y build-essential cmake git ccache libcurl4-openssl-dev
+
+git clone https://github.com/ggml-org/llama.cpp.git /opt/llama.cpp
+cd /opt/llama.cpp
+git checkout b8920  # pin a known-good tag
+
+cmake -B build \
+  -DGGML_NATIVE=OFF \
+  -DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF \
+  -DGGML_F16C=ON -DGGML_BMI2=OFF \
+  -DGGML_AVX512=OFF -DGGML_AVX512_VBMI=OFF -DGGML_AVX512_VNNI=OFF \
+  -DGGML_AVX_VNNI=OFF -DGGML_CUDA=OFF \
+  -DLLAMA_CURL=ON -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build --config Release -j"$(nproc)"
+sudo cmake --install build --prefix /usr/local
+```
+
+### Pin model files reproducibly
+
+```bash
+# Pin both file and revision (HF commit SHA)
+huggingface-cli download \
+  unsloth/Qwen3-30B-A3B-GGUF Qwen3-30B-A3B-Q4_K_M.gguf \
+  --revision d5b1d57bd0b504ac62ae6c725904e96ef228dc74 \
+  --local-dir /var/lib/llama/models
+```
+
+A bare repo+filename pulls "whatever the author serves now". Author rebases silently change
+runtime behavior.
+
+### Run as a server
+
+```bash
+llama-server \
+  --model /var/lib/llama/models/Qwen3-30B-A3B-Q4_K_M.gguf \
+  --host 0.0.0.0 --port 8080 \
+  --ctx-size 32768 --cache-reuse 256 \
+  --threads 28 --threads-batch 32 \
+  --temp 0.7 --top-k 20 --top-p 0.8 \
+  --mlock --api-key-file /etc/llama/api-key.txt
+```
+
+Endpoint is OpenAI-compatible at `/v1/chat/completions`. Point any OpenAI client at it.
+
+### One systemd unit per model
+
+For multi-model deployment, create one `llama-server-<alias>.service` per model on its own
+port. Independent unit files mean independent restarts, separate logs, and no shared crash
+blast radius. Don't try to multiplex multiple models behind a single llama-server process.
+
+---
+
+## 10. Benchmarking methodology
+
+Establish baseline numbers before tuning anything. Re-bench after every model swap,
+llama.cpp version bump, or cmake flag change.
+
+### Fixed prompt suite
+
+A reusable benchmark needs five prompts at minimum:
+
+| Class | Prompt shape | Why |
+|---|---|---|
+| chat-short | "What is X?" (1 sentence answer) | Pure decode latency, low prefill cost |
+| chat-long | Multi-turn context (~32 tokens prompt) | KV cache reuse behavior |
+| code-simple | "Write a Python function that..." | Short prefill, long decode |
+| code-complex | Diff-style refactor with 50+ tokens of context | Realistic prefill |
+| reasoning | Math word problem requiring chain-of-thought | Tests sustained decode |
+
+For each: warm up once (discard), then record `latency`, `prompt_tokens`, `completion_tokens`,
+and `decode_tok_per_sec` over a fixed `max_tokens` cap (e.g., 400) at fixed temperature
+(e.g., 0.3 - low for reproducibility).
+
+### Output format
+
+Versioned markdown table per run. The header captures host, started-at, max_tokens,
+temperature, and warmup. Diffs across runs become readable.
+
+```markdown
+# AI VM Model Benchmark
+- Host: http://192.168.x.x
+- Started: 2026-04-25T01:19:12+02:00
+- max_tokens: 400, temperature: 0.3, warmup: yes
+
+| model | test | latency (s) | prompt_tok | completion_tok | decode t/s |
+|---|---|---:|---:|---:|---:|
+| qwen3-30b-a3b-q4 | chat-short | 24.37 | 19 | 327 | 13.42 |
+```
+
+### What to actually compare
+
+- **decode t/s** (not latency) - latency conflates prefill cost with decode speed
+- **decode t/s at fixed completion_tokens** - short outputs misleadingly look fast
+- **across model classes**, not just within one - MoE vs dense at the same parameter count is
+  the most informative comparison
+
+### Pitfalls
+
+- Cold cache vs warm cache: always include a discarded warmup
+- Background load: bench on an otherwise-idle host
+- mlock at first run: model paging in inflates the first measurement
+
+---
+
+## 11. NUMA, threading, mlock
+
+### NUMA on multi-socket hosts
+
+Multi-socket servers expose two memory controllers. Inference threads ping-ponging across
+sockets pay a cross-socket latency penalty. Three options:
+
+- **distribute** (default): kernel spreads pages across nodes. Simple, often fine.
+- **isolate** with `numactl --cpunodebind=0 --membind=0`: pin one model to one socket.
+  Better for single-model serving on a dual-socket box where the model fits in one node's RAM.
+- **interleave** with `numactl --interleave=all`: stripe pages across nodes. Helps when the
+  model is bigger than one node's RAM.
+
+Per-model override is the right granularity. Some models prefer isolation, others don't care.
+
+### Thread tuning
+
+```
+total_threads = physical_cores            # don't include SMT siblings for decode
+threads (-t)  = physical_cores - 4        # leave 4 cores for OS, llama-server overhead, OWUI
+threads_batch (-tb) = logical_cores       # prefill scales with all logical cores
+```
+
+Going past `physical_cores` for decode hurts: cache thrashing dominates. Going under
+`logical_cores` for prefill leaves throughput on the table during prompt processing.
+
+### mlock implications
+
+`--mlock` (or `LimitMEMLOCK=infinity` in systemd) page-faults the entire GGUF into RAM at
+service start. Three consequences:
+
+1. **Eager memory accounting.** Sum the GGUF sizes of all `llama-server-*` units running on
+   the host. That's your committed RAM, before KV cache.
+2. **Slow first-request penalty disappears.** Without mlock, the first inference request
+   triggers page-ins that look like a 30-60 second hang on big models.
+3. **OOM killer is the failure mode.** Run `free -h` and verify `available` exceeds the sum
+   of GGUF sizes plus headroom (~10% per model for KV cache at advertised ctx).
+
+Disable mlock on memory-constrained hosts where you're willing to trade first-request
+latency for safer overcommit behavior.

--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -15,8 +15,8 @@ metadata:
 
 Write, review, and architect Ansible automation - from single playbooks to multi-tier, compliance-hardened infrastructure management. The goal is idempotent, auditable, maintainable automation that works the same locally and in CI/CD.
 
-**Target versions** (March 2026):
-- ansible-core 2.20.x (Python 3.12+ controller, 3.9+ target, EOL May 2027)
+**Target versions** (April 2026):
+- ansible-core **2.20.x LTS** (Python 3.12+ controller, 3.9+ target, EOL May 2027)
 - ansible (community package) 13.x (depends on ansible-core 2.20)
 - molecule 26.x (CalVer), ansible-lint 26.x (CalVer), ansible-navigator 26.x (CalVer)
 - ansible-builder 3.1.x (EE definition v3)

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -24,13 +24,13 @@ Write, review, and architect CI/CD pipelines across GitHub Actions, GitLab CI/CD
 Actions, Gitea Actions, and Woodpecker. The goal is secure, fast, auditable pipelines that
 satisfy both engineering needs and compliance requirements (PCI-DSS 4.0).
 
-**Target versions** (March 2026):
+**Target versions** (April 2026):
 - **GitHub Actions**: ubuntu-24.04 runners (ubuntu-latest), arm64 GA, artifact v4, attestations GA
-- **GitLab CI/CD**: GitLab 18.10, CI/CD Catalog GA, CI Components with typed `spec: inputs`
-- **Forgejo Actions**: Forgejo v14.0, Runner v11.x (stable; check `data.forgejo.org/forgejo/runner` releases for current major tag before pinning)
-- **Gitea Actions**: Gitea v1.23.x, act runner v0.2.x (GA since Gitea 1.21, March 2024)
+- **GitLab CI/CD**: GitLab 18.10.3, CI/CD Catalog GA, CI Components with typed `spec: inputs`
+- **Forgejo Actions**: Forgejo v15.0, Runner v11.x (stable; check `data.forgejo.org/forgejo/runner` releases for current major tag before pinning)
+- **Gitea Actions**: Gitea v1.26.0, act runner v0.2.x (GA since Gitea 1.21, March 2024)
 - **Woodpecker CI**: v3.13.x (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)
-- **Supply chain**: cosign v3.x (Sigstore), Syft/Trivy for SBOM, SLSA v1.0
+- **Supply chain**: cosign v3.x (Sigstore), Syft/Trivy for SBOM, SLSA v1.1
 
 This skill covers six domains depending on context:
 - **Workflow design** - stages, jobs, caching, artifacts, parallelism, reusable patterns

--- a/skills/ci-cd/references/best-practices.md
+++ b/skills/ci-cd/references/best-practices.md
@@ -111,7 +111,7 @@ lists become zombie tech debt. Example:
 
 ---
 
-## 2. Linting: Pre-commit → CI → Blocking
+## 2. Linting: Pre-commit -> CI -> Blocking
 
 Linting works when it's fast locally and authoritative in CI. Three layers, each with a
 different job:

--- a/skills/command-prompt/SKILL.md
+++ b/skills/command-prompt/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 Reference skill for writing commands, scripts, and configuration across Unix shells. Detects
 the target shell from context and routes to the appropriate reference.
 
-**Target versions** (March 2026):
+**Target versions** (April 2026):
 - Zsh: 5.10
 - Bash: 5.3
 - Fish: 4.6

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Configure, tune, design schemas, migrate, back up, and review database engines - from single-node dev setups to PCI-compliant production clusters. The goal is correct, performant, durable databases that survive failures, pass audits, and don't wake you up at 3am.
 
-**Target versions** (March 2026):
+**Target versions** (April 2026):
 - PostgreSQL **18.3** (EOL 2030-11), previous: 17.9, 16.13
 - MongoDB **8.0.20** (GA), 8.2.6 (rapid release, EOL 2026-07)
 - MariaDB **11.8.6** (LTS, EOL 2028-06), 12.2.2 (rolling GA, EOL 2026-05)

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: deep-audit
 description: >
-  · Orchestrate a 5-wave repo audit across quality, security, docs, and domain skills. Triggers: 'deep audit', 'full audit', 'comprehensive review', 'audit report', 'audit everything'. Not for quick sweeps (use full-review).
+  · Orchestrate a 5-wave repo audit, persist findings, generate phased tasks. Triggers:
+  'deep audit', 'full audit', 'comprehensive review', 'audit report', 'mega review',
+  'deep review'. Not for quick sweeps (use full-review).
 license: MIT
 compatibility: "Requires iuliandita/skills collection installed. Subagent support strongly recommended. Optional: a brainstorming or ideation skill in the host harness (matched by name pattern) for large-audit planning handoff."
 metadata:
@@ -13,7 +15,7 @@ metadata:
 
 # Deep Audit: Wave-Based Repo Orchestrator
 
-Run up to 21 custom skills against a repo in 5 sequential waves, presenting results
+Run up to 27 custom skills against a repo in 5 sequential waves, presenting results
 progressively. Wave 1 detects the tech stack. Waves 2-5 dispatch only the skills that
 match. Each wave completes and reports before the next begins.
 
@@ -21,17 +23,15 @@ The five waves:
 
 1. **Reconnaissance** - detect languages, frameworks, infra, file structure
 2. **Code Quality** (parallel) - code-review, anti-slop, anti-ai-prose
-3. **Domain-Specific** (parallel, conditional) - up to 13 skills based on detection
+3. **Domain-Specific** (parallel, conditional) - up to 19 skills based on detection
 4. **Security** (sequential) - security-audit, then zero-day
 5. **Docs & Hygiene** (parallel) - update-docs, roadmap, git
 
 After the waves, three post-wave phases produce durable artifacts (Workflow Steps 7-9):
-
-- **Persist** - cumulative findings to `docs/local/audits/DEEP-AUDIT.md`
-- **Plan** - phased task list at `docs/local/audits/DEEP-AUDIT-TASKS.md`
-- **Route** - SMALL audit stops at the task list; LARGE audit recommends a
-  brainstorming skill (when one is installed) or generates execution plans directly
-  in `docs/local/specs/` and `docs/local/plans/`
+**Persist** findings to `docs/local/audits/DEEP-AUDIT.md`, **Plan** phased tasks in
+`DEEP-AUDIT-TASKS.md`, **Route** SMALL audits to the task list or LARGE audits to a
+brainstorming skill (when installed) or directly-generated plans in `docs/local/specs/`
+and `docs/local/plans/`.
 
 For a quick 4-skill sweep, use **full-review** instead.
 
@@ -48,7 +48,7 @@ For a quick 4-skill sweep, use **full-review** instead.
 - Single-dimension audit (e.g., only security or only code quality) - use the individual skill directly (**security-audit**, **code-review**, etc.)
 - Auditing the skill collection itself - use **skill-creator** (Mode 3)
 - Offensive security engagement or CTF - use **lockpick** directly
-- OS-level administration - use **arch-btw** directly
+- Live-system OS administration (running `pacman`/`apt`/`dnf`, fixing a NixOS rebuild, configuring SELinux on a host, debugging an OPNsense appliance) - use the matching distro/appliance skill directly (**arch-btw**, **debian-ubuntu**, **rhel-fedora**, **nixos-btw**, **firewall-appliance**). Repo-level audit of OS-related files (PKGBUILDs, `debian/`, `*.spec`, `flake.nix`, `pf.conf`, etc.) belongs in Wave 3 of this skill
 
 ---
 
@@ -105,7 +105,7 @@ If the user specified a scope, pass it as the script's first argument to filter 
 to that subtree (`git ls-files -- path/to/scope` instead of the full repo).
 
 After detection, present the recon summary before proceeding. Compute
-`{unmatched_skills}` as the 13 Wave 3 candidates minus the matched set.
+`{unmatched_skills}` as the 19 Wave 3 candidates minus the matched set.
 Compute `{count}` by summing: 3 (Wave 2) + matched Wave 3 skills + 2 (Wave 4) +
 3 (Wave 5). Example: if 6 Wave 3 skills match, count = 3 + 6 + 2 + 3 = 14.
 
@@ -139,7 +139,7 @@ Skills that will run:
 Total agents: {count}
 ```
 
-Concrete example for a Node+Postgres+Docker+K8s repo with i18n and GitHub Actions (7 Wave 3 skills matched):
+Concrete example for a Node+Postgres+Docker+K8s repo with i18n and GitHub Actions (8 Wave 3 skills matched out of 19):
 
 ```
 Repo: myorg/api @ a3f91c2 (main)  |  Files: 412  |  Scope: full codebase
@@ -147,7 +147,7 @@ Languages: TypeScript, SQL, YAML
 
 Wave 2 (always): code-review, anti-slop, anti-ai-prose
 Wave 3 (detected): testing, command-prompt, databases, backend-api, localize, docker, kubernetes, ci-cd
-Wave 3 (skipped): terraform, ansible, networking, ai-ml, mcp
+Wave 3 (skipped): terraform, ansible, networking, ai-ml, mcp, arch-btw, debian-ubuntu, rhel-fedora, nixos-btw, firewall-appliance, virtualization
 Wave 4 (always): security-audit, zero-day
 Wave 5 (always): update-docs, roadmap, git
 
@@ -230,7 +230,7 @@ All other skills use the generic prompt.
 Present results:
 
 ```markdown
-## Wave 3: Domain-Specific [{N} of 13 skills matched]
+## Wave 3: Domain-Specific [{N} of 19 skills matched]
 
 ### {Skill Display Name}
 {report verbatim}
@@ -461,8 +461,25 @@ but preserves the wave ordering.
 - **code-review**, **anti-slop**, **anti-ai-prose** - Wave 2 participants.
 - **security-audit**, **zero-day** - Wave 4 participants.
 - **update-docs**, **roadmap**, **git** - Wave 5 participants.
-- **testing**, **command-prompt**, **databases**, **backend-api**, **localize**, **ai-ml**, **mcp**, **docker**, **kubernetes**, **terraform**, **ansible**, **ci-cd**, **networking** - Wave 3 candidates (conditional).
+- **testing**, **command-prompt**, **databases**, **backend-api**, **localize**, **ai-ml**, **mcp**, **docker**, **kubernetes**, **terraform**, **ansible**, **ci-cd**, **networking**, **arch-btw**, **debian-ubuntu**, **rhel-fedora**, **nixos-btw**, **firewall-appliance**, **virtualization** - Wave 3 candidates (conditional).
 - **skill-creator** - audits the skill collection. This skill audits application repos.
+
+### Deliberately Excluded Skills
+
+These published skills are intentionally NOT dispatched by deep-audit. Recorded here so future contributors don't re-add them by reflex:
+
+| Skill | Reason for exclusion |
+|---|---|
+| **browse** | Operational tool (fetch a page, fill a form). Not an audit lens. |
+| **dev-cycle** | Workflow orchestrator (start-to-finish dev: branch -> ship). Acts on the repo; doesn't audit it. |
+| **prompt-generator** | Creative authoring of LLM prompts. Produces content; doesn't evaluate code. |
+| **routine-writer** | Creative authoring of cloud-routine prompts. Same shape as prompt-generator. |
+| **skill-creator** | Audits the skill collection itself, not application code. Use Mode 3 of skill-creator separately. |
+| **skill-refiner** | Batch-improves skill collections via eval loops. Same domain as skill-creator. |
+| **lockpick** | Offensive security / CTF / privesc. Different threat model from defensive audit; security-audit + zero-day cover the defensive side. |
+| **kali-linux** | Live-system administration of Kali. Kali is Debian-based, so any repo-side packaging concerns are caught by debian-ubuntu in Wave 3. The skill itself is for running Kali, not auditing repos. |
+| **full-review** | Alternate orchestrator (the smaller 4-skill version). Mutually exclusive with deep-audit by design. |
+| **deep-audit** | This skill. Self-invocation would loop. |
 
 ---
 

--- a/skills/deep-audit/references/detection-patterns.md
+++ b/skills/deep-audit/references/detection-patterns.md
@@ -26,6 +26,12 @@ its domain isn't actually present.
 | ansible | `ansible.cfg`, `galaxy.yml`, `galaxy.yaml`, `roles/*/tasks/main.yml` | Also: `playbooks/*.yml` containing `hosts:`, or `requirements.yml` containing `roles:` or `collections:` |
 | ci-cd | `.github/workflows/*.yml`, `.github/workflows/*.yaml`, `.gitlab-ci.yml`, `.forgejo/workflows/`, `Jenkinsfile`, `.circleci/config.yml` | - |
 | networking | `nginx.conf`, `Caddyfile`, `haproxy.cfg`, `traefik.yml`, `traefik.yaml`, `traefik.toml`, `*.zone`, `named.conf`, `dnsmasq.conf`, `wg*.conf`, `nftables.conf` | - |
+| arch-btw | `PKGBUILD`, `*.install`, `mkinitcpio.conf*`, `archinstall.json`, `etc/pacman.d/`, `etc/pacman.conf` | - |
+| debian-ubuntu | `debian/control`, `debian/changelog`, `debian/rules`, `debian/copyright`, `*.dsc`, `snapcraft.yaml`, `snap/snapcraft.yaml` | - |
+| rhel-fedora | `*.spec`, `.copr/`, `dracut.conf*`, `selinux/*.te`, `comps.xml*`, `dnf/modules.d/` | - |
+| nixos-btw | `flake.nix`, `flake.lock`, `*.nix`, `configuration.nix`, `home.nix`, `default.nix`, `shell.nix` | - |
+| firewall-appliance | `pf.conf`, `opnsense/`, `pfsense/`, `configctl*`, `pf.anchors/` | - |
+| virtualization | `Vagrantfile`, `*.pkr.hcl`, `packer*.json`, `cloud-init*`, `user-data`, `meta-data`, `libvirt/*.xml`, `proxmox-*.json` | - |
 
 Manifests to check for dependency patterns: `package.json`, `requirements.txt`,
 `pyproject.toml`, `go.mod`, `Cargo.toml`, `Gemfile`, `composer.json`.
@@ -98,6 +104,30 @@ echo "$files" | grep -qE '\.github/workflows/|\.gitlab-ci\.yml$|\.forgejo/workfl
 # networking
 echo "$files" | grep -qE 'nginx\.conf|Caddyfile|haproxy\.cfg|traefik\.(ya?ml|toml)|\.zone$|named\.conf|dnsmasq\.conf|wg[0-9]*\.conf$|nftables\.conf' \
   && matched+=(networking)
+
+# arch-btw
+echo "$files" | grep -qE '(^|/)PKGBUILD$|\.install$|(^|/)mkinitcpio\.conf|(^|/)archinstall\.json$|(^|/)etc/pacman\.(d/|conf)' \
+  && matched+=(arch-btw)
+
+# debian-ubuntu
+echo "$files" | grep -qE '(^|/)debian/(control|changelog|rules|copyright)$|\.dsc$|(^|/)(snap/)?snapcraft\.yaml$' \
+  && matched+=(debian-ubuntu)
+
+# rhel-fedora
+echo "$files" | grep -qE '\.spec$|(^|/)\.copr/|(^|/)dracut\.conf|(^|/)selinux/.*\.te$|(^|/)comps\.xml|(^|/)dnf/modules\.d/' \
+  && matched+=(rhel-fedora)
+
+# nixos-btw (any .nix file is a strong signal; flake.lock is the conclusive one)
+echo "$files" | grep -qE '\.nix$|(^|/)flake\.lock$' \
+  && matched+=(nixos-btw)
+
+# firewall-appliance (OPNsense/pfSense config repos)
+echo "$files" | grep -qE '(^|/)pf\.conf|(^|/)opnsense/|(^|/)pfsense/|(^|/)configctl|(^|/)pf\.anchors/' \
+  && matched+=(firewall-appliance)
+
+# virtualization (Packer, cloud-init, libvirt, Proxmox, Vagrant)
+echo "$files" | grep -qE '(^|/)Vagrantfile|\.pkr\.hcl$|(^|/)packer.*\.json$|(^|/)cloud-init|(^|/)user-data$|(^|/)meta-data$|(^|/)libvirt/.*\.xml$|(^|/)proxmox-.*\.json$' \
+  && matched+=(virtualization)
 
 # --- Dependency-manifest checks (only for skills not yet matched) ---
 

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-cycle
 description: >
-  · Run dev workflow: branch, implement, lint/test, review, docs, PR, merge, release. Triggers: 'start working', 'kick off', 'wrap up', 'ship this', 'ready to ship'. Not for single git ops.
+  · Run dev workflow: branch, implement, lint/test, review, docs, PR, merge, release. Triggers: 'start working', 'kick off', 'wrap up', 'ship this', 'ready to ship'. Not for single git ops (use git).
 license: MIT
 compatibility: "Requires git. Optional forge CLIs by host: gh (GitHub), glab (GitLab), tea (Forgejo/Gitea). Bitbucket uses web UI or REST API. Bare git (no remote) works via format-patch/bundle. Delegates to git, testing, code-review, update-docs, and a brainstorming skill if installed."
 metadata:

--- a/skills/dev-cycle/references/finish.md
+++ b/skills/dev-cycle/references/finish.md
@@ -642,10 +642,10 @@ In this mode, "cut release" means "merge the release-please PR and verify the ta
 
 From conventional commits in the merged branch:
 
-- `feat:` or `feat!:` → minor (or major if breaking)
-- `fix:` → patch
-- `perf:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:` → patch (usually)
-- `BREAKING CHANGE:` footer anywhere → major
+- `feat:` or `feat!:` -> minor (or major if breaking)
+- `fix:` -> patch
+- `perf:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:` -> patch (usually)
+- `BREAKING CHANGE:` footer anywhere -> major
 
 If unclear, ask the user. Offer the three options with the current version shown.
 

--- a/skills/dev-cycle/references/size-heuristics.md
+++ b/skills/dev-cycle/references/size-heuristics.md
@@ -38,9 +38,9 @@ Bias toward large when in doubt. The 5 minutes spent writing a spec is cheap ins
 | **Rollback complexity** | trivial revert | multi-step |
 | **Review cycles expected** | 1 | 2+ |
 
-Match 3+ small signals without large signals → **small**.
-Match 3+ large signals → **large**.
-Mixed signals → **medium/ambiguous** → ask the user.
+Match 3+ small signals without large signals -> **small**.
+Match 3+ large signals -> **large**.
+Mixed signals -> **medium/ambiguous** -> ask the user.
 
 ---
 
@@ -80,7 +80,7 @@ Ask at most two. Default to large if still unclear.
 2. **Public surface**: "Does this change behavior users or API consumers will notice?"
 3. **Reversibility**: "If we ship this and need to back it out, is that a trivial revert or a coordinated rollback?"
 
-One large answer is enough to tip ambiguous → large.
+One large answer is enough to tip ambiguous -> large.
 
 ---
 

--- a/skills/dev-cycle/references/version-bump-sites.md
+++ b/skills/dev-cycle/references/version-bump-sites.md
@@ -176,13 +176,13 @@ Usually no public version bump needed. But:
 Before editing, show the user something like:
 
 ```
-Version bump: 1.4.2 → 1.5.0 (minor)
+Version bump: 1.4.2 -> 1.5.0 (minor)
 
 Proposed edits:
-  package.json                  "version": "1.4.2" → "1.5.0"
-  Dockerfile                    LABEL version="1.4.2" → "1.5.0"
-  helm/myapp/Chart.yaml         appVersion: 1.4.2 → 1.5.0
-  helm/myapp/values.yaml        image.tag: 1.4.2 → 1.5.0
+  package.json                  "version": "1.4.2" -> "1.5.0"
+  Dockerfile                    LABEL version="1.4.2" -> "1.5.0"
+  helm/myapp/Chart.yaml         appVersion: 1.4.2 -> 1.5.0
+  helm/myapp/values.yaml        image.tag: 1.4.2 -> 1.5.0
   CHANGELOG.md                  + new section: ## [1.5.0] - 2026-04-14
 
 Not touching (confirm):
@@ -203,16 +203,16 @@ Some files regenerate on build (e.g., `dist/package.json` in some Node setups). 
 ### Monorepo version coordination
 
 Packages in a monorepo may version independently (Lerna/changesets style) or in lockstep. Check the repo's release tooling:
-- `changeset/` directory → changesets, bump per package
-- `lerna.json` with `"version": "independent"` → per-package
-- `lerna.json` with a fixed version → lockstep
+- `changeset/` directory -> changesets, bump per package
+- `lerna.json` with `"version": "independent"` -> per-package
+- `lerna.json` with a fixed version -> lockstep
 - Nx: check `release.yml` or `nx.json`
 
 Don't manually bump every `package.json` in a changesets repo - the tool does it on release.
 
 ### SemVer pre-releases
 
-Pre-release tags like `1.5.0-rc.1`, `1.5.0-beta.2` sort before `1.5.0`. Bumping from `1.5.0-rc.1` → `1.5.0` is a release-out-of-prerelease, not a new minor.
+Pre-release tags like `1.5.0-rc.1`, `1.5.0-beta.2` sort before `1.5.0`. Bumping from `1.5.0-rc.1` -> `1.5.0` is a release-out-of-prerelease, not a new minor.
 
 ### Calendar versioning
 

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker
 description: >
-  · Write/review Dockerfiles, Compose, OCI builds, Podman/BuildKit, signing, hardening. Triggers: 'docker', 'dockerfile', 'compose', 'container', 'podman', 'buildkit'. Not for Kubernetes manifests.
+  · Write/review Dockerfiles, Compose, OCI builds, Podman/BuildKit, signing, hardening. Triggers: 'docker', 'dockerfile', 'compose', 'container', 'podman', 'buildkit'. Not for Kubernetes manifests (use kubernetes).
 license: MIT
 compatibility: "Requires docker or podman. Optional: docker compose, buildkit, cosign, trivy"
 paths:
@@ -20,12 +20,12 @@ metadata:
 
 Write, review, and architect Dockerfiles, Compose stacks, and container workflows - from single-service dev setups to multi-arch production pipelines with image signing and compliance gates. The goal is minimal, secure, reproducible images that a team can maintain and a QSA can audit.
 
-**Target versions** (March 2026):
-- Docker Engine 29.3.0, Docker Desktop 4.66.1
-- Docker Compose v5.1.1 (Go SDK, Bake-delegated builds)
-- BuildKit v0.28.1 (bundled with Engine 29.x)
-- containerd 2.2.2 (2.3 LTS ships April 2026)
-- Podman 5.8.1, Buildah 1.43.0
+**Target versions** (April 2026):
+- Docker Engine 29.4.0, Docker Desktop 4.66.1
+- Docker Compose v5.1.3 (Go SDK, Bake-delegated builds)
+- BuildKit v0.29.0 (bundled with Engine 29.x)
+- containerd 2.2.3 / **2.3 LTS** (April 2026, recommended for production)
+- Podman 5.8.2, Buildah 1.43.0
 - runc 1.4.1 (latest; CVE-2025-31133/52565/52881 patched since 1.4.0)
 
 This skill covers five domains depending on context:

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -16,10 +16,10 @@ metadata:
 Manage, troubleshoot, and harden OPNsense and pfSense firewalls via SSH. Both are FreeBSD-based,
 pf-powered firewall distributions - most concepts, commands, and patterns apply to both.
 
-**Target versions** (March 2026):
-- OPNsense: 26.1.5 (26.1 "Witty Woodpecker" series)
-- pfSense CE: 2.8.1 / pfSense Plus: 25.11.1
-- CrowdSec: v1.7.6
+**Target versions** (April 2026):
+- OPNsense: 26.4.0 (26.4 series; 26.1.6_2 still supported on the 26.1 stable branch)
+- pfSense CE: 2.8.1 / pfSense Plus: 26.03
+- CrowdSec: v1.7.7
 
 ## When to use
 

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -18,13 +18,13 @@ cut releases, and maintain audit-grade change history across GitHub, GitLab, and
 The goal is clean, signed, traceable history that satisfies both engineering standards and
 compliance requirements (PCI-DSS 4.0).
 
-**Target versions** (March 2026):
+**Target versions** (April 2026):
 - **git**: 2.53.x (current stable). Git 3.0 expected late 2026 (reftable default, SHA-256 default)
-- **GitHub CLI (`gh`)**: 2.89.x
+- **GitHub CLI (`gh`)**: 2.91.0
 - **GitLab CLI (`glab`)**: 1.90.x
 - **Forgejo CLI (`fj`)**: 0.4.1 (March 2026). Rust-written, official community CLI at `codeberg.org/forgejo-contrib/forgejo-cli`. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
-- **Forgejo**: v14.0.3 (current stable). Critical RCE (CVE-2025-68937) patched in v13.0.2+.
-- **prek**: 0.3.x (Rust, recommended) or **pre-commit**: 4.5.x (Python, largest ecosystem)
+- **Forgejo**: v15.0 (current stable, April 2026). Critical RCE (CVE-2025-68937) patched in v13.0.2+.
+- **prek**: 0.3.x (Rust, recommended) or **pre-commit**: 4.6.0 (Python, largest ecosystem)
 - **git-filter-repo**: 2.47.x
 - **gitleaks**: 8.30.x (secret scanning)
 - **cosign**: 3.x (Sigstore, for tag/release signing context)

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kali-linux
 description: >
-  · Administer Kali: apt, branches, metapackages, images, live USB persistence, NetHunter, wireless/GPU. Triggers: 'kali', 'kali rolling', 'kali snapshot', 'kali-tweaks', 'nethunter'. Not for exploitation.
+  · Administer Kali: apt, branches, metapackages, images, live USB persistence, NetHunter, wireless/GPU. Triggers: 'kali', 'kali rolling', 'kali snapshot', 'kali-tweaks', 'nethunter'. Not for exploitation (use lockpick).
 license: MIT
 compatibility: Requires Kali Linux or Kali images with apt and Kali repositories
 metadata:

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Create, review, and architect Kubernetes infrastructure - from raw manifests to Helm charts to multi-cluster strategy. The goal is production-ready, security-hardened, cost-aware infrastructure that a team can maintain.
 
-**Target versions** (March 2026): Kubernetes 1.33-1.35+ (1.36 due April 22, 2026), Helm 4.1.3, Helm 3.20.x (security fixes until Nov 2026).
+**Target versions** (April 2026): Kubernetes 1.34-1.36 (1.36.0 "Haru" released April 22, 2026; **1.32 is the active LTS branch with patches through April 2028**), Helm 4.1.4, Helm 3.20.x LTS (security fixes until Nov 2026).
 
 This skill covers four domains depending on context:
 - **Manifests** - raw YAML for Deployments, Services, Gateway API routes, ConfigMaps, Secrets, PVCs

--- a/skills/lockpick/SKILL.md
+++ b/skills/lockpick/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lockpick
 description: >
-  · Handle authorized privesc, CTFs, post-exploitation on Linux, containers, K8s. Triggers: 'privesc', 'CTF', 'pentest', 'post-exploitation', 'container escape', 'SUID', 'GTFOBins'. Not for hardening.
+  · Handle authorized privesc, CTFs, post-exploitation on Linux, containers, K8s. Triggers: 'privesc', 'CTF', 'pentest', 'post-exploitation', 'container escape', 'SUID', 'GTFOBins'. Not for hardening (use security-audit).
 license: MIT
 compatibility: Requires authorized access to target Linux systems and bash/python
 metadata:

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mcp
 description: >
-  · Build/review MCP servers, tools, resources, prompts, transports, OAuth, handlers. Triggers: 'mcp', 'model context protocol', 'mcp server', 'tool handler', 'fastmcp', '@modelcontextprotocol/sdk'. Not for APIs.
+  · Build/review MCP servers, tools, resources, prompts, transports, OAuth, handlers. Triggers: 'mcp', 'model context protocol', 'mcp server', 'tool handler', 'fastmcp', '@modelcontextprotocol/sdk'. Not for HTTP APIs (use backend-api).
 license: MIT
 compatibility: Requires Node.js or Python runtime
 metadata:
@@ -17,10 +17,10 @@ Build, review, and debug MCP servers that expose tools, resources, and prompts t
 assistants. The goal is secure, well-structured servers that follow the protocol spec and don't
 become yet another server with preventable injection vulnerabilities.
 
-**Target versions** (March 2026):
-- MCP specification: 2025-11-25 (current stable)
-- TypeScript SDK: @modelcontextprotocol/sdk 1.x
-- Python SDK: mcp 1.x (v1.26.0+)
+**Target versions** (April 2026):
+- MCP specification: 2025-11-25 (current stable; 2026-03-15 in draft)
+- TypeScript SDK: @modelcontextprotocol/sdk 1.29.0 (1.x stable; 2.0.0-alpha in dev)
+- Python SDK: mcp 1.27.0 (v1.26.0+)
 - Protocol transports: stdio, streamable HTTP (SSE deprecated in spec 2025-03-26)
 
 ## When to use

--- a/skills/networking/SKILL.md
+++ b/skills/networking/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: networking
 description: >
-  · Configure/troubleshoot Linux networking: DNS, proxies, VPNs, VLANs, nftables, routing. Triggers: 'dns', 'reverse proxy', 'vpn', 'wireguard', 'tailscale', 'vlan', 'nftables', 'mtr'. Not for OPNsense.
+  · Configure/troubleshoot Linux networking: DNS, proxies, VPNs, VLANs, nftables, routing. Triggers: 'dns', 'reverse proxy', 'vpn', 'wireguard', 'tailscale', 'vlan', 'nftables', 'mtr'. Not for OPNsense (use firewall-appliance).
 license: MIT
 compatibility: "Requires Linux. Tools vary by task: nftables, WireGuard, dig, mtr, tcpdump"
 metadata:
@@ -17,16 +17,16 @@ Configure, troubleshoot, and optimize Linux networking infrastructure. Covers DN
 VPNs, firewalls (nftables), VLANs, subnetting, high availability, dynamic routing, and network
 performance tuning.
 
-**Target versions** (March 2026):
+**Target versions** (April 2026):
 
 | Tool | Version | Notes |
 |------|---------|-------|
 | Caddy | 2.11.2 | Auto-HTTPS, Caddyfile + JSON API |
-| Nginx | 1.28.3 stable / 1.29.7 mainline | Multiple CVEs patched early 2026 - verify current advisories |
-| Traefik | 3.6.12 | Gateway API native, v2 EOL approaching |
-| HAProxy | 3.3.6 stable / 3.2.15 LTS | LTS EOL 2030-Q2 |
+| Nginx | 1.30.0 stable / 1.29.8 mainline | New stable branch released Apr 2026; verify current advisories |
+| Traefik | 3.6.14 | Gateway API native, v2 EOL approaching |
+| HAProxy | 3.3.7 stable / 3.2.16 LTS | LTS EOL 2030-Q2 |
 | WireGuard tools | 1.0.20260223 | Kernel module + userspace tools |
-| strongSwan | 6.0.5 | swanctl config (legacy ipsec.conf deprecated) |
+| strongSwan | 6.0.6 | swanctl config (legacy ipsec.conf deprecated) |
 | nftables | 1.1.6 | iptables successor, default on modern distros |
 | keepalived | 2.3.4 | VRRP + health checks |
 | Unbound | 1.24.2 | CVE-2025-11411 fix (unsolicited NS RRSets) |
@@ -34,7 +34,7 @@ performance tuning.
 | FRRouting | 10.6.0 | BGP, OSPF, IS-IS, PIM |
 | Tailscale / Headscale | Headscale 0.28.0 | Self-hosted control server |
 | cloudflared | 2026.3.0 | Cloudflare Tunnel (outbound-only) |
-| OpenVPN | 2.7.0 / 2.6.19 | 2.7.0: multi-socket, DCO kernel module |
+| OpenVPN | 2.7.2 / 2.6.20 LTS | 2.7.x: multi-socket, DCO; 2.6 is the LTS branch |
 
 ## When to use
 

--- a/skills/roadmap/SKILL.md
+++ b/skills/roadmap/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: roadmap
 description: >
-  · Maintain a gitignored ROADMAP.md: ideas, shipped work, priorities, competitors. Triggers: 'roadmap', 'ideas', 'feature ideas', 'competitive analysis', 'what should I build'. Not for code review.
+  · Capture, track, and prioritize ideas in a gitignored ROADMAP.md. Triggers: 'roadmap',
+  'ideas', 'feature ideas', 'competitive analysis', 'what should I build', 'feature backlog'.
+  Not for project management or code review.
 license: MIT
 compatibility: "Requires git. Optional: gh (GitHub CLI) or glab (GitLab CLI) for PR tracking and competitive scanning"
 metadata:
@@ -35,6 +37,7 @@ scratchpad that evolves with the project.
 - Sprint or iteration planning with task dependencies
 - Code review or PR review - use **code-review**
 - Writing project docs or READMEs - use **update-docs**
+- Factual drift in `ROADMAP.md` itself (stated version mismatch, shipped highlights out of date, `[planned]` / `[exploring]` items that already shipped) - use **update-docs**. This skill owns prioritisation and idea capture; update-docs owns keeping the file's stated facts honest.
 - Tracking bugs or incidents - use issue trackers directly
 
 ---
@@ -460,8 +463,10 @@ silently - move to **Parked** with a reason, or confirm deletion explicitly.
 - **git** - update mode (Mode 2) reads git history and PR data to match shipped work
 - **code-review** - reviews code correctness. This skill tracks what to build;
   code-review evaluates the code that implements it
-- **update-docs** - updates project documentation. This skill manages the roadmap;
-  update-docs handles READMEs, API docs, and runbooks
+- **update-docs** - updates project documentation AND audits ROADMAP.md for factual drift
+  (header version, shipped highlights, items that already shipped but still listed as planned).
+  This skill owns prioritisation, capture, and competitive intel; update-docs owns keeping
+  the file's facts in sync with HEAD. Boundary: ideas + sequencing here, factual freshness there.
 
 ## Rules
 

--- a/skills/routine-writer/SKILL.md
+++ b/skills/routine-writer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: routine-writer
 description: >
-  · Write Claude Code routine prompts for unattended schedules, APIs, GitHub events. Triggers: 'routine', 'claude routine', 'scheduled claude task', 'unattended claude', '/schedule', '/fire'. Not for one-off prompts.
+  · Write Claude Code routine prompts for unattended schedules, APIs, GitHub events. Triggers: 'routine', 'claude routine', 'scheduled claude task', 'unattended claude', '/schedule', '/fire'. Not for one-off prompts (use prompt-generator).
 license: MIT
 compatibility: "Routines require a Pro, Max, Team, or Enterprise plan with Claude Code on the web. CLI automation requires the claude binary on PATH"
 metadata:

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: security-audit
 description: >
-  · Audit code security: OWASP, credentials, auth, access control, supply chain, hardening. Triggers: 'security audit', 'vulnerability scan', 'secret scan', 'OWASP', 'auth review'. Not for offensive work.
+  · Audit code security: OWASP, credentials, auth, access control, supply chain, hardening. Triggers: 'security audit', 'vulnerability scan', 'secret scan', 'OWASP', 'auth review'. Not for offensive work (use lockpick).
 license: MIT
 compatibility: "Optional: betterleaks, gitleaks, trivy, semgrep, bandit, checkov, scorecard"
 metadata:
@@ -18,9 +18,9 @@ Structured, multi-pass security audit. Combines automated tooling with manual pa
 Patterns drawn from real OSS incidents (unauthenticated admin endpoints, credential exfiltration, zip slip, auth bypass whitelists, Trivy supply chain compromise) and OpenSSF/SLSA/OWASP standards.
 
 **Target versions** (April 2026):
-- Semgrep 1.157.0, Bandit 1.9.3
-- Gitleaks 8.30.1, Betterleaks 1.1.1 (successor by same author), TruffleHog 3.94.1
-- Trivy 0.69.3 (safe version - 0.69.4-0.69.6 compromised, see known incidents)
+- Semgrep 1.161.0, Bandit 1.9.4
+- Gitleaks 8.30.1, Betterleaks 1.1.1 (successor by same author), TruffleHog 3.95.2
+- Trivy 0.70.0 (0.69.4-0.69.6 was compromised - see known incidents; 0.70.x is the safe upgrade path)
 - OpenSSF Scorecard 5.1.0 (v6 in proposal stage)
 - OWASP Top 10:2025 (confirmed January 2026), OWASP Agentic Top 10:2026 (released December 2025)
 

--- a/skills/skill-refiner/SKILL.md
+++ b/skills/skill-refiner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-refiner
 description: >
-  · Batch-improve skill collections with evaluation loops, lint checks, behavioral tests, peer review. Triggers: 'skill refiner', 'improve skills', 'quality sweep', 'batch improve', 'skill loop'. Not for one skill.
+  · Batch-improve skill collections with evaluation loops, lint checks, behavioral tests, peer review. Triggers: 'skill refiner', 'improve skills', 'quality sweep', 'batch improve', 'skill loop'. Not for one skill (use skill-creator).
 license: MIT
 compatibility: "Requires: skill-creator skill, git. Optional: secondary AI harness (codex, claude, opencode) for cross-model review"
 metadata:

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Write, review, and architect Terraform/OpenTofu infrastructure - from individual resources to multi-account, PCI-compliant platform architectures. The goal is reproducible, drift-free, auditable infrastructure that passes both peer review and QSA assessment.
 
-**Target versions**: Terraform 1.13-1.14+ (IBM/HashiCorp, BSL), OpenTofu 1.10-1.11+ (Linux Foundation, MPL). Helm provider v3.1+, K8s provider v3.0+, AWS provider v6.x, Azure v4.x, GCP v7.x.
+**Target versions** (April 2026): Terraform 1.14.9 (IBM/HashiCorp, BSL; 1.15.0-rc2 in progress), OpenTofu 1.11.6 (Linux Foundation, MPL). Helm provider v3.1+, K8s provider v3.0+, AWS provider v6.x, Azure v4.x, GCP v7.x.
 
 This skill covers four domains depending on context:
 - **HCL** - resource configs, variables, outputs, data sources, expressions, lifecycle rules

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testing
 description: >
-  · Write/debug tests: unit, integration, E2E, TDD, mocks, fixtures, a11y, perf. Triggers: 'test', 'spec', 'TDD', 'playwright', 'vitest', 'jest', 'pytest', 'coverage', 'flaky'. Not for security tests.
+  · Write/debug tests: unit, integration, E2E, TDD, mocks, fixtures, a11y, perf. Triggers: 'test', 'spec', 'TDD', 'playwright', 'vitest', 'jest', 'pytest', 'coverage', 'flaky'. Not for security tests (use security-audit).
 license: MIT
 compatibility: "Requires one or more of: vitest, jest, pytest, go test, cargo test, playwright"
 metadata:

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: update-docs
 description: >
-  · Sweep docs after changes: README, changelog, API docs, runbooks, gotchas. Triggers: 'update docs', 'refresh docs', 'docs drift', 'update changelog', 'update README'. Not for PR text or roadmaps.
+  · Sweep docs after changes: README, changelog, API, runbooks. Triggers: 'update docs',
+  'refresh docs', 'sync docs', 'docs drift', 'merged PR', 'release cut', 'version bump',
+  'update changelog'. Not for PR text (use git).
 license: MIT
 compatibility: "Requires git. Optional: wc (for size audits)"
 metadata:
@@ -32,7 +34,7 @@ Post-change documentation sweep. Captures non-obvious knowledge into the right d
 - Prompt authoring or reusable skill-file maintenance - use **prompt-generator** or **skill-creator**
 - Full codebase audit across multiple domains - use **full-review** (it invokes update-docs as one pass)
 - Git commit messages, PR descriptions, release announcement copy, or tag operations - use **git**
-- Roadmap prioritization, backlog shaping, or competitor scouting - use **roadmap**
+- Roadmap prioritisation and backlog shaping belongs to the **roadmap** skill; factual drift (stated version, shipped highlights, items mistakenly listed as planned) belongs here
 
 ---
 
@@ -51,6 +53,9 @@ Before presenting documentation updates, verify:
 - [ ] `.env.example` updated if env vars or runtime config changed
 - [ ] If repo docs are too thin, a minimal docs bootstrap was offered to the user as a suggestion, not forced
 - [ ] Size check run (`wc -c`) - instruction files under 40,000 chars
+- [ ] All roadmap files (committed AND gitignored) checked - their stated version/date matches current HEAD or latest tag
+- [ ] `[planned]` / `[exploring]` items that actually shipped have moved to Shipped Highlights, not left in the in-progress list
+- [ ] When private and public roadmaps both exist, both are updated, with the public one carrying user-visible highlights only and the private one carrying internal detail
 
 ---
 
@@ -63,6 +68,7 @@ Before presenting documentation updates, verify:
 **Audit-only mode:** When invoked by full-review or when the user asks to "just report" or "check docs," run Steps 1-6 and report findings without making changes or committing. Skip Steps 7-8.
 
 1. Identify changes
+1.5. Roadmap freshness check
 2. Categorize doc impact
 3. Check whether the repo's docs surface is missing or too thin
 4. Update affected docs (or report what needs updating in audit-only mode)
@@ -79,11 +85,99 @@ Check git diff and conversation context to understand what was modified:
 # Uncommitted changes
 git diff --name-only
 
-# Recent commits on this branch (compare against main/master)
-git log --oneline main..HEAD 2>/dev/null || git log --oneline -10
+# Compare against the roadmap's stated version, falling back to last tag, falling back to last 10
+ROADMAP_VER=$(grep -hoE 'Current:?\s*v?[0-9]+\.[0-9]+\.[0-9]+' ROADMAP.md docs/ROADMAP.md 2>/dev/null | head -1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+')
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+RANGE="${ROADMAP_VER:-${LAST_TAG}}..HEAD"
+git log --oneline "$RANGE" 2>/dev/null || git log --oneline -10
 ```
 
 Scan for changes in: configuration, infrastructure, service deployments, scripts, CI workflows, network/IP assignments, service versions, and anything operational.
+
+### 1.5. Roadmap Freshness Check
+
+Roadmaps drift the hardest because they restate facts the code, tags, and commit history already prove. Run this check whenever the repo has a roadmap - committed OR gitignored. If no roadmap is found, the step is silent and you move on; absence of `ROADMAP.md` is not an error.
+
+```bash
+# Discover all roadmap files (tracked AND gitignored). Normalize the leading ./ from find
+# so it doesn't duplicate paths returned by git ls-files.
+ROADMAPS=$(
+  { git ls-files '*ROADMAP*' '*roadmap*' 2>/dev/null
+    find . -maxdepth 4 -iname 'ROADMAP*' -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null \
+      | sed 's|^\./||'
+  } | sort -u
+)
+
+if [[ -n "$ROADMAPS" ]]; then
+  # Resolve the source-of-truth version (try common manifests in order)
+  REPO_VER=""
+  [[ -f package.json   ]] && REPO_VER=$(node -p "require('./package.json').version" 2>/dev/null)
+  [[ -z "$REPO_VER" && -f Cargo.toml     ]] && REPO_VER=$(grep -m1 '^version' Cargo.toml     | sed -E 's/.*"([^"]+)".*/\1/')
+  [[ -z "$REPO_VER" && -f pyproject.toml ]] && REPO_VER=$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
+  [[ -z "$REPO_VER" && -f setup.py       ]] && REPO_VER=$(grep -oE "version=['\"][^'\"]+" setup.py | sed -E "s/.*['\"]//")
+  LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+  HEAD_DATE=$(git log -1 --format=%cs HEAD 2>/dev/null)
+
+  # For each roadmap, parse the stated Current/Updated/Version header and compare
+  echo "$ROADMAPS" | while read -r rm; do
+    [[ -f "$rm" ]] || continue
+    STATED=$(grep -hE '^>.*(Current|Updated|Version)' "$rm" 2>/dev/null | head -3)
+    RM_VER=$(printf '%s' "$STATED"  | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    RM_DATE=$(printf '%s' "$STATED" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}'  | head -1)
+    [[ -z "$RM_VER$RM_DATE" ]] && continue  # no parseable header, skip silently
+
+    # Informational counts (used in the drift output, not as triggers - commit count is a
+    # bad proxy for staleness when an agentic /loop session can ship 5 commits in 20 min).
+    COMMITS=0; TAGS=0
+    if [[ -n "$RM_VER" ]]; then
+      COMMITS=$(git rev-list --count "${RM_VER}..HEAD" 2>/dev/null || echo 0)
+      TAGS=$(git tag --sort=v:refname 2>/dev/null | awk -v r="$RM_VER" 'found{c++} $0==r{found=1} END{print c+0}')
+    fi
+
+    # Tags cut AFTER the roadmap's stated date - the cleanest "you shipped, roadmap is
+    # behind" signal. Releases are deliberate punctuation; arbitrary commits are not.
+    NEWER_TAGS=$(git for-each-ref --sort=-creatordate \
+      --format='%(creatordate:short) %(refname:short)' refs/tags 2>/dev/null \
+      | awk -v d="${RM_DATE:-9999-99-99}" '$1 > d {print $2}')
+    NEW_TAG_COUNT=$(printf '%s\n' "$NEWER_TAGS" | grep -c .)
+
+    # Calendar-day staleness fallback for projects that do not tag releases. Portable across
+    # GNU date (Linux) and BSD date (macOS).
+    DAYS_BEHIND=0
+    if [[ -n "$RM_DATE" && -n "$HEAD_DATE" ]]; then
+      H=$(date -d "$HEAD_DATE" +%s 2>/dev/null || date -j -f %Y-%m-%d "$HEAD_DATE" +%s 2>/dev/null)
+      R=$(date -d "$RM_DATE"   +%s 2>/dev/null || date -j -f %Y-%m-%d "$RM_DATE"   +%s 2>/dev/null)
+      [[ -n "$H" && -n "$R" ]] && DAYS_BEHIND=$(( (H - R) / 86400 ))
+    fi
+
+    # Drift if ANY of: stated version older than latest tag; one or more releases cut since
+    # the header date; or >14 calendar days since the header date with no release activity.
+    DRIFT=0
+    [[ -n "$RM_VER" && -n "$LAST_TAG" && "$(printf '%s\n' "$RM_VER" "$LAST_TAG" | sort -V | tail -1)" != "$RM_VER" ]] && DRIFT=1
+    [[ "$NEW_TAG_COUNT" -gt 0 ]] && DRIFT=1
+    [[ "$DAYS_BEHIND" -gt 14 ]] && DRIFT=1
+
+    if [[ "$DRIFT" -eq 1 ]]; then
+      echo "ROADMAP DRIFT: $rm states ${RM_VER:-?} / ${RM_DATE:-?}; HEAD is ${LAST_TAG:-v$REPO_VER} / $HEAD_DATE; $COMMITS commits, $TAGS tags between, $NEW_TAG_COUNT releases since header date, ${DAYS_BEHIND}d calendar gap."
+      # Feed the drift range into Step 2 - widens the diff window beyond `git log -10`
+      [[ -n "$RM_VER" ]] && export RANGE="${RM_VER}..HEAD"
+    fi
+  done
+fi
+```
+
+**Why tags-and-days, not commit-count:** commit count was the obvious proxy for staleness in pre-agentic days. It is unusable now - a `/loop` or agentic refactor session can ship 5+ commits in under an hour without touching anything the roadmap should track. Tags and calendar days are velocity-independent: a release tag is a deliberate event the roadmap should reflect, and 14 calendar days without an updated header is real staleness regardless of how many commits passed through. Commit count survives only as informational context in the drift output.
+
+**Side-channel staleness:** the header check is structural - it flags drift in stated metadata, not the *substance* of the roadmap. Roadmaps often contain time-stamped sections like `Scanned 2026-04-10`, `Last refreshed 2026-04-10`, `as of 2026-04-10`, or `Weekly refresh covers ...`. Surface those as **separate observations** when the date is older than HEAD by more than a week:
+
+```bash
+echo "$ROADMAPS" | while read -r rm; do
+  [[ -f "$rm" ]] || continue
+  grep -nE '([Ss]canned|[Ll]ast [Rr]efreshed|[Aa]s of|[Ww]eekly refresh)[^0-9]*[0-9]{4}-[0-9]{2}-[0-9]{2}' "$rm" 2>/dev/null
+done
+```
+
+Do NOT fabricate refreshed content. The user wants staleness called out so they can decide whether to refresh manually, not invented data.
 
 ### 2. Categorize Doc Impact
 
@@ -109,6 +203,9 @@ Map changes to documentation targets. Common instruction file names: `CLAUDE.md`
 | Feature added, removed, or materially changed | `README.md`, feature docs (`FEATURES.md`, `FEATURESET.md`, `docs/features/*.md`), changelog |
 | Merged PR with user-visible impact | Changelog, roadmap/status docs, release notes, affected feature/API/setup docs |
 | Version bumps / new release cut | `CHANGELOG.md`, release notes, `README.md`, install/upgrade docs, badges, package manager instructions |
+| Release cut or version bump (roadmap-side) | `ROADMAP.md` header (`Current` / `Updated`), Shipped Highlights section, status docs |
+| Multiple shipped features since last roadmap update | `ROADMAP.md` Shipped Highlights, Where-We-Are summary, `[planned]` / `[exploring]` items that actually shipped |
+| Gitignored private roadmap AND committed public roadmap both present | Update both - private gets the deeper internal detail, public gets the user-visible summary |
 | Strategy or sequencing changes | `ROADMAP.md`, status docs, milestone docs |
 
 **When to write an ADR:** If the decision affects multiple components, constrains future options, or reverses a previous decision, it's worth a dedicated Architecture Decision Record. If it's a one-liner ("switched from X to Y because Z"), a short bullet in the project's instruction file is enough.
@@ -277,6 +374,8 @@ When a feature, service, or API is deprecated during a session:
 - **Dangling links**: Renaming a doc without updating references elsewhere creates dead links that erode trust in documentation.
 - **Bootstrapping without consent**: If the repo lacks docs, suggest a minimal docs surface; don't silently create a documentation tree the user did not ask for.
 - **Deleting deprecated docs too early**: Keep deprecated entries visible for at least one release cycle so people find the migration path.
+- **Skipping the roadmap header check**: A roadmap with `Current: v0.27` while HEAD is on `v0.43` is the loudest possible drift signal. Always parse and compare the header before deciding whether the roadmap needs updates.
+- **Treating a gitignored roadmap as out of scope**: Private roadmaps drift hardest because nobody complains about them publicly. Run the freshness check against ALL roadmaps the `find` command surfaces, not just tracked ones.
 
 ---
 

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: virtualization
 description: >
-  · Create/troubleshoot VMs and hypervisors: Proxmox, QEMU/KVM, libvirt, XCP-ng, vSphere. Triggers: 'proxmox', 'qemu', 'kvm', 'libvirt', 'virsh', 'vm', 'cloud-init'. Not for containers.
+  · Create/troubleshoot VMs and hypervisors: Proxmox, QEMU/KVM, libvirt, XCP-ng, vSphere. Triggers: 'proxmox', 'qemu', 'kvm', 'libvirt', 'virsh', 'vm', 'cloud-init'. Not for containers (use docker).
 license: MIT
 compatibility: "Varies by hypervisor. Proxmox: pvesh, qm, pct. Libvirt: virsh, virt-install. Optional: packer, terraform"
 metadata:

--- a/skills/zero-day/SKILL.md
+++ b/skills/zero-day/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: zero-day
 description: >
-  · Hunt novel vulnerabilities: reversing, patch diffing, fuzzing, attack surface, PoCs. Triggers: 'zero-day', '0-day', 'vulnerability research', 'variant analysis', 'fuzz', 'exploit dev', 'CVE'. Not for SAST.
+  · Hunt novel vulnerabilities: reversing, patch diffing, fuzzing, attack surface, PoCs. Triggers: 'zero-day', '0-day', 'vulnerability research', 'variant analysis', 'fuzz', 'exploit dev', 'CVE'. Not for SAST (use security-audit).
 license: MIT
 compatibility: "Optional: codeql, semgrep, joern, ghidra, radare2/rizin, afl++, gdb, pwntools, strace, ltrace, checksec"
 metadata:


### PR DESCRIPTION
## Summary

- **Skill-creator audit (5 iterations)**: 0 errors, 0 warnings across 37 published skills. Cross-references valid, no banned chars, all sections present.
- **Skill-refiner (8 iterations)**: trigger description tightening, routing hints, ASCII compliance, version freshness sweep against live web sources.
- **ai-ml feature expansion**: llama.cpp CPU-only inference, GGUF quant guide, AVX2 ISA cliff, HF SHA pinning, mlock memory model, NUMA, benchmarking methodology.
- **Cross-model peer review**: codex flagged 'audit report' trigger loss in deep-audit (agreed and restored).

## Highlights

### Trigger / routing improvements
12 skills gained explicit \`(use Y)\` routing hints. mcp + testing got concrete alternatives. deep-audit restored a triggering keyword that codex caught as missing.

### Version freshness (web-verified April 2026)
Bumps in 12 skills based on parallel agents that hit GitHub releases pages:
- **ci-cd**: Forgejo v15.0, Gitea v1.26.0, SLSA v1.1
- **docker**: Engine 29.4.0, Compose v5.1.3, BuildKit v0.29.0, containerd 2.2.3 + 2.3 LTS, Podman 5.8.2
- **kubernetes**: 1.36.0 "Haru" released April 22, Helm 4.1.4, 1.32 LTS marker
- **networking**: Nginx 1.30.0 stable, Traefik 3.6.14, HAProxy 3.3.7/3.2.16, strongSwan 6.0.6, OpenVPN 2.7.2/2.6.20 LTS
- **firewall-appliance**: OPNsense 26.4.0, pfSense Plus 26.03, CrowdSec 1.7.7
- **security-audit**: Semgrep 1.161.0, Bandit 1.9.4, TruffleHog 3.95.2, Trivy 0.70.0
- **git**: gh 2.91.0, Forgejo v15.0, pre-commit 4.6.0
- **mcp**: SDK 1.29.0, Python 1.27.0
- **ai-ml**: Claude Agent SDK 0.2.117, OpenAI SDK 2.32.0, LangChain 1.2.15, LangGraph 1.1.8, LlamaIndex 0.14.21, Ollama 0.20.0
- terraform, ansible, command-prompt date labels refreshed

### LTS annotations
Added formal LTS markers where they exist: kubernetes 1.32 LTS, containerd 2.3 LTS, ansible-core 2.20 LTS, OpenVPN 2.6 LTS, Helm 3.20.x LTS. Skipped where no formal LTS (ai-ml frameworks, mcp, testing, command-prompt - all rolling-release).

### ai-ml: llama.cpp expansion
New section in SKILL.md (~30 lines) covering when CPU-only makes sense (MoE with low active params hits 13+ t/s on Ivy Bridge), the AVX2 ISA cliff that breaks PyTorch/TF/JAX/Ollama prebuilts, GGUF quant quick-pick, HF commit-SHA pinning, mlock memory accounting, decode vs prefill threading, API-key-via-file (avoid \`/proc/<pid>/cmdline\` leak).

\`references/local-inference.md\` gained 179 lines: per-CPU-generation build flag table, full pre-Haswell build walkthrough, systemd-per-model deployment pattern, benchmark methodology (fixed prompt suite, warmup, decode t/s comparison), NUMA distribute/isolate/interleave choices, mlock implications and capacity planning.

## Validation

- \`scripts/lint-skills.sh\`: PASSED (0 errors, 0 warnings)
- \`scripts/validate-spec.sh\`: PASSED (0 errors, 0 warnings)
- All cross-references resolve
- ASCII purity verified (only allowed \`·\` prefix and locale orthography in localize examples)
- Strict YAML safe-load: 0 errors
- Codex peer review: 1 minor flag agreed and resolved, 1 disputed and discarded

## Test plan
- [x] Both lint scripts pass
- [x] Description length warnings cleared
- [x] Cross-references all resolve
- [x] No regressions in non-touched skills
- [ ] Local install verification with \`./install.sh --tool claude,codex,opencode --link --include-internal --force\` (after merge)