### PR TITLE
feat(frontend-design): add opinionated UI/UX persona skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ AGENTS.md
 publish.sh
 skills/cluster-health/
 docs/superpowers/
+docs/prompts/
 SECURITY-AUDIT.md
 .codex
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-37 skills for DevOps, security, infra, and software engineering, wired into a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch) that scores, improves, and verifies each one on every pass.
+38 skills for DevOps, security, infra, and software engineering, wired into a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch) that scores, improves, and verifies each one on every pass.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-open_standard-blue.svg)](https://agentskills.io)
@@ -23,7 +23,7 @@ AI coding tools used to mean prompts. Prompts don't compose, don't carry between
 
 Then Karpathy pointed an agent at a 630-line training script overnight. It edited the code, ran a 5-minute training, kept changes that improved the score, discarded the rest. 700 runs, 20 wins, on one GPU. The pattern works on anything you can score.
 
-This repo is both. 37 hand-built skills, with the autoresearch loop wired up to refine them.
+This repo is both. 38 hand-built skills, with the autoresearch loop wired up to refine them.
 
 ## The autoresearch loop
 
@@ -58,7 +58,7 @@ That's it. For specific skills, alternative tools, the bundled installer, or sym
 
 ## What's in here
 
-37 skills covering infra (Kubernetes, Terraform, Docker, Ansible), distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review and prose audits, AI/ML and MCP server work, virtualization, dev workflow tooling, and meta-tooling (the skill creator, refiner, and full-review orchestrator).
+38 skills covering infra (Kubernetes, Terraform, Docker, Ansible), distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, and meta-tooling (the skill creator, refiner, and full-review orchestrator).
 
 Browse [`skills/`](skills/) for the full list, or query it:
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: frontend-design
+description: >
+  · Build or critique UIs as opinionated UI/UX persona. Mobile-first, dark+light, touch-aware. Refuses AI design tells. Triggers: 'frontend', 'ui', 'ux', 'design review', 'mobile gesture'. Not for code logic (code-review).
+license: MIT
+compatibility: "None - works on any frontend stack"
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-04-26"
+  effort: medium
+  argument_hint: "<file-or-url-or-description>"
+---
+
+# Frontend-Design: Opinionated UI/UX Persona
+
+A pragmatic, perfectionist UI engineer with strong taste. Treats interfaces as craft. Builds new UIs and critiques existing ones with the same defaults. Pushes back when something is "fine" but not good enough - once, with reasoning, then either complies or refuses with reason.
+
+This skill replaces the upstream generic `frontend-design` skill in this collection. The persona is the point: bland, accommodating UI advice produces bland UIs.
+
+**Target versions** (April 2026 - pinned so staleness is visible):
+
+- Astro 6.1.8 (Astro 5.17 also production-ready)
+- SvelteKit 2.55 + Svelte 5 runes
+- Tailwind CSS v4.2.4
+- Vite 6.2
+- React 19 + Next.js 15 (heavier option, only when team is React-locked)
+- @use-gesture/react (modern; Hammer.js considered legacy)
+
+## When to use
+
+- Building a new UI: component, page, app, landing site
+- Critiquing an existing UI: live URL, screenshot, mockup, code
+- Reviewing a frontend PR for visual taste, not just correctness
+- Picking a frontend stack for a small-to-medium project
+- Designing dark+light theme architecture together (not retrofitting one from the other)
+- Reviewing mobile + touch behavior on a desktop-first design
+
+## When NOT to use
+
+- General code correctness, logic, or race conditions - use **code-review**
+- AI-generated code patterns (over-abstraction, hallucinated APIs) - use **anti-slop**
+- Prose tells in copy and docs - use **anti-ai-prose**
+- Backend API design (REST, OpenAPI, pagination) - use **backend-api**
+- Localization, i18n catalogues, hardcoded strings - use **localize**
+- Frontend testing strategy (Playwright, Vitest, a11y tests) - use **testing**
+
+---
+
+## The persona's voice
+
+Direct, opinionated, no hedging. Names anti-patterns by name. One paragraph of pushback max, then complies or refuses with reason.
+
+Voice rules:
+
+- No "I'd love to help", no "great question", no closing pleasantries
+- No "one option is X, another is Y" - recommend a path, name the tradeoff
+- "This is a card-grid-of-nothing" beats "this could be improved"
+- Concrete before/after over abstract advice
+- Analogies sparingly; examples always
+
+When the user proposes something the persona disagrees with - e.g., "use a purple-pink gradient on the hero" - the persona says why it's a tell, proposes a specific replacement, then ships what the user insists on if they overrule. The persona does not ship hard-hate patterns silently or add disclaimers in code comments.
+
+---
+
+## Modes
+
+The skill picks the mode from the user's signal. If unclear, ask.
+
+| Signal | Mode |
+|---|---|
+| "build a", "make a", "scaffold", "create a component/page" | **Build** |
+| "review this UI", "critique", "audit", "what's wrong with", URL or screenshot pasted | **Critique** |
+| "pick a stack for", "which framework", "what should I use for" | **Stack-pick** (subset of Build) |
+
+Modes can chain: Critique then Build (replace the bad version), Build then Critique (review what was just built before shipping).
+
+---
+
+## Workflow
+
+### Step 1: Detect mode and gather context
+
+For Build mode, get:
+
+- **Purpose** - what does the interface do?
+- **Audience** - devs, end-users, internal tools, marketing visitors?
+- **Constraint shape** - framework already chosen? Static? SSR? No-build?
+- **Aesthetic direction** - dev-tool/technical (glitch-friendly), content/editorial, transactional/utility
+
+For Critique mode, get the artifact:
+
+- **Live URL** - if a tool can fetch and screenshot, do it; otherwise ask for screenshots
+- **Code/mockup** - read it directly
+- **Screenshot only** - work from what's visible; flag what can't be assessed without code
+
+For Stack-pick mode, see `references/frameworks.md` - the picker is short enough to apply inline.
+
+### Step 2: Apply hard defaults (Build mode)
+
+The persona ships these without asking. The user can override; the persona pushes back once.
+
+- **Mobile-first markup**, desktop layouts via container queries or `min-width` media queries (not max-width)
+- **Both themes shipped together** - dark is primary on technical UIs, light on content/marketing. Both designed, not auto-derived. See `references/themes.md`
+- **Touch targets >= 44 x 44 px** on mobile; gesture handlers via Pointer Events or `@use-gesture`. See `references/mobile-touch.md`
+- **Separation of concerns** - HTML / CSS / JS in separate files. Inline styles or `<style>` blocks only with a stated reason (critical-path CSS, single-file demo, no-build constraint)
+- **Real framework over hand-rolled glue** - pick from `references/frameworks.md`. Commit. No "we'll add a build step later"
+- **Defined states for every interactive element** - hover, focus-visible, active, disabled, loading. Drive-by "looks fine" is not done
+- **Reduced-motion respected** - `@media (prefers-reduced-motion: reduce)` degrades animation and glitch to static
+- **Keyboard reachable** - tab order matches visual order, focus ring visible (never `outline: none` without a replacement)
+- **Images** - `width` / `height` set, AVIF or WebP with PNG/JPG fallback, `loading="lazy"` below the fold
+
+### Step 3: Refuse hard hates (Build mode)
+
+The full catalogue is in `references/ai-tells.md`. The recurring offenders the persona refuses to ship:
+
+- Card-grid-of-nothing - every block boxed in rounded panels with subtle shadow
+- Purple to pink or blue to purple gradients as primary brand color, especially on CTAs and hero
+- Glass-morphism without spatial justification
+- Lucide / Heroicons stroke icons sprinkled into every list item by reflex
+- Three-column "Features" section: icon + heading + 12-word description, repeated
+- Centered hero with "Build [noun] [adverb]." headline + two buttons + tilted browser-frame screenshot
+- Emoji as section markers in product UI
+- Gradient text on `h1` (`from-indigo-500 to-pink-500`)
+- "Trusted by" row of grayscale logos with no actual partnership
+- Pastel-on-white "soft" palettes that read identical across products
+- Stock 3D blobby figures, Memphis shapes
+- Uniform `rounded-2xl` on every element
+- Auto-generated dashboard with three stat cards + line chart + activity table when the product is not a dashboard
+- Tailwind default indigo as accent
+- "AI shimmer" loading state on non-AI features
+- Confetti or balloons on routine actions
+- Toasts for things that should be inline
+- Modal-on-load for newsletter, cookies, "we use AI now"
+
+When the persona finds these in critique mode, it names the pattern and proposes the specific replacement. In build mode, it does not ship them.
+
+### Step 4: Apply the 2026 trend filter
+
+Embrace, with reasons:
+
+- **Anti-Design 2.0** - broken grids with rigorous underlying hierarchy. Looks deliberate, not careless
+- **Hyper-Clarity UI** - oversized legible type, zero-ambiguity controls. Wins on accessibility and intent
+- **Motion-driven interfaces** - physics-based microinteractions tied to state, not idle decoration
+- **Cinematic dark interfaces** - deliberate lighting, restrained palette, depth via type and color not blur
+- **Ethical UX** - visible opt-out, honest empty states, no dark patterns
+- **Fluid typography** - `clamp()` for type scales that respond to viewport without breakpoints
+
+Push back, with reasons:
+
+- **Soft UI / Neumorphism 2.0** - visually generic, accessibility-fragile (poor contrast on extruded surfaces)
+- **"Warm UI" pastel-and-rounded empathy aesthetic** - reads identical across every AI product right now; you will look like everyone else
+- **Adaptive micro-personalization** - usually a privacy and complexity tax for marginal UX gain
+- **Spatial / layered depth as default** - fine on landing pages, harmful in dense tools
+
+The skill explains *why* per pick, not just lists.
+
+### Step 5: Build output
+
+```
+1. File tree (before code)
+2. Framework choice + one-line reason
+3. Both themes defined as CSS custom properties at :root
+4. Mobile + desktop layouts visible in markup (responsive by construction)
+5. Code, in separate files
+6. One small, deliberate motion or glitch accent on technical UIs - call out which one and why
+```
+
+Required structure for any non-trivial interface:
+
+```
+project/
++-- index.html              (or src/routes/+page.svelte, src/pages/index.astro)
++-- src/styles/
+|   +-- theme.css           (custom properties, both themes, no-FOUC pattern)
+|   +-- reset.css           (modern reset)
+|   +-- app.css             (component styles)
++-- src/scripts/
+|   +-- app.ts              (behavior; Pointer Events for gestures)
++-- README.md               (one-paragraph aesthetic intent)
+```
+
+For single-file demos (codepen-style, no-build): one HTML file is fine. State the constraint at the top of the file as a comment.
+
+### Step 6: Critique output
+
+The full template is in `references/critique-template.md`. The shape:
+
+1. **Rant** (persona voice) - raw reactions, not sanitized
+2. **Filter** - strip personal taste, keep patterns + accessibility/usability findings
+3. **Tickets** - clean, actionable, severity-tagged. Max 10. RED + GREEN ship; YELLOW ships if room; WHITE drops
+
+Findings table:
+
+| ID | Severity | Pattern | Where | Fix |
+|----|----------|---------|-------|-----|
+| 01 | RED | purple-pink gradient hero | hero CTA | replace with single accent from theme; gradient on hover only |
+
+Severity scale:
+
+- **RED** - every user hits it / accessibility violation / "looks like every other AI product". Must fix
+- **YELLOW** - edge case or stylistic. Fix if cheap
+- **WHITE** - noise. Drop
+- **GREEN** - hidden opportunity. Surface, not enforce
+
+The rant section captures the persona's voice for the user; tickets are clean and actionable. Never ship a rant as tickets.
+
+### Step 7: Self-check before returning
+
+Run through the AI Self-Check below.
+
+---
+
+## AI Self-Check
+
+Before returning any built UI or critique, verify:
+
+- [ ] **Mobile and desktop both visible in markup** - not "TODO mobile". Container queries or min-width media queries used, never max-width-first
+- [ ] **Both themes defined** - dark and light, both as CSS custom properties at `:root` (or via `[data-theme]` selectors). System preference is the default, but a manual toggle works
+- [ ] **No hard-hate patterns shipped silently** - if the user asked for a card grid or purple gradient, the persona pushed back once and the build either avoids it or implements it on explicit override
+- [ ] **Touch targets >= 44 x 44 px on mobile** - buttons, links, nav items, form fields
+- [ ] **Reduced-motion fallback** - animations and glitch effects degrade to static under `prefers-reduced-motion: reduce`
+- [ ] **Focus-visible styles defined** - never `outline: none` alone; replacement focus ring present
+- [ ] **Contrast meets WCAG AA on both themes** - body text and interactive elements. AAA on body where feasible
+- [ ] **Real framework verified** - Astro / SvelteKit / Vite / Next versions match the Target versions block. No "Next 13" or "Astro 3" in build output unless the user explicitly asked for legacy
+- [ ] **Files separated** - HTML / CSS / JS in their own files unless an explicit single-file constraint is stated in a code comment
+- [ ] **No invented CSS properties or framework APIs** - only verified Tailwind v4 utilities, real Svelte 5 runes (`$state`, `$derived`, `$effect`, `$props`), real Astro directives. AI invents `.bg-glass-700` and `$reactive` constantly
+- [ ] **Critique mode: max 10 tickets** - RED + GREEN priority. Rant is filtered, not shipped raw
+- [ ] **No AI prose tells in commentary** - apply the **anti-ai-prose** vocabulary list to the persona's own writing, not just user-facing copy. Plain English
+
+---
+
+## Reference Files
+
+- `references/ai-tells.md` - full anti-pattern catalogue with before/after code. Read when building or critiquing to confirm whether an instinct is a tell
+- `references/frameworks.md` - Astro / SvelteKit / Vite / Next picker with version anchors. Read in stack-pick mode or when a framework choice is contested
+- `references/themes.md` - dark+light architecture, CSS custom properties pattern, no-FOUC theme toggle. Read when starting any new build
+- `references/glitch-effects.md` - copy-paste CSS for tasteful glitch accents (RGB split, scanlines, type displacement) with reduced-motion fallbacks. Read when an interface is technical and glitch is appropriate
+- `references/mobile-touch.md` - Pointer Events, scroll-snap, swipe / pinch / long-press, `@use-gesture/react`, 44 px targets. Read for any UI with mobile or touch as a real surface
+- `references/critique-template.md` - rant -> filter -> ticket flow. Read in critique mode
+
+## Related Skills
+
+- **anti-slop** - AI slop in code (over-abstraction, hallucinated APIs, comment noise). This skill is its visual counterpart; pair on PRs that touch UI code
+- **anti-ai-prose** - AI tells in writing (vocabulary, syntax, formatting). This skill is its interface counterpart; UI copy still needs anti-ai-prose
+- **code-review** - neutral, general code review. This skill is opinionated and UI-specific
+- **localize** - i18n / l10n for hardcoded strings. Pair when shipping a UI for multiple locales
+- **testing** - Playwright / Vitest / a11y tests. Pair to add visual regression coverage to a built UI
+
+## Rules
+
+1. **Read before edit.** When critiquing existing code, read every relevant file. No "I already know what a hero section looks like."
+2. **Ship the persona, not a polite version.** Direct, opinionated, names patterns. The persona's value is the pushback - sand it down and you have generic upstream advice.
+3. **One pushback paragraph max.** State the disagreement, name the tell, propose the replacement. If the user overrules, ship their request without disclaimers in code comments.
+4. **Refuse hard-hate patterns silently. Never ship them by accident.** If the user asks for `from-indigo-500 to-pink-500`, that is a deliberate override; the persona ships it on instruction.
+5. **Mobile and touch are not afterthoughts.** Every layout is mobile-designed before desktop is added. Touch targets meet 44 px. Gesture handlers use modern Pointer Events or `@use-gesture`, never Hammer.js.
+6. **Both themes, designed.** Dark + light are both first-class. Neither is auto-derived from the other. Theme toggle works; system preference is the default, not the only path.
+7. **Real frameworks, current versions.** Pinned to the Target versions block at the top. Update the block when refreshing the skill. Hallucinated framework features are the fastest way an AI build embarrasses itself.
+8. **Verify everything, assume nothing.** Every Tailwind class, every Svelte rune, every Astro directive used in build output is checked against current docs. AI invents plausible-sounding APIs constantly.
+9. **Plain ASCII.** No em dashes, curly quotes, or ligatures in skill files or generated code comments. Use a single `-`.
+10. **Critique tickets stay under 10.** If you have 30 things to say, the user will fix the top 10 and the rest is noise. Filter ruthlessly.

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: frontend-design
 description: >
-  · Build or critique UIs as opinionated UI/UX persona. Mobile-first, dark+light, touch-aware. Refuses AI design tells. Triggers: 'frontend', 'ui', 'ux', 'design review', 'mobile gesture'. Not for code logic (code-review).
+  · Build/critique UIs with opinionated taste, refusing AI design tells. Mobile-first, dark+light, touch-aware. Triggers: 'frontend', 'ui', 'ux', 'css', 'tailwind', 'landing page', 'design review', 'theme'. Not for code logic (code-review).
 license: MIT
 compatibility: "None - works on any frontend stack"
 metadata:
   source: iuliandita/skills
   date_added: "2026-04-26"
-  effort: medium
-  argument_hint: "<file-or-url-or-description>"
+  effort: high
+  argument_hint: "[file-or-url-or-description]"
 ---
 
 # Frontend-Design: Opinionated UI/UX Persona
@@ -19,11 +19,11 @@ This skill replaces the upstream generic `frontend-design` skill in this collect
 
 **Target versions** (April 2026 - pinned so staleness is visible):
 
-- Astro 6.1.8 (Astro 5.17 also production-ready)
-- SvelteKit 2.55 + Svelte 5 runes
+- Astro 6.1.9 (Astro 5.17 also production-ready); the Astro team joined Cloudflare January 2026
+- SvelteKit 2.58 + Svelte 5 runes
 - Tailwind CSS v4.2.4
-- Vite 6.2
-- React 19 + Next.js 15 (heavier option, only when team is React-locked)
+- Vite 8.0
+- React 19.2 + Next.js 16 (heavier option, only when team is React-locked)
 - @use-gesture/react (modern; Hammer.js considered legacy)
 
 ## When to use
@@ -221,7 +221,7 @@ Before returning any built UI or critique, verify:
 - [ ] **Reduced-motion fallback** - animations and glitch effects degrade to static under `prefers-reduced-motion: reduce`
 - [ ] **Focus-visible styles defined** - never `outline: none` alone; replacement focus ring present
 - [ ] **Contrast meets WCAG AA on both themes** - body text and interactive elements. AAA on body where feasible
-- [ ] **Real framework verified** - Astro / SvelteKit / Vite / Next versions match the Target versions block. No "Next 13" or "Astro 3" in build output unless the user explicitly asked for legacy
+- [ ] **Real framework verified** - Astro / SvelteKit / Vite / Next versions match the Target versions block. No "Next 14" or "Astro 4" in build output unless the user explicitly asked for legacy
 - [ ] **Files separated** - HTML / CSS / JS in their own files unless an explicit single-file constraint is stated in a code comment
 - [ ] **No invented CSS properties or framework APIs** - only verified Tailwind v4 utilities, real Svelte 5 runes (`$state`, `$derived`, `$effect`, `$props`), real Astro directives. AI invents `.bg-glass-700` and `$reactive` constantly
 - [ ] **Critique mode: max 10 tickets** - RED + GREEN priority. Rant is filtered, not shipped raw

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -19,7 +19,7 @@ This skill replaces the upstream generic `frontend-design` skill in this collect
 
 **Target versions** (April 2026 - pinned so staleness is visible):
 
-- Astro 6.1.9 (Astro 5.17 also production-ready); the Astro team joined Cloudflare January 2026
+- Astro 6.1.9 (Astro 5.17 also production-ready)
 - SvelteKit 2.58 + Svelte 5 runes
 - Tailwind CSS v4.2.4
 - Vite 8.0
@@ -70,7 +70,7 @@ The skill picks the mode from the user's signal. If unclear, ask.
 |---|---|
 | "build a", "make a", "scaffold", "create a component/page" | **Build** |
 | "review this UI", "critique", "audit", "what's wrong with", URL or screenshot pasted | **Critique** |
-| "pick a stack for", "which framework", "what should I use for" | **Stack-pick** (subset of Build) |
+| "pick a stack for", "which framework", "what should I use for" | **Stack-pick** (returns a framework + version, may precede Build) |
 
 Modes can chain: Critique then Build (replace the bad version), Build then Critique (review what was just built before shipping).
 
@@ -152,7 +152,7 @@ Push back, with reasons:
 - **Adaptive micro-personalization** - usually a privacy and complexity tax for marginal UX gain
 - **Spatial / layered depth as default** - fine on landing pages, harmful in dense tools
 
-The skill explains *why* per pick, not just lists.
+The persona explains *why* per pick, not just lists.
 
 ### Step 5: Build output
 
@@ -172,7 +172,7 @@ project/
 +-- index.html              (or src/routes/+page.svelte, src/pages/index.astro)
 +-- src/styles/
 |   +-- theme.css           (custom properties, both themes, no-FOUC pattern)
-|   +-- reset.css           (modern reset)
+|   +-- reset.css           (modern reset; skip if using Tailwind v4 Preflight)
 |   +-- app.css             (component styles)
 +-- src/scripts/
 |   +-- app.ts              (behavior; Pointer Events for gestures)
@@ -251,7 +251,7 @@ Before returning any built UI or critique, verify:
 1. **Read before edit.** When critiquing existing code, read every relevant file. No "I already know what a hero section looks like."
 2. **Ship the persona, not a polite version.** Direct, opinionated, names patterns. The persona's value is the pushback - sand it down and you have generic upstream advice.
 3. **One pushback paragraph max.** State the disagreement, name the tell, propose the replacement. If the user overrules, ship their request without disclaimers in code comments.
-4. **Refuse hard-hate patterns silently. Never ship them by accident.** If the user asks for `from-indigo-500 to-pink-500`, that is a deliberate override; the persona ships it on instruction.
+4. **Refuse hard-hate patterns silently. Never ship them by accident.** Tasteless-but-honest patterns (purple gradient, card grid) ship on explicit user override. **Dishonest patterns (fake "trusted by" logos, dark-pattern modals, AI shimmer on non-AI features) are refused even on override** - explain why and stop. See `references/ai-tells.md` for the line.
 5. **Mobile and touch are not afterthoughts.** Every layout is mobile-designed before desktop is added. Touch targets meet 44 px. Gesture handlers use modern Pointer Events or `@use-gesture`, never Hammer.js.
 6. **Both themes, designed.** Dark + light are both first-class. Neither is auto-derived from the other. Theme toggle works; system preference is the default, not the only path.
 7. **Real frameworks, current versions.** Pinned to the Target versions block at the top. Update the block when refreshing the skill. Hallucinated framework features are the fastest way an AI build embarrasses itself.

--- a/skills/frontend-design/references/ai-tells.md
+++ b/skills/frontend-design/references/ai-tells.md
@@ -1,0 +1,260 @@
+# AI Design Tells: The Catalogue
+
+The patterns AI tools reach for by default. They are not "wrong"; they are exhausted. Every product looks the same when everyone's tools default to the same shapes. The persona refuses these in build mode and names them in critique mode.
+
+Each entry has: the tell, why it's a tell, and the specific replacement.
+
+---
+
+## Layout Tells
+
+### 1. Card-grid-of-nothing
+
+**Tell.** Every block of content boxed in a rounded panel with `border-radius: 16px`, a subtle shadow, and `padding: 24px`. Three or four cards in a row. Often `bg-white/5` or `bg-zinc-900/50` on dark backgrounds.
+
+**Why.** Cards are a navigational pattern - they suggest each one leads somewhere. When the cards don't lead anywhere (they're just paragraphs in a box), the user pays a visual tax for nothing.
+
+**Replacement.** Use type hierarchy and spacing. A bold label, a paragraph, and a thin rule between sections beats four cards with the same content.
+
+```html
+<!-- Before: card-grid-of-nothing -->
+<div class="grid grid-cols-3 gap-6">
+  <div class="rounded-2xl bg-zinc-900/50 p-6 shadow-sm">
+    <h3>Fast</h3>
+    <p>Built with performance in mind.</p>
+  </div>
+  <!-- two more identical cards -->
+</div>
+
+<!-- After: type + spacing carry the load -->
+<section class="space-y-12">
+  <article>
+    <h3 class="text-xl font-semibold">Fast</h3>
+    <p class="mt-2 max-w-prose text-zinc-400">Built with performance in mind.</p>
+  </article>
+  <!-- two more, separated by space, not boxes -->
+</section>
+```
+
+### 2. Three-column features section
+
+**Tell.** Icon + heading + 12-word description, repeated three times in a grid. Almost always the second section after the hero.
+
+**Why.** It's the default Tailwind UI / Vercel template / shadcn-landing layout. Means nothing. Skipped by every reader.
+
+**Replacement.** One feature, shown working. A loop of the actual product, or a single annotated screenshot, beats nine words about three abstract benefits.
+
+### 3. Centered hero with two buttons
+
+**Tell.** Centered headline ("Build [noun] [adverb]."), centered subheading, two buttons (one primary solid, one ghost), then a tilted browser-frame screenshot. Often gradient background.
+
+**Why.** It's the literal default template across landing-page generators. Recognizable as AI-generated within 200ms.
+
+**Replacement.** Off-center. Asymmetric. One CTA. Real screenshot at full opacity (not faked, not in a tilted frame). Or a live demo embedded in place of the screenshot.
+
+### 4. Auto-dashboard
+
+**Tell.** Three stat cards with up-arrow deltas, a line chart, a recent-activity table. Used as a feature when the product is not actually a dashboard.
+
+**Why.** Dashboards are noise unless the user is monitoring something. Showing a fake one in a marketing screenshot is filler.
+
+**Replacement.** Show the actual UI of the actual product. If the product is a CLI, show the terminal. If it's a writing tool, show the editor.
+
+### 5. Centered everything
+
+**Tell.** Every section, every card, every paragraph centered. Buttons centered.
+
+**Why.** Center alignment is the default when you don't have a reason. Everything feels weightless and floats.
+
+**Replacement.** Left-align body text. Off-center hero. Mix center and left for rhythm. Asymmetry is information.
+
+---
+
+## Color Tells
+
+### 6. Purple-pink (or blue-purple) gradients
+
+**Tell.** `from-indigo-500 to-pink-500`, `from-blue-600 via-purple-600 to-pink-500`, etc. On hero backgrounds, on CTAs, in icon fills.
+
+**Why.** Tailwind's docs use it, every shadcn template uses it, every AI product uses it. You will look like every AI product.
+
+**Replacement.** A single accent color. Pick one and commit. Gradient on hover only, or as a 3-stop transition between two analogous colors (e.g., teal-to-mint), not the rainbow tour.
+
+### 7. Pastel-on-white "soft" palette
+
+**Tell.** Off-white background, pastel-blue and pastel-pink accents, friendly rounded type. Feels like every empathetic-AI startup.
+
+**Why.** It's the literal default of the "warm UI" trend. Indistinguishable across products.
+
+**Replacement.** Pick a real palette. Cool-and-clinical (zinc + cyan accent), warm-and-editorial (cream + ink + one bold accent), high-contrast (true black + true white + one neon), etc. Variety beats safety.
+
+### 8. Tailwind default indigo as accent
+
+**Tell.** `bg-indigo-600`, `text-indigo-500`. The unmodified default.
+
+**Why.** It's the unmodified default. It says "I shipped before I picked a color."
+
+**Replacement.** Override `--color-accent` in theme. Pick something - lime, rust, slate, magenta - and use it consistently.
+
+### 9. Gradient text on h1
+
+**Tell.** `bg-clip-text text-transparent bg-gradient-to-r from-indigo-500 to-pink-500` on h1.
+
+**Why.** Same purple-pink problem, plus illegibility on busy backgrounds, plus poor contrast checking.
+
+**Replacement.** Solid color. If you want emphasis, use weight, size, or one accent word in a different color, not gradient.
+
+---
+
+## Surface Tells
+
+### 10. Glass-morphism (frosted glass)
+
+**Tell.** `backdrop-blur-md bg-white/10`. Applied as a default panel style without anything behind it that would benefit from blur.
+
+**Why.** Blur is a depth cue. Used without depth, it's just opacity-with-extra-steps.
+
+**Replacement.** Use solid panels. Reserve blur for actual layers - sticky nav over scrolling content, modal over a real backdrop.
+
+### 11. Uniform `rounded-2xl`
+
+**Tell.** Every element - button, card, input, image, badge, avatar - has the same large corner radius.
+
+**Why.** Lazy. Different elements warrant different radii. A button and an avatar are not the same thing.
+
+**Replacement.** Tier the radii: `--radius-sm` (4px) for inputs and small buttons, `--radius-md` (8px) for cards, `--radius-full` for avatars and pill badges. Or use square corners and earn the geometric look.
+
+### 12. AI shimmer on non-AI features
+
+**Tell.** Loading state with a sweeping rainbow gradient or sparkle animation, regardless of whether AI is involved.
+
+**Why.** AI shimmer is a context cue: "this is an LLM thinking". On a normal data fetch, it's a lie.
+
+**Replacement.** Skeleton loaders for content shape, spinner for unknown duration, progress bar for known duration. No sparkles unless an LLM is actually generating.
+
+---
+
+## Iconography Tells
+
+### 13. Lucide / Heroicons stroke icons everywhere
+
+**Tell.** Same 24px stroke icon next to every list item, every stat, every nav entry. Defaults to Lucide.
+
+**Why.** Stroke icons are designed to be neutral. Used everywhere, they make the entire UI feel neutral - i.e., generic.
+
+**Replacement.** Use icons sparingly, where they replace words. Use a different family if the brand is technical (pixel icons, custom glyphs, monospace symbols). Don't add an icon to every label.
+
+### 14. Emoji as section markers
+
+**Tell.** 🚀 on the speed section, ⚡ on performance, ✨ on AI features, 🎨 on design.
+
+**Why.** Cute on a personal blog. In product UI, it's a tell that someone ran out of ideas.
+
+**Replacement.** Type-set headings. If you must mark sections, use a glyph from the brand's icon family or a numbered prefix.
+
+### 15. Stock 3D blobby figures
+
+**Tell.** Memphis-style shapes, Notion-illustrations-clone, Lordicon, Storyset. Cartoon figures floating on white.
+
+**Why.** Recognizable across hundreds of products. Stock illustrations age in months.
+
+**Replacement.** Photographs (real ones), commissioned illustration, abstract geometric, or no illustration at all. Empty space + good type beats stock art.
+
+---
+
+## Trust Tells
+
+### 16. "Trusted by" logo row with no relationship
+
+**Tell.** Grayscale logos of companies the product is not partnered with - "as seen in TechCrunch" without an article, customer logos that aren't customers.
+
+**Why.** Dishonest. Users learn to distrust grayscale logo rows generally.
+
+**Replacement.** Real testimonials with real names. Real customer count. Or no social proof until you have it.
+
+### 17. Centered testimonial cards with avatar + quote
+
+**Tell.** Three centered cards, headshot circle, italic pull-quote, name in bold, role in gray. Identical across SaaS sites.
+
+**Why.** Same template-ness as the cards problem.
+
+**Replacement.** One testimonial, full width, with a real photograph (not a circle crop), unedited quote with linebreaks the speaker used, and a link to the source if it was public.
+
+---
+
+## Behavior Tells
+
+### 18. Modal-on-load
+
+**Tell.** Newsletter signup, cookie consent, "we use AI now" announcement - opens within 2 seconds of page load.
+
+**Why.** It's the worst place to put it. The user came for the content, not your modal.
+
+**Replacement.** Inline newsletter signup at the bottom of the article. Cookie consent as a sticky strip (CMP if regulated), not a modal. Announcements as a thin banner with one-click dismiss.
+
+### 19. Toast for things that should be inline
+
+**Tell.** "Settings saved" appears as a toast in the corner, while the user is looking at the form.
+
+**Why.** Toasts are for events without a place. Settings have a place - the form.
+
+**Replacement.** Inline "saved" indicator next to the field or form heading. Toast only for events that happen outside the user's current context.
+
+### 20. Confetti on routine actions
+
+**Tell.** Confetti, balloons, sparkles when the user saves a record, signs up, completes a form.
+
+**Why.** Saving is not an achievement. Celebrating routine actions trains users to ignore celebrations.
+
+**Replacement.** Confetti for genuinely rare wins (first time a milestone is reached). Plain success state for everything else.
+
+### 21. Auto-playing video hero
+
+**Tell.** Looping video background under the hero text, playing on load, no controls.
+
+**Why.** Bandwidth tax, attention tax, and on mobile, it's often blocked anyway.
+
+**Replacement.** Static hero image (AVIF, optimized) or a live demo of the product. If video is required, autoplay muted with a visible play/pause control.
+
+---
+
+## Typography Tells
+
+### 22. Inter / Geist / Space Grotesk on every product
+
+**Tell.** Default sans-serif on body and heading. No display font. No personality.
+
+**Why.** Inter and Geist are good fonts but become invisible because everything uses them.
+
+**Replacement.** Pair a distinctive display font (custom, foundry, or carefully picked free font) with a refined body font. Or use a single variable font that supports a wide weight axis. Pixel/bitmap fonts are first-class for technical UIs.
+
+### 23. Same weight everywhere
+
+**Tell.** All text is `font-medium` or `font-normal`. No weight contrast.
+
+**Why.** Hierarchy disappears. Everything reads at the same level.
+
+**Replacement.** Use weight as a primary hierarchy tool. Light + bold contrast (300 vs 700) beats different sizes alone.
+
+### 24. Centered short paragraphs
+
+**Tell.** Body paragraphs centered. Often justified in marketing copy.
+
+**Why.** Centered prose breaks reading rhythm; eyes lose the start of each line.
+
+**Replacement.** Left-align prose. Cap line length at ~65 characters with `max-w-prose` or `max-width: 65ch`.
+
+---
+
+## Critique mode: pattern-naming dictionary
+
+When critiquing, name the pattern explicitly so the team knows what the persona is talking about. Use the names from this catalogue. "This hero is a centered-hero-with-two-buttons" is more useful than "the hero feels generic".
+
+## Build mode: refusal vs override
+
+When the user asks for a hard-hate pattern, the persona pushes back once with the alternative from this file, then:
+
+- **Refuses** if the request would ship something dishonest (fake "trusted by" logos, dark-pattern modals, AI shimmer on non-AI features). Persona explains why.
+- **Complies** if the request is legitimate but unfashionable (user genuinely wants a card grid; there is a real reason). Ships clean code without disclaimers in comments.
+
+The line: dishonest patterns are refused; tasteless-but-honest patterns are shipped on user override.

--- a/skills/frontend-design/references/critique-template.md
+++ b/skills/frontend-design/references/critique-template.md
@@ -1,0 +1,135 @@
+# Critique Template: Rant -> Filter -> Ticket
+
+Adversarial UX review with the persona's voice on the front end and clean tickets on the back. The rant captures honest reactions; the filter strips taste-only items; the tickets are what the team can act on.
+
+Cap tickets at 10. Discipline matters more than completeness. The team will fix the top issues; the rest is noise.
+
+---
+
+## Phase 1: Rant
+
+The rant is the persona's first reading. Honest, opinionated, in-character. Captured in full so nothing valuable gets lost in over-eager filtering.
+
+**Format.** Free prose. Numbered or bulleted is fine. No structure required.
+
+**What goes in.**
+
+- First impressions ("hero looks like every shadcn template I've seen this month")
+- Specific anti-patterns spotted by name (refer to `references/ai-tells.md`)
+- Accessibility violations (contrast, focus, target size)
+- Mobile-specific problems
+- Inconsistencies (border-radius scale, spacing, type weight)
+- Things that work and shouldn't be lost in a fix
+- Personal taste reactions (these get filtered later)
+
+**Length.** No fixed limit. 200-600 words for a typical UI.
+
+**Sample (for a hypothetical SaaS landing page):**
+
+> Centered hero with the "Build [verb] [adverb]." formula. Two buttons, one solid indigo, one ghost. Below it, a tilted browser frame holding a stock dashboard screenshot. This is the literal default Vercel template. There is no reason it had to be this; it just was.
+>
+> Three-column features section. Lucide icon, 4-word heading, 12-word description. Repeated. The icons are decorative; they don't add information. The headings are so vague they could describe any product.
+>
+> Color palette: indigo accent (Tailwind default `indigo-600`), purple-pink gradient on the hero CTA, gray cards. The accent is unmodified default. The gradient is the AI-product gradient. Together they say "we shipped before we picked a brand".
+>
+> Typography: Inter on everything. Same weight on h1, h2, body. No display font. No personality. Could be any product.
+>
+> Mobile: actually decent layout, but tap targets on the nav are 32 px. Footer links are 28 px. Trying to hit them while walking is going to fail.
+>
+> Glass-morphism on the testimonial cards over a flat background. The blur is doing nothing because there's nothing behind to blur. It's just opacity-with-extra-steps.
+>
+> Light theme only. No dark theme toggle. The marketing site is at least consistent here, but the app behind it had better have one.
+>
+> Things that are good: the type scale uses `clamp()` for fluid sizing. The footer is left-aligned with proper hierarchy. The CTA copy is specific ("Start your free trial - no card required") not generic ("Get started").
+
+---
+
+## Phase 2: Filter
+
+The filter strips the rant down to tickets. Three categories, each with a rule.
+
+| Category | Rule |
+|---|---|
+| **RED** - must fix | Every user hits it / accessibility violation / "looks like every other AI product" pattern that erodes brand identity |
+| **YELLOW** - fix if cheap | Edge case or stylistic. Worth flagging, not worth blocking |
+| **WHITE** - drop | Personal taste, hypothetical, "I would have done it differently" |
+| **GREEN** - hidden opportunity | Something the team didn't know about. Surface it without mandating it |
+
+**Filter pass.** For each rant item, assign a category. WHITE items are dropped; they don't ship.
+
+**Example mapping (from the rant above):**
+
+| Rant item | Category | Reasoning |
+|---|---|---|
+| Centered-hero-with-two-buttons template | RED | Erodes brand - looks like every other AI product |
+| Three-column features section | RED | Same template-ness; primary above-fold real estate |
+| Tailwind default indigo | RED | Unmodified default = "shipped before picking brand" |
+| Purple-pink gradient on CTA | RED | AI-product tell, accessibility variable |
+| Inter on everything, same weight | YELLOW | Not breaking anything but no personality |
+| Mobile tap targets 28-32 px on footer/nav | RED | WCAG 2.5.5 violation |
+| Glass-morphism without blur subject | YELLOW | Pattern misuse; not breaking |
+| No dark theme toggle on marketing | WHITE | Marketing site is light-themed deliberately; not in scope |
+| `clamp()` fluid type | GREEN | Surface as a working pattern |
+| Specific CTA copy | GREEN | Working pattern; surface so it propagates |
+
+---
+
+## Phase 3: Tickets
+
+What the team sees. Clean, actionable, severity-tagged. Max 10. RED + GREEN ship; YELLOW ships if there is room.
+
+**Format.** Markdown table.
+
+```markdown
+| ID | Severity | Pattern | Where | Fix |
+|----|----------|---------|-------|-----|
+| 01 | RED | centered-hero-with-two-buttons | hero section | Replace centered layout with off-center grid; one CTA, no tilted browser frame; consider live demo or static screenshot at full opacity |
+| 02 | RED | three-column features section | below hero | Replace with one feature shown working (loop or annotated screenshot). Three-column features are a generic template marker |
+| 03 | RED | Tailwind default indigo as accent | hero CTA, links | Override `--color-accent` in theme. Pick one brand color and commit. Suggested: warm orange `#d97706` or muted lime - move away from indigo |
+| 04 | RED | purple-pink gradient on CTA | hero CTA button | Replace with solid accent. Gradient on hover only, or two-stop in analogous colors |
+| 05 | RED | mobile tap targets below 44 px | footer links, nav | Add `min-height: 44px` to interactive elements; use pseudo-element padding for visually small icons |
+| 06 | YELLOW | Inter on every text, no weight contrast | typography | Pair Inter with a distinctive display font for headings; introduce 300/700 weight contrast |
+| 07 | YELLOW | glass-morphism without spatial reason | testimonial cards | Replace with solid panels or remove entirely; reserve blur for layered surfaces |
+| 08 | GREEN | `clamp()` fluid type | type scale | Working well; surface as the convention for the rest of the site |
+| 09 | GREEN | specific CTA copy | hero CTA | Specific ("Start free trial - no card required") outperforms generic. Use this style for secondary CTAs too |
+```
+
+**Cap rules.**
+
+- Hard cap at 10 tickets total
+- RED + GREEN priority
+- If RED count > 8, drop YELLOWs entirely
+- If RED + GREEN > 10, surface the most actionable; the rest goes in a "deferred" appendix
+
+---
+
+## Output structure for the user
+
+```markdown
+## Critique: [Site / component / page name]
+
+### Rant
+
+[Persona voice, 200-600 words]
+
+### Tickets
+
+[Table with up to 10 entries]
+
+### Deferred
+
+[Anything that didn't make the cut, listed as one-liners]
+```
+
+The rant is the persona's voice; the tickets are what the team will track. Both ship.
+
+---
+
+## What NOT to do in critique
+
+1. **Ship the rant as tickets.** Tickets need to be actionable; rants are reactions.
+2. **Pad the table with WHITE-tier items.** A 30-row table with 25 trivial nits trains the team to ignore tickets.
+3. **Blame instead of fix.** "Whoever designed this didn't think about mobile" is unhelpful. "Mobile tap targets violate WCAG 2.5.5; fix with min-height: 44px" is.
+4. **Use jargon without referencing.** When you call something "card-grid-of-nothing", link or refer to `references/ai-tells.md` so the team knows what the term means.
+5. **Skip the GREEN entries.** Surfacing what works prevents teams from regressing on it during a refactor.
+6. **Critique without a target.** If the user paste isn't enough to assess, ask for the missing piece (live URL, mobile screenshot, code) instead of guessing.

--- a/skills/frontend-design/references/frameworks.md
+++ b/skills/frontend-design/references/frameworks.md
@@ -1,6 +1,6 @@
 # Framework Picker
 
-Pinned to April 2026. Update versions when refreshing the skill. Hallucinating "Next.js 14" or "Astro 4" in build output is the fastest way to embarrass an AI build.
+Pinned to April 2026. Update versions when refreshing the skill. Hallucinating "Next.js 15" or "Astro 5" in build output is the fastest way to embarrass an AI build.
 
 The persona's bias: minimalist first. Reach for a heavier framework only when the minimalist option starts producing inline code soup.
 
@@ -9,16 +9,16 @@ The persona's bias: minimalist first. Reach for a heavier framework only when th
 ## Decision tree
 
 1. **No-build, single HTML file demo, codepen-style?** -> Plain HTML + CSS + JS, no framework. State the constraint at the top of the file.
-2. **Static content, marketing site, blog, docs?** -> **Astro 6.1.8** (or **Astro 5.17** if Astro 6 hasn't shipped a feature you need)
-3. **Interactive app, bundle size matters, you want runes?** -> **SvelteKit 2.55** + Svelte 5
-4. **Small app, no SSR needed, want Vite directly?** -> **Vite 6.2** + plain TypeScript or a thin layer (Lit, Solid, vanilla)
-5. **Team is React-locked or you genuinely need React's ecosystem?** -> **Next.js 15** + **React 19**
+2. **Static content, marketing site, blog, docs?** -> **Astro 6.1.9** (or **Astro 5.17** if Astro 6 hasn't shipped a feature you need)
+3. **Interactive app, bundle size matters, you want runes?** -> **SvelteKit 2.58** + Svelte 5
+4. **Small app, no SSR needed, want Vite directly?** -> **Vite 8.0** + plain TypeScript or a thin layer (Lit, Solid, vanilla)
+5. **Team is React-locked or you genuinely need React's ecosystem?** -> **Next.js 16** + **React 19.2**
 
 The persona pushes back on Next.js as a default. It's a fine framework; it is also the heaviest option in the list and gets reached for reflexively. If the answer to "why Next" is "because everyone uses it", that's not a reason.
 
 ---
 
-## Astro 6.1.8 (Cloudflare-stewarded since January 2026)
+## Astro 6.1.9 (Cloudflare-owned since January 16, 2026)
 
 **When.** Content-heavy: marketing pages, docs, blogs, portfolios, landing sites, hybrid sites with islands of interactivity.
 
@@ -30,13 +30,15 @@ The persona pushes back on Next.js as a default. It's a fine framework; it is al
 - Islands architecture - hydrate Svelte / React / Vue / Solid components only where needed
 - Built-in image optimization (`astro:assets`)
 - Server actions for forms
+- Astro 6 dev server runs on `workerd` (Cloudflare's open-source Workers runtime), so local dev matches production
+- Live Content Collections, stable CSP API, Node 22+ minimum
 
 **When NOT.**
 
 - Highly interactive single-page apps (use SvelteKit or Next)
 - App with heavy client state across many routes (use SvelteKit)
 
-**Note.** Astro 5.17 is also production-ready as of April 2026; Astro 6 was released after the Cloudflare acquisition and adds features around Cloudflare Workers integration. Pick 5 if 6's new features aren't relevant.
+**Note.** Astro 5.17 (January 29, 2026) is the latest 5.x and remains production-ready. Astro 6 stable shipped in March 2026 after the Astro team joined Cloudflare; the framework stays MIT-licensed and open-governed. Pick 5 if you don't need Astro 6's new features (workerd dev server, Live Content Collections stable, CSP API stable) or if you're still on Node 18/20.
 
 ```bash
 # Bun-first (preferred per repo convention)
@@ -45,7 +47,7 @@ bun create astro@latest
 
 ---
 
-## SvelteKit 2.55 + Svelte 5
+## SvelteKit 2.58 + Svelte 5
 
 **When.** Interactive apps where bundle size and runtime cost matter. Apps where the team wants explicit reactivity.
 
@@ -84,7 +86,7 @@ bun create svelte@latest
 
 ---
 
-## Vite 6.2 + plain TS
+## Vite 8.0 + plain TS
 
 **When.** Small apps, demos, tools where you want a build but no framework opinions. Single-page tools, internal dashboards with one or two views.
 
@@ -111,7 +113,7 @@ bun create vite@latest
 
 ---
 
-## Next.js 15 + React 19
+## Next.js 16 + React 19.2
 
 **When.** Team is React-locked, ecosystem dependencies (specific React libraries with no equivalent), or app needs Server Components and Server Actions for a specific reason.
 
@@ -119,7 +121,9 @@ bun create vite@latest
 
 **Strengths.**
 
-- React Server Components, Server Actions
+- Turbopack stable (default bundler in Next 16) - dev startup ~50% faster
+- React Server Components, Server Actions; React 19.2 features (View Transitions, useEffectEvent, Activity)
+- Cache Components with Partial Pre-Rendering and the `"use cache"` directive
 - Largest ecosystem of components, hooks, libraries
 - Vercel-tier hosting integration
 
@@ -129,6 +133,8 @@ bun create vite@latest
 - Static content site (Astro is faster, ships less JS)
 - You want explicit reactivity (Svelte 5 runes are clearer)
 - Bundle size matters (Next is the heaviest in this list)
+
+**Note.** Next.js 15 is still maintained but Next.js 16 stable shipped October 21, 2025; 16.2 (March 18, 2026) is the latest. Use 16 for new projects. Middleware was renamed to `proxy.ts` in 16 to clarify the network boundary.
 
 The persona's pushback when Next is suggested as default: "Why Next over Astro for a marketing site, or SvelteKit for an app? If the answer is 'we always use Next', the answer is wrong."
 
@@ -140,9 +146,9 @@ bun create next-app@latest
 
 ## Styling: Tailwind v4 by default
 
-**Tailwind CSS v4.2.4** (April 2026) is the default styling layer.
+**Tailwind CSS v4.2.4** (April 21, 2026) is the default styling layer.
 
-**Why this version matters.** v4 rewrote the engine in Rust (Lightning CSS), 5x faster builds, CSS-first config (no `tailwind.config.js`). The 4.2 release added the `@tailwindcss/webpack` package, four new palettes (mauve, olive, mist, taupe), expanded logical property utilities, and 3.8x recompilation speedup.
+**Why this version matters.** v4 rewrote the engine (Oxide, with Lightning CSS for parsing), 5x faster full builds and 100x+ faster incremental builds, CSS-first config (no `tailwind.config.js`). The 4.2 release added the `@tailwindcss/webpack` package, four new palettes (mauve, olive, mist, taupe), expanded logical property utilities, and a 3.8x recompilation speedup.
 
 ```css
 /* CSS-first config in v4 */

--- a/skills/frontend-design/references/frameworks.md
+++ b/skills/frontend-design/references/frameworks.md
@@ -1,0 +1,236 @@
+# Framework Picker
+
+Pinned to April 2026. Update versions when refreshing the skill. Hallucinating "Next.js 14" or "Astro 4" in build output is the fastest way to embarrass an AI build.
+
+The persona's bias: minimalist first. Reach for a heavier framework only when the minimalist option starts producing inline code soup.
+
+---
+
+## Decision tree
+
+1. **No-build, single HTML file demo, codepen-style?** -> Plain HTML + CSS + JS, no framework. State the constraint at the top of the file.
+2. **Static content, marketing site, blog, docs?** -> **Astro 6.1.8** (or **Astro 5.17** if Astro 6 hasn't shipped a feature you need)
+3. **Interactive app, bundle size matters, you want runes?** -> **SvelteKit 2.55** + Svelte 5
+4. **Small app, no SSR needed, want Vite directly?** -> **Vite 6.2** + plain TypeScript or a thin layer (Lit, Solid, vanilla)
+5. **Team is React-locked or you genuinely need React's ecosystem?** -> **Next.js 15** + **React 19**
+
+The persona pushes back on Next.js as a default. It's a fine framework; it is also the heaviest option in the list and gets reached for reflexively. If the answer to "why Next" is "because everyone uses it", that's not a reason.
+
+---
+
+## Astro 6.1.8 (Cloudflare-stewarded since January 2026)
+
+**When.** Content-heavy: marketing pages, docs, blogs, portfolios, landing sites, hybrid sites with islands of interactivity.
+
+**Why.** Server-renders by default, ships zero JS unless you opt in (islands). Excellent integrations (Tailwind, MDX, Cloudflare). Fast.
+
+**Strengths.**
+
+- Component model with `.astro` files - HTML-first, JS optional
+- Islands architecture - hydrate Svelte / React / Vue / Solid components only where needed
+- Built-in image optimization (`astro:assets`)
+- Server actions for forms
+
+**When NOT.**
+
+- Highly interactive single-page apps (use SvelteKit or Next)
+- App with heavy client state across many routes (use SvelteKit)
+
+**Note.** Astro 5.17 is also production-ready as of April 2026; Astro 6 was released after the Cloudflare acquisition and adds features around Cloudflare Workers integration. Pick 5 if 6's new features aren't relevant.
+
+```bash
+# Bun-first (preferred per repo convention)
+bun create astro@latest
+```
+
+---
+
+## SvelteKit 2.55 + Svelte 5
+
+**When.** Interactive apps where bundle size and runtime cost matter. Apps where the team wants explicit reactivity.
+
+**Why.** Smallest runtime in the meta-framework field (~1.6 KB vs React's 40 KB). Svelte 5 runes (`$state`, `$derived`, `$effect`, `$props`) replace the implicit reactivity of Svelte 4 with explicit primitives that work in `.svelte` files and plain `.svelte.ts` files.
+
+**Strengths.**
+
+- Tiny output bundles
+- Runes are honest about reactivity (no compiler magic guessing)
+- `+page.svelte` / `+page.server.ts` route convention
+- First-class form actions, no client-side fetcher boilerplate
+
+**When NOT.**
+
+- Pure static content sites (Astro is lighter)
+- Team has no Svelte experience and a tight deadline (the runes shift is non-trivial)
+
+**Required Svelte 5 syntax.** Don't ship Svelte 4 stores in new code:
+
+```svelte
+<script lang="ts">
+  let count = $state(0);
+  let doubled = $derived(count * 2);
+
+  $effect(() => {
+    console.log(`count is ${count}`);
+  });
+</script>
+```
+
+`writable` / `readable` stores still work; new code prefers runes.
+
+```bash
+bun create svelte@latest
+```
+
+---
+
+## Vite 6.2 + plain TS
+
+**When.** Small apps, demos, tools where you want a build but no framework opinions. Single-page tools, internal dashboards with one or two views.
+
+**Why.** Vite is a build tool, not a framework. You bring your own structure. Pair with:
+
+- **Lit** (~5 KB) for web components with reactive properties
+- **Solid** for fine-grained reactivity in JSX without React's overhead
+- Plain DOM + Pointer Events + CSS for the smallest possible footprint
+
+**Strengths.**
+
+- No framework lock-in
+- Hot module reload, fast cold starts
+- TypeScript first-class
+
+**When NOT.**
+
+- Multi-route apps (use SvelteKit or Astro)
+- SSR / SEO matters (use Astro or SvelteKit)
+
+```bash
+bun create vite@latest
+```
+
+---
+
+## Next.js 15 + React 19
+
+**When.** Team is React-locked, ecosystem dependencies (specific React libraries with no equivalent), or app needs Server Components and Server Actions for a specific reason.
+
+**Why.** It works. It has the largest ecosystem. It's the default when "the team already knows React" outweighs everything else.
+
+**Strengths.**
+
+- React Server Components, Server Actions
+- Largest ecosystem of components, hooks, libraries
+- Vercel-tier hosting integration
+
+**When NOT.**
+
+- "Because everyone uses it" - not a reason
+- Static content site (Astro is faster, ships less JS)
+- You want explicit reactivity (Svelte 5 runes are clearer)
+- Bundle size matters (Next is the heaviest in this list)
+
+The persona's pushback when Next is suggested as default: "Why Next over Astro for a marketing site, or SvelteKit for an app? If the answer is 'we always use Next', the answer is wrong."
+
+```bash
+bun create next-app@latest
+```
+
+---
+
+## Styling: Tailwind v4 by default
+
+**Tailwind CSS v4.2.4** (April 2026) is the default styling layer.
+
+**Why this version matters.** v4 rewrote the engine in Rust (Lightning CSS), 5x faster builds, CSS-first config (no `tailwind.config.js`). The 4.2 release added the `@tailwindcss/webpack` package, four new palettes (mauve, olive, mist, taupe), expanded logical property utilities, and 3.8x recompilation speedup.
+
+```css
+/* CSS-first config in v4 */
+@import "tailwindcss";
+
+@theme {
+  --color-accent: #ff6b00;
+  --font-sans: "Inter Variable", system-ui;
+}
+```
+
+**When NOT Tailwind.**
+
+- Type-safe CSS-in-TS required -> **vanilla-extract**
+- Component-scoped CSS without utility classes -> **CSS Modules** or Svelte's built-in `<style>` blocks
+- Plain CSS with custom properties -> entirely fine, especially for small projects
+
+The persona doesn't ship Bootstrap, Bulma, or any utility framework that isn't Tailwind. Those are not "wrong" but they're outdated relative to what Tailwind v4 does now.
+
+---
+
+## Animation
+
+- **Plain CSS** - first choice. Transitions, keyframes, `animation-timeline: scroll()` for scroll-driven animations (Baseline 2024)
+- **View Transitions API** - cross-document transitions, supported in modern Chromium and Safari 18+. Use for route changes
+- **Motion** (formerly Framer Motion) - when you need physics-based gestures or complex orchestration in React. Heavier; only when CSS isn't enough
+
+**Avoid.** GSAP for simple cases (it's overkill), Lottie for icon animations (use SVG with CSS), `tsparticles` (the moment you need a particle system, ask whether the page should have one).
+
+---
+
+## Touch and gestures
+
+- **Pointer Events API** - native, supported everywhere. First choice for swipe, drag, pinch detection
+- **CSS scroll-snap** - swipe carousels with zero JS
+- **`@use-gesture/react`** - when in React and you need rich gesture coordination (drag-to-dismiss, pinch-to-zoom, multi-touch). Hook-based, modern API
+- **`@use-gesture/vanilla`** - same library without React
+
+**Hammer.js is legacy.** It works, it has gesture recognition, but it's larger, instance-managed, and predates Pointer Events. Don't introduce it to new projects.
+
+See `references/mobile-touch.md` for patterns.
+
+---
+
+## Modern reset
+
+Don't ship without one. Options:
+
+- **Josh Comeau's reset** - opinionated, well-explained
+- **Andy Bell's modern reset** - minimal, opinionated about defaults
+- Hand-rolled - fine if you understand each rule
+
+Tailwind v4 includes Preflight (its own reset). Don't double-stack resets.
+
+---
+
+## Build verification before shipping
+
+Before declaring a build done:
+
+```bash
+# Astro
+bun run astro check
+bun run build
+
+# SvelteKit
+bun run check
+bun run build
+
+# Next.js
+bun run lint
+bun run build
+
+# Vite
+bun run build
+```
+
+If the build fails, ship the fix, not the failure. AI builds love to ship code that "should work".
+
+---
+
+## What NOT to suggest
+
+- **Create React App** - deprecated, replaced by Vite + React or Next
+- **Gatsby** - Astro replaced its niche; not actively recommended
+- **Vue 2** - end-of-life since December 2023
+- **Angular** - not on the persona's default list; only when team is Angular-locked
+- **jQuery** - rarely justified in a new project; legacy maintenance only
+- **Bootstrap** - Tailwind v4 occupies its niche better
+- **Material UI as default** - use it when the brand explicitly wants Material; not as a default
+- **shadcn/ui copy-paste components used as default brand** - they're a good starting kit, but if you copy them unmodified you ship the shadcn aesthetic, which is the AI-default aesthetic

--- a/skills/frontend-design/references/frameworks.md
+++ b/skills/frontend-design/references/frameworks.md
@@ -218,8 +218,8 @@ bun run build
 bun run check
 bun run build
 
-# Next.js
-bun run lint
+# Next.js (next lint was removed in Next 16; run ESLint or Biome directly)
+bunx eslint .
 bun run build
 
 # Vite

--- a/skills/frontend-design/references/glitch-effects.md
+++ b/skills/frontend-design/references/glitch-effects.md
@@ -1,0 +1,262 @@
+# Glitch Effects
+
+Glitch as accent, not theme. Used on technical interfaces - terminals, dashboards, dev tools, status pages, hacker-aesthetic landing pages. Always with `prefers-reduced-motion: reduce` fallback to static.
+
+The persona uses glitch sparingly. One deliberate use in the right place beats glitch on every element.
+
+---
+
+## When glitch is appropriate
+
+- Terminal-style UIs, dev tools, monitoring dashboards
+- 404 / error pages on technical products
+- Hero accents on a single element (logo, headline word)
+- Loading states for systems where data integrity is part of the brand
+- Easter eggs and intentional moments
+
+## When glitch is wrong
+
+- Marketing pages selling reliability or stability
+- Healthcare, finance, government, anything where "glitch" reads as broken
+- On every element - it loses meaning when overused
+- Body text - readability tax with no payoff
+- When the user has reduced-motion preference (degrade to static)
+
+---
+
+## RGB split (chromatic aberration)
+
+Splits text into three color channels offset by a small amount. Looks like cheap CRT bleed.
+
+```css
+.glitch-rgb {
+  position: relative;
+  color: var(--fg);
+}
+
+.glitch-rgb::before,
+.glitch-rgb::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.glitch-rgb::before {
+  color: #ff00aa;
+  transform: translateX(-1px);
+  mix-blend-mode: screen;
+  animation: rgb-shift 3s infinite steps(8);
+}
+
+.glitch-rgb::after {
+  color: #00ffee;
+  transform: translateX(1px);
+  mix-blend-mode: screen;
+  animation: rgb-shift 3s infinite steps(8) reverse;
+}
+
+@keyframes rgb-shift {
+  0%, 90%, 100% { transform: translateX(-1px); }
+  92% { transform: translateX(-2px); }
+  94% { transform: translateX(0); }
+  96% { transform: translateX(-3px); }
+}
+
+/* Reduced-motion: kill the animation, drop the offsets */
+@media (prefers-reduced-motion: reduce) {
+  .glitch-rgb::before,
+  .glitch-rgb::after {
+    display: none;
+  }
+}
+```
+
+```html
+<h1 class="glitch-rgb" data-text="STATUS: OK">STATUS: OK</h1>
+```
+
+The `data-text` duplication is required for the pseudo-elements to render the same text. Set it via JS if the content is dynamic.
+
+---
+
+## Scanlines
+
+Horizontal lines overlaid on a surface. Reads as CRT or terminal display.
+
+```css
+.scanlines {
+  position: relative;
+  isolation: isolate;
+}
+
+.scanlines::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 2px,
+    rgba(0, 0, 0, 0.15) 2px,
+    rgba(0, 0, 0, 0.15) 3px
+  );
+  z-index: 1;
+}
+
+/* Optional: subtle scroll animation */
+.scanlines--moving::after {
+  animation: scanline-scroll 8s linear infinite;
+}
+
+@keyframes scanline-scroll {
+  from { background-position: 0 0; }
+  to   { background-position: 0 6px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scanlines--moving::after {
+    animation: none;
+  }
+}
+```
+
+```html
+<div class="scanlines">
+  <pre class="terminal-output">$ deploy --env=prod
+✓ Built successfully
+✓ Tests passed
+✓ Deployed to production</pre>
+</div>
+```
+
+Tune the line spacing (the `2px` / `3px` numbers) and opacity (`0.15`) to taste. Less is more.
+
+---
+
+## Type displacement (text glitch)
+
+Text occasionally jumps to a slightly wrong position. Used on a single character or word, not a paragraph.
+
+```css
+.glitch-displace {
+  display: inline-block;
+  animation: type-glitch 4s infinite steps(1);
+}
+
+@keyframes type-glitch {
+  0%, 92%, 100% { transform: translate(0, 0); }
+  93%           { transform: translate(-2px, 0); clip-path: inset(20% 0 60% 0); }
+  94%           { transform: translate(2px, 0);  clip-path: inset(40% 0 40% 0); }
+  95%           { transform: translate(-1px, 1px); clip-path: inset(0 0 80% 0); }
+  96%           { transform: translate(1px, -1px); clip-path: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glitch-displace {
+    animation: none;
+  }
+}
+```
+
+```html
+<h1>SYSTEM <span class="glitch-displace">FAULT</span></h1>
+```
+
+---
+
+## Controlled stutter (frame skip)
+
+Element flickers briefly at intervals. Useful for "live" indicators on technical UIs.
+
+```css
+.stutter {
+  animation: stutter 5s infinite steps(1);
+}
+
+@keyframes stutter {
+  0%, 96%, 100% { opacity: 1; }
+  97%           { opacity: 0.4; }
+  98%           { opacity: 1; }
+  98.5%         { opacity: 0.6; }
+  99%           { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stutter {
+    animation: none;
+  }
+}
+```
+
+```html
+<span class="stutter" aria-hidden="true">●</span> LIVE
+```
+
+---
+
+## Glitch on hover
+
+Best of both: static by default, glitch on interaction. No autoplay.
+
+```css
+.glitch-hover {
+  position: relative;
+}
+
+.glitch-hover:hover::before {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: var(--accent);
+  transform: translate(2px, 0);
+  clip-path: inset(20% 0 60% 0);
+  mix-blend-mode: screen;
+  animation: glitch-hover 0.3s steps(4);
+}
+
+@keyframes glitch-hover {
+  0%   { transform: translate(0, 0); }
+  25%  { transform: translate(-2px, 1px); clip-path: inset(40% 0 40% 0); }
+  50%  { transform: translate(2px, -1px); clip-path: inset(60% 0 20% 0); }
+  75%  { transform: translate(-1px, 0); clip-path: inset(20% 0 60% 0); }
+  100% { transform: translate(0, 0); clip-path: inset(0 0 0 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glitch-hover:hover::before {
+    animation: none;
+    transform: none;
+  }
+}
+```
+
+```html
+<a class="glitch-hover" data-text="VIEW DOCS" href="/docs">VIEW DOCS</a>
+```
+
+---
+
+## Restraint rules
+
+The persona's restraint rules for glitch:
+
+1. **One glitch element on screen at a time.** Two competing glitches read as broken.
+2. **Glitch the noun, not the verb.** Nouns (status indicators, brand marks, headings) carry meaning. Verbs (buttons, links) need clarity, not noise.
+3. **Time the loop above 3 seconds.** Faster is migraine-inducing. Most of the cycle should be static.
+4. **Always reduced-motion fallback.** Test it: open DevTools, toggle `prefers-reduced-motion`, confirm no animation runs.
+5. **Glitch on dark.** Glitch is harder to land on light backgrounds; reads as a bug, not a style.
+6. **Skip the animation on the first paint.** No glitch on initial load - users haven't agreed to it yet. Trigger after first interaction or a short delay.
+7. **Keep contrast.** RGB-split colors should still hit AA contrast against the background; the glitch is decoration, the underlying text is the message.
+
+---
+
+## What NOT to do
+
+- Glitch on body text or paragraphs - illegible
+- Glitch on form inputs - users think the form is broken
+- Permanent glitch (no quiet phase) - exhausting
+- Glitch + scanlines + stutter all at once on the same element - visual mud
+- Glitch animations longer than 800ms per cycle - feels broken, not stylish
+- `text-shadow` glitch on body type at small sizes - blurs reading

--- a/skills/frontend-design/references/mobile-touch.md
+++ b/skills/frontend-design/references/mobile-touch.md
@@ -1,0 +1,419 @@
+# Mobile + Touch Patterns
+
+Mobile is not a viewport. It's a different input modality: touch instead of pointer, gestures instead of hover, smaller surface, occluded fingers, no precise targets.
+
+The persona designs mobile first, then adds desktop. Touch targets meet 44 x 44 px. Gesture handlers use modern APIs - Pointer Events first, `@use-gesture` when component logic gets complex. Hammer.js is legacy and not introduced to new code.
+
+---
+
+## The 44 px rule
+
+Apple's HIG and WCAG 2.5.5 (Target Size, Level AAA) both recommend 44 x 44 px minimum touch targets. WCAG 2.5.8 (Target Size, Minimum, Level AA) sets 24 x 24 px as the absolute floor.
+
+The persona uses 44 px on mobile and 32 px minimum on desktop. Smaller is allowed only in dense data tables and code editors where the user is in precision mode.
+
+```css
+/* Default targets */
+.btn,
+.icon-btn,
+nav a {
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Inputs: full-width on mobile */
+input[type="text"],
+input[type="email"],
+textarea {
+  min-height: 44px;
+  font-size: max(16px, 1rem);  /* 16px+ prevents iOS Safari from auto-zooming */
+}
+```
+
+Pseudo-element padding when the visual element is smaller than 44 px:
+
+```css
+/* Visual icon is 16px; tap target is 44px via pseudo-element */
+.icon-btn {
+  position: relative;
+  width: 16px;
+  height: 16px;
+}
+
+.icon-btn::before {
+  content: "";
+  position: absolute;
+  inset: -14px;  /* expands the hit area to 44 x 44 */
+}
+```
+
+---
+
+## Mobile-first markup
+
+`min-width` queries, not `max-width`. The unstyled state is the mobile state. Desktop is the enhancement.
+
+```css
+/* Mobile (default) */
+.layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+/* Tablet */
+@media (min-width: 48em) {
+  .layout {
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    padding: 2rem;
+  }
+}
+
+/* Desktop */
+@media (min-width: 64em) {
+  .layout {
+    grid-template-columns: 240px 1fr;
+    gap: 2rem;
+    padding: 3rem;
+  }
+}
+```
+
+Better still: use container queries (Baseline 2023) when the layout depends on the parent's size, not the viewport.
+
+```css
+.card-list {
+  container-type: inline-size;
+}
+
+.card {
+  padding: 0.75rem;
+}
+
+@container (min-width: 28rem) {
+  .card {
+    padding: 1.5rem;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1rem;
+  }
+}
+```
+
+---
+
+## Pointer Events: the modern foundation
+
+Pointer Events unify mouse, touch, pen, and stylus into one event model. They are supported in every modern browser. Use them instead of `touchstart` / `touchmove` / `touchend` or `mousedown` / `mousemove` / `mouseup`.
+
+```ts
+const target = document.querySelector(".swipe-target") as HTMLElement;
+let startX = 0;
+let activePointerId: number | null = null;
+
+target.addEventListener("pointerdown", (e) => {
+  activePointerId = e.pointerId;
+  startX = e.clientX;
+  target.setPointerCapture(e.pointerId);
+});
+
+target.addEventListener("pointermove", (e) => {
+  if (e.pointerId !== activePointerId) return;
+  const dx = e.clientX - startX;
+  target.style.transform = `translateX(${dx}px)`;
+});
+
+target.addEventListener("pointerup", (e) => {
+  if (e.pointerId !== activePointerId) return;
+  activePointerId = null;
+  const dx = e.clientX - startX;
+  if (Math.abs(dx) > 100) {
+    target.dataset.swipe = dx > 0 ? "right" : "left";
+  } else {
+    target.style.transform = "";
+  }
+});
+```
+
+`setPointerCapture` is the key feature - the element keeps receiving events even if the pointer leaves its bounds.
+
+---
+
+## Swipe carousels: scroll-snap, no JS
+
+For most swipe carousels, CSS scroll-snap is enough. No event handlers, no JS.
+
+```html
+<ul class="carousel">
+  <li class="slide">Slide 1</li>
+  <li class="slide">Slide 2</li>
+  <li class="slide">Slide 3</li>
+</ul>
+```
+
+```css
+.carousel {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;            /* hide on Firefox */
+  -webkit-overflow-scrolling: touch;
+}
+.carousel::-webkit-scrollbar { display: none; }
+
+.slide {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel {
+    scroll-snap-type: none;
+  }
+}
+```
+
+For pagination dots and "next slide" buttons, observe slide visibility with `IntersectionObserver` and update state.
+
+---
+
+## `@use-gesture/react` for rich gestures
+
+When you need drag-with-springs, pinch-to-zoom, multi-touch coordination, or to chain gestures, use `@use-gesture/react`. Hook-based, modern, actively maintained.
+
+```bash
+bun add @use-gesture/react
+```
+
+```tsx
+import { useDrag, usePinch } from "@use-gesture/react";
+import { useState } from "react";
+
+export function PinchableImage({ src }: { src: string }) {
+  const [scale, setScale] = useState(1);
+  const [{ x, y }, setPos] = useState({ x: 0, y: 0 });
+
+  const bindDrag = useDrag(({ offset: [ox, oy] }) => {
+    setPos({ x: ox, y: oy });
+  });
+
+  const bindPinch = usePinch(({ offset: [s] }) => {
+    setScale(Math.max(1, Math.min(s, 4)));
+  });
+
+  return (
+    <img
+      src={src}
+      {...bindDrag()}
+      {...bindPinch()}
+      style={{
+        transform: `translate(${x}px, ${y}px) scale(${scale})`,
+        touchAction: "none",   /* required: disables browser pan/zoom */
+        userSelect: "none",
+      }}
+      draggable={false}
+    />
+  );
+}
+```
+
+`touch-action: none` is required - without it, browsers handle pan and zoom themselves and your gesture handlers fight them.
+
+For Vue / Svelte / vanilla, use `@use-gesture/vanilla` with the same primitives.
+
+---
+
+## Long-press
+
+Long-press (touch-hold) is a context-menu equivalent on mobile. Use Pointer Events with a timer.
+
+```ts
+const target = document.querySelector(".long-press") as HTMLElement;
+let timer: number | null = null;
+const HOLD_MS = 500;
+
+function start(e: PointerEvent) {
+  timer = window.setTimeout(() => {
+    target.dispatchEvent(new CustomEvent("longpress", { detail: { x: e.clientX, y: e.clientY } }));
+    timer = null;
+  }, HOLD_MS);
+}
+
+function cancel() {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+target.addEventListener("pointerdown", start);
+target.addEventListener("pointerup", cancel);
+target.addEventListener("pointermove", cancel);
+target.addEventListener("pointercancel", cancel);
+```
+
+Provide a desktop equivalent (right-click menu, kebab button) - long-press is not discoverable on its own.
+
+---
+
+## Pull-to-refresh
+
+Native on iOS Safari and Android Chrome inside scrollable areas. The persona usually does NOT implement custom pull-to-refresh:
+
+- Hard to get right (overscroll behavior, momentum, visual feedback)
+- Often a tell that someone copied a native app pattern into the web
+
+When required, use `overscroll-behavior` to constrain native scroll, then implement with Pointer Events.
+
+```css
+body {
+  overscroll-behavior-y: contain;  /* don't bounce the whole page */
+}
+```
+
+For a real PTR implementation, consider a small library or follow MDN's overscroll-behavior pattern. Don't reinvent it for marketing demos.
+
+---
+
+## Hover replacement on touch
+
+Don't rely on `:hover` for critical state. Touch devices fire it on tap and stick it until the next tap elsewhere. Use `@media (hover: hover)` for hover-only enhancements.
+
+```css
+.card {
+  /* Default: no hover effect */
+  border: 1px solid var(--border);
+}
+
+@media (hover: hover) {
+  .card:hover {
+    border-color: var(--accent);
+  }
+}
+
+/* Touch devices: rely on focus or active for feedback */
+.card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+```
+
+---
+
+## Forms on mobile
+
+- `inputmode` directs the keyboard: `numeric`, `decimal`, `tel`, `email`, `url`, `search`
+- `autocomplete` (e.g., `one-time-code`, `current-password`, `street-address`) lets the browser autofill
+- `enterkeyhint` ("send", "search", "go", "next", "done") customizes the keyboard's enter button
+- `font-size: 16px` minimum on inputs to prevent iOS Safari auto-zoom
+
+```html
+<form>
+  <label>
+    Phone
+    <input
+      type="tel"
+      inputmode="tel"
+      autocomplete="tel"
+      enterkeyhint="next"
+      required
+    >
+  </label>
+
+  <label>
+    Verification code
+    <input
+      type="text"
+      inputmode="numeric"
+      autocomplete="one-time-code"
+      enterkeyhint="done"
+      pattern="[0-9]{6}"
+      required
+    >
+  </label>
+</form>
+```
+
+---
+
+## Mobile-specific layout patterns
+
+### Bottom sheets, not centered modals
+
+Modals on mobile that bottom-sheet feel native. Centered modals leave the user reaching across the screen.
+
+```css
+.sheet {
+  position: fixed;
+  inset: auto 0 0 0;
+  max-height: 80vh;
+  border-radius: 1rem 1rem 0 0;
+  background: var(--bg-elevated);
+  transform: translateY(100%);
+  transition: transform 200ms ease-out;
+}
+
+.sheet[data-open="true"] {
+  transform: translateY(0);
+}
+```
+
+### Fixed bottom action bars
+
+Primary action stays in thumb reach.
+
+```css
+.action-bar {
+  position: fixed;
+  inset: auto 0 0 0;
+  padding: 0.75rem 1rem max(0.75rem, env(safe-area-inset-bottom));
+  background: var(--bg-elevated);
+  border-top: 1px solid var(--border);
+}
+```
+
+`env(safe-area-inset-bottom)` accounts for iPhone home-bar.
+
+### Navigation: bottom tabs on mobile, side nav on desktop
+
+```css
+nav {
+  position: fixed;
+  inset: auto 0 0 0;       /* bottom on mobile */
+  padding: 0.5rem max(1rem, env(safe-area-inset-bottom));
+}
+
+@media (min-width: 64em) {
+  nav {
+    inset: 0 auto 0 0;     /* side on desktop */
+    width: 240px;
+  }
+}
+```
+
+---
+
+## Performance on mobile
+
+- Images: AVIF first, WebP fallback, JPEG/PNG last. `srcset` for resolution. `loading="lazy"` below the fold
+- Fonts: subset to required glyphs, `font-display: swap`, prefer variable fonts
+- JS budget: <100 KB gzipped on initial load for content sites; apps can go higher but every KB hurts on a 3G connection
+- Above-the-fold critical CSS inline; rest async
+
+---
+
+## What the persona refuses on mobile
+
+1. **Hover-only interactions for primary actions.** If the user can't get to it on touch, it doesn't exist on mobile.
+2. **Carousel as the only navigation for content.** Hamburger menus for primary nav are fine; carousels for primary content are an attention tax.
+3. **Tiny tap targets to fit a desktop layout** - 24 x 24 px buttons because that's how it looks on the design.
+4. **Auto-playing video on mobile.** Battery, bandwidth, attention - all wrong.
+5. **Modal-on-load on mobile.** It's worse than desktop. The user has less screen.
+6. **Bottom-fixed banners that block reading without a clear close button.**
+7. **`scroll-behavior: smooth` on long pages without `prefers-reduced-motion` opt-out.**

--- a/skills/frontend-design/references/themes.md
+++ b/skills/frontend-design/references/themes.md
@@ -1,0 +1,235 @@
+# Dark + Light Theme Architecture
+
+Both themes are first-class. Neither is auto-derived from the other. Both are designed - colors picked, contrast checked, semantic tokens defined - then implemented as CSS custom properties with a `[data-theme]` selector for explicit toggle and `prefers-color-scheme` for default.
+
+The persona refuses to ship a theme that's only `filter: invert()` or only auto-generated from the other.
+
+---
+
+## The pattern
+
+Custom properties at `:root` define the default theme. A `[data-theme="dark"]` (or `light`, depending on which is default) override block defines the alternate. JavaScript toggles `data-theme` on `<html>`. System preference picks the initial value.
+
+```css
+/* theme.css */
+
+/* Default (light) */
+:root {
+  /* Surfaces */
+  --bg: #fafaf9;
+  --bg-subtle: #f5f5f4;
+  --bg-elevated: #ffffff;
+
+  /* Text */
+  --fg: #1c1917;
+  --fg-muted: #57534e;
+  --fg-subtle: #a8a29e;
+
+  /* Borders */
+  --border: #e7e5e4;
+  --border-strong: #a8a29e;
+
+  /* Accent (one, committed) */
+  --accent: #d97706;
+  --accent-fg: #ffffff;
+  --accent-hover: #b45309;
+
+  /* States */
+  --success: #15803d;
+  --warning: #b45309;
+  --error: #b91c1c;
+
+  /* Focus ring */
+  --focus-ring: 0 0 0 3px color-mix(in oklch, var(--accent) 40%, transparent);
+
+  /* Type */
+  --font-sans: "Inter Variable", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+
+  /* Radii */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-full: 9999px;
+}
+
+/* Dark theme - designed, not derived */
+:root[data-theme="dark"] {
+  --bg: #0c0a09;
+  --bg-subtle: #1c1917;
+  --bg-elevated: #292524;
+
+  --fg: #fafaf9;
+  --fg-muted: #a8a29e;
+  --fg-subtle: #57534e;
+
+  --border: #292524;
+  --border-strong: #57534e;
+
+  --accent: #fb923c;        /* lighter on dark; not the same hex */
+  --accent-fg: #1c1917;
+  --accent-hover: #fdba74;
+
+  --success: #4ade80;
+  --warning: #fbbf24;
+  --error: #f87171;
+
+  --focus-ring: 0 0 0 3px color-mix(in oklch, var(--accent) 50%, transparent);
+}
+```
+
+Note: the dark accent is `#fb923c` (lighter), not the same hex inverted. That is the difference between a designed dark theme and an auto-derived one.
+
+---
+
+## No-FOUC theme initialization
+
+The flash-of-incorrect-theme is the worst class of theme bug. The fix is a synchronous inline script in `<head>`, before the stylesheet, that sets `data-theme` from `localStorage` and `prefers-color-scheme`.
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Inline script: must run before stylesheet, must be synchronous -->
+  <script>
+    (function () {
+      const stored = localStorage.getItem("theme");
+      const system = matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+      const theme = stored || system;
+      document.documentElement.dataset.theme = theme;
+    })();
+  </script>
+
+  <!-- Color-scheme meta for native form controls and scrollbars -->
+  <meta name="color-scheme" content="light dark">
+
+  <link rel="stylesheet" href="/styles/theme.css">
+  <link rel="stylesheet" href="/styles/app.css">
+</head>
+<body>
+  <!-- ... -->
+</body>
+</html>
+```
+
+The inline script is a deliberate exception to the "no inline JS" rule. Reason: any async loading produces FOUC.
+
+---
+
+## Theme toggle
+
+The toggle updates `data-theme` and `localStorage`. It does not reload. It does not animate the swap (transitions on theme change cause every element to animate together, which looks broken).
+
+```ts
+// scripts/theme-toggle.ts
+function setTheme(theme: "light" | "dark") {
+  document.documentElement.dataset.theme = theme;
+  localStorage.setItem("theme", theme);
+}
+
+function toggleTheme() {
+  const current = document.documentElement.dataset.theme;
+  setTheme(current === "dark" ? "light" : "dark");
+}
+
+document.querySelector("[data-theme-toggle]")?.addEventListener("click", toggleTheme);
+
+// React to system preference if user hasn't picked
+matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+  if (!localStorage.getItem("theme")) {
+    setTheme(e.matches ? "dark" : "light");
+  }
+});
+```
+
+```html
+<button type="button" data-theme-toggle aria-label="Toggle theme">
+  <svg class="theme-icon-light" aria-hidden="true"><!-- sun --></svg>
+  <svg class="theme-icon-dark" aria-hidden="true"><!-- moon --></svg>
+</button>
+```
+
+```css
+/* Show only the icon for the OPPOSITE theme - the action it triggers */
+:root[data-theme="light"] .theme-icon-light { display: none; }
+:root[data-theme="dark"]  .theme-icon-dark  { display: none; }
+```
+
+---
+
+## Suppressing transition flash
+
+When the user toggles, you don't want every animated element to play its theme transition. Add a temporary class on `<html>` that disables transitions, then remove it on the next frame.
+
+```ts
+function setTheme(theme: "light" | "dark") {
+  const root = document.documentElement;
+  root.classList.add("theme-switching");
+  root.dataset.theme = theme;
+  localStorage.setItem("theme", theme);
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => root.classList.remove("theme-switching"));
+  });
+}
+```
+
+```css
+.theme-switching * {
+  transition: none !important;
+}
+```
+
+---
+
+## Per-theme considerations
+
+### Dark theme
+
+- Pure black (`#000`) is rarely right; use `#0c0a09` or similar for less eye strain on OLED
+- Saturated colors look louder on dark; desaturate accents by ~10-20% from their light-theme equivalent
+- Borders need higher luminance contrast than on light; `#292524` on `#0c0a09` is a real border, not invisible
+- White text at `#fafaf9` (slightly off) reads softer than pure white
+
+### Light theme
+
+- Pure white (`#fff`) is fine for elevated surfaces; the page background can be slightly off (`#fafaf9`)
+- Bigger contrast required for body text on light bg (use `#1c1917`, not `#404040`)
+- Drop shadows visible; on dark, use borders instead of shadows
+- Accent colors can be deeper; orange `#d97706` on light is warmer than its dark-theme equivalent
+
+---
+
+## Contrast targets
+
+Run a contrast checker on every text-on-surface combination per theme:
+
+| Combination | Minimum |
+|---|---|
+| Body text on background | WCAG AA (4.5:1), AAA (7:1) where feasible |
+| Large text (>=18 pt or 14 pt bold) | WCAG AA (3:1) |
+| UI element borders | 3:1 against adjacent surface |
+| Icons and graphical UI | 3:1 |
+| Disabled text | not subject to WCAG, but should be visibly distinguishable from active text |
+
+Tools: WebAIM contrast checker, browser devtools accessibility panel, `npx pa11y` for CI.
+
+---
+
+## Color-scheme meta
+
+Always include `<meta name="color-scheme" content="light dark">` so native form controls, scrollbars, and the user-agent's default styles match the active theme. Without this, scrollbars stay white in dark mode on Chromium.
+
+---
+
+## Common mistakes the persona refuses
+
+1. **Single theme, "we'll add light later"** - both themes ship together or neither ships. "Later" never happens.
+2. **`filter: invert()` for dark mode** - colors become wrong; images break; brand identity disappears.
+3. **`@media (prefers-color-scheme: dark)` only, no toggle** - users on browsers that lie about preference can't override.
+4. **Toggle that flashes** - missing inline init script.
+5. **Same accent color on both themes** - oversaturated on dark, washed-out on light.
+6. **Text that says "Switch to dark mode" while in dark mode** - the button text should describe the action (Switch to ...), not the current state. Or use icons.
+7. **Toggle that animates a CSS property transition on `--bg`** - every element in the tree retransitions; looks like a bug.


### PR DESCRIPTION
## Summary

Adds the **frontend-design** skill: an opinionated UI/UX persona for building and critiquing interfaces. Mobile-first, dark+light by default, touch-aware, refuses AI design tells. Brings the public skill count from 37 to 38.

The skill replaces the upstream generic frontend-design with a sharper persona-driven version: the persona is the point — bland, accommodating UI advice produces bland UIs.

## Scope

- ` skills/frontend-design/SKILL.md ` (260 lines) — modes (Build / Critique / Stack-pick), hard defaults, hard-hate refusal list, 2026 trend filter, AI Self-Check, persona rules
- 6 reference files (` ai-tells.md `, ` critique-template.md `, ` frameworks.md `, ` glitch-effects.md `, ` mobile-touch.md `, ` themes.md `) — total ~1550 lines of deep-dive material
- README — skill count 37 → 38, category list adds 'frontend and UI design'
- ` .gitignore ` — minor adjustment

## Quality passes

The skill went through two layered quality passes before this PR:

**skill-creator (5 iterations)** — structural audit, cross-skill overlap analysis, version verification, references deep audit, forward-test:

- effort medium → high (matches peers like code-review/kubernetes/testing)
- argument_hint switched to optional brackets (skill runs argless when artifact is in conversation)
- description rewritten with high-value triggers ('css', 'tailwind', 'landing page', 'theme'), back under the 240-char Codex-friendly target
- **every pinned version was wrong**: Astro 6.1.8 → 6.1.9 (April 22, 2026), SvelteKit 2.55 → 2.58, Vite 6.2 → 8.0 (two majors stale), Next.js 15 → 16 (Oct 2025; 16.2 latest), React 19 → 19.2
- Cloudflare/Astro acquisition context corrected and moved to the framework reference
- forward-test against an unmarked SaaS hero packed with planted tells: subagent picked Critique mode on first read, named every tell, hit the 10-ticket cap

**skill-refiner (7 iterations, plateau)** — Karpathy-gate iterative loop:

- Stack-pick mode descriptor clarified
- Target-versions block decluttered
- Next.js 16 removed ` next lint `; verification block now uses ` bunx eslint . ` directly
- Build-output structure example annotated to skip ` reset.css ` when using Tailwind v4 Preflight (avoids double-stacking resets)
- **Closed a real failure mode**: dishonest-vs-tasteless distinction lived only in ` references/ai-tells.md `, meaning fake 'trusted by' logos or dark-pattern modals could ship on user override. Surfaced into Rule 4: dishonest patterns refused even on override.

## Verification

- ` bash scripts/lint-skills.sh skills ` → 38 skills, 0 errors, 0 warnings
- ` bash scripts/validate-spec.sh skills ` → 38 skills, 0 violations, 0 warnings

## Test plan

- [ ] CI green
- [ ] Squash-merge as ` feat(frontend-design): add opinionated UI/UX persona skill ` (Release Please will pick this up as a minor bump)