### PR TITLE
docs: refresh skills for May 2026

### DIFF
--- a/skills/ai-ml/SKILL.md
+++ b/skills/ai-ml/SKILL.md
@@ -17,7 +17,7 @@ Build, review, and architect applications that use AI models - from single-API c
 multi-agent systems with RAG pipelines. The goal is production-grade AI apps that are reliable,
 cost-effective, and don't hallucinate their way into an incident.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 
 | Component | Version | Notes |
 |-----------|---------|-------|
@@ -86,6 +86,29 @@ AI tools consistently produce the same mistakes when generating AI application c
 - [ ] Temperature set intentionally (0 for deterministic tasks, higher for creative)
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Provider drift checked**: Responses/Agents/SDK examples use current provider surfaces, not deprecated Assistants-era or chat-only patterns
+- [ ] **RAG evidence bounded**: retrieval thresholds, citations, and empty-result behavior are defined before generation
+
+---
+
+## Performance
+
+- Batch embeddings and eval runs; avoid one request per row when the provider offers batch or bulk APIs.
+- Cache deterministic retrieval, tool metadata, and prompt templates, but never cache tenant-specific model outputs without a data-retention decision.
+- Track token, latency, and retry budgets separately for interactive, background, and eval traffic.
+
+
+---
+
+## Best Practices
+
+- Prefer raw provider SDKs until orchestration complexity justifies LangGraph, LlamaIndex, or LangChain.
+- Keep model, tool, retrieval, and safety decisions configurable per environment; avoid hardcoding preview model names in application logic.
+- Treat model output as untrusted input: validate structure, refusal states, tool arguments, and downstream side effects.
+
 
 ## Workflow
 

--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Write, review, and architect Ansible automation - from single playbooks to multi-tier, compliance-hardened infrastructure management. The goal is idempotent, auditable, maintainable automation that works the same locally and in CI/CD.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - ansible-core **2.20.x LTS** (Python 3.12+ controller, 3.9+ target, EOL May 2027)
 - ansible (community package) 13.x (depends on ansible-core 2.20)
 - molecule 26.x (CalVer), ansible-lint 26.x (CalVer), ansible-navigator 26.x (CalVer)
@@ -77,6 +77,29 @@ AI tools consistently produce the same Ansible mistakes. **Before returning any 
 Run generated playbooks through `ansible-lint` (production profile) when available.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Collection docs checked**: module arguments and return values match the installed collection version
+- [ ] **Idempotence proven**: changed/ok behavior is verified with check mode or a second run where practical
+
+---
+
+## Performance
+
+- Use targeted inventories, tags, and `--limit` for large fleets; avoid full-fleet runs while iterating on a single role.
+- Gather only required facts and cache facts where supported for slow or high-latency environments.
+- Prefer native modules over shell loops so Ansible can batch work, diff safely, and report idempotence.
+
+
+---
+
+## Best Practices
+
+- Pin collection versions in `requirements.yml` for production automation.
+- Run destructive playbooks with `--check --diff` first and require a human-reviewed limit for production hosts.
+- Keep Vault values out of diffs, logs, callback output, and generated examples.
+
 
 ## Workflow
 

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -56,6 +56,29 @@ Before returning any audit, verify:
 - [ ] **Density threshold applied** before assigning severity level
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Overflagging avoided**: plain but valid technical prose is not labeled AI-written without concrete evidence
+- [ ] **Audience preserved**: edits keep the author's domain vocabulary, intent, and required formality
+
+---
+
+## Performance
+
+- Review a representative sample first, then expand only if the same pattern repeats across the document.
+- Group repeated prose issues by pattern instead of leaving near-duplicate comments on every paragraph.
+- Prioritize high-visibility text: titles, summaries, intros, conclusions, and user-facing docs.
+
+
+---
+
+## Best Practices
+
+- Flag exact phrases and structural patterns, not vibes.
+- Offer replacement copy when the fix is obvious; otherwise describe the problem and let the author decide.
+- Do not erase necessary caveats, compliance language, or domain-specific precision to make prose sound casual.
+
 
 ## Workflow
 

--- a/skills/anti-slop/SKILL.md
+++ b/skills/anti-slop/SKILL.md
@@ -56,6 +56,29 @@ Before returning any anti-slop audit, verify:
 - [ ] **Structural duplication sweep done**: compare same-role modules/classes across sibling dirs (`providers`, `targets`, `sources`, `clients`, `registry`) and either report near-twins or note why the duplication is intentional
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **API reality checked**: suspicious helpers, flags, imports, and config keys are verified before being called hallucinations
+- [ ] **Test theater separated**: tests that assert mocks or snapshots only are distinguished from tests proving behavior
+
+---
+
+## Performance
+
+- Focus review on changed files and shared abstractions before scanning unrelated code.
+- Collapse repeated slop patterns into one finding with examples, not one finding per occurrence.
+- Use cheap static checks first, then run expensive tests only where they can confirm a real risk.
+
+
+---
+
+## Best Practices
+
+- Prefer deleting unnecessary abstraction over adding a new abstraction to hide it.
+- Treat duplicate code as a finding only when it creates real divergence or maintenance risk.
+- Require concrete failure modes; style dislike is not slop.
+
 
 ## Workflow
 

--- a/skills/arch-btw/SKILL.md
+++ b/skills/arch-btw/SKILL.md
@@ -17,7 +17,7 @@ Administer Arch Linux and Arch-style systems without falling into rolling-releas
 Focus on vanilla Arch first, then layer in CachyOS behavior, `paru` workflow, systemd-native
 service management, boot recovery, kernel handling, and derivative-specific cautions.
 
-**Versions worth pinning** (April 2026):
+**Versions worth pinning** (May 2026):
 
 Only pin versions here when they materially affect compatibility or troubleshooting shape. For
 ordinary rolling packages, prefer the current repo state over stale version tables.
@@ -90,6 +90,29 @@ Before returning Arch or CachyOS commands, verify:
 - [ ] **Conflicting files use exact path**: `--overwrite` uses the specific file path from pacman error output, never a blanket `'*'` glob
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Mirror and repo state checked**: package advice matches current Arch/CachyOS repos and local mirror sync status
+- [ ] **AUR trust handled**: PKGBUILDs, install scripts, and maintainer changes are reviewed before build/install
+
+---
+
+## Performance
+
+- Use `pacman -Syu` before large installs to avoid partial-upgrade churn and repeated dependency resolution.
+- Keep package cache cleanup deliberate; retain at least one known-good package version when rollback may matter.
+- For slow mirrors, rank mirrors before troubleshooting package-manager performance.
+
+
+---
+
+## Best Practices
+
+- Never recommend partial upgrades on Arch-family systems.
+- Snapshot or otherwise preserve rollback paths before kernel, bootloader, filesystem, or GPU driver changes.
+- Read pacman hooks and `.pacnew` files after major updates; do not assume config merges happened automatically.
+
 
 ## Workflow
 

--- a/skills/backend-api/SKILL.md
+++ b/skills/backend-api/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 Design and review HTTP APIs that stay coherent as they grow. Focus on contracts, auth
 boundaries, error models, and framework structure for Python and Node.js services.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - FastAPI **0.135.3** (released 2026-04-01)
 - Express **5.2.1** (published 2025-12-01)
 - NestJS **11.1.18** (published 2026-04-03)
@@ -77,6 +77,29 @@ Before returning API code, route design, or OpenAPI output, verify:
 - [ ] Sensitive defaults are explicit: cookie flags, token TTLs, scope boundaries, and rate limits are not hand-waved
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Framework version checked**: FastAPI, Express, NestJS, and OpenAPI examples match current APIs and migration notes
+- [ ] **Contract compatibility checked**: response codes, pagination, errors, and auth behavior preserve existing clients unless a version bump is explicit
+
+---
+
+## Performance
+
+- Paginate and filter at the data store; never load full collections just to slice in the handler.
+- Set timeouts and body limits at the framework, proxy, and client layers.
+- Measure p95/p99 latency and error rates for changed endpoints before optimizing internals.
+
+
+---
+
+## Best Practices
+
+- Design idempotency for retries on create, payment, provisioning, and webhook endpoints.
+- Generate or validate OpenAPI from the implementation contract and keep examples executable.
+- Use explicit auth scopes and tenancy checks in handlers, not only in route grouping or UI state.
+
 
 ## Workflow
 

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -16,7 +16,7 @@ Guide AI agents through web browsing tasks using the cheapest tool that gets the
 Every browsing action has a token cost - this skill minimizes it through progressive disclosure,
 smart format selection, and backend-aware strategies.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - Lightpanda: 0.2.8
 - @playwright/mcp: 0.0.70
 - agent-browser: 0.24.0
@@ -66,6 +66,22 @@ don't use interactive tools. Escalate only when the cheaper option fails.
 
 **Tool availability check**: before starting, verify what's available. If the best tool for
 the task isn't present, skip straight to the next tier rather than failing mid-workflow.
+
+---
+
+## Performance
+
+- Prefer official APIs, sitemaps, or static fetches before launching a browser.
+- Extract only required page regions; avoid dumping full DOMs, screenshots, or network logs into context.
+- Reuse browser sessions for multi-step flows, but clear cookies/storage between unrelated accounts or tenants.
+
+---
+
+## Best Practices
+
+- Use stable selectors and semantic roles before brittle CSS paths.
+- Record source URLs and timestamps for facts likely to change.
+- Do not automate destructive account actions unless the user explicitly requested the exact action and target.
 
 ---
 
@@ -396,6 +412,11 @@ Before returning any browsing result, verify:
 - [ ] Escalated to the next tool tier on failure rather than retrying the same tool
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Robots and terms considered**: scraping or automation respects access rules, auth boundaries, and rate limits
+- [ ] **Dynamic content verified**: browser-rendered pages are checked with the real tool when static HTML may be incomplete
 
 ## Rules
 

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -24,7 +24,7 @@ Write, review, and architect CI/CD pipelines across GitHub Actions, GitLab CI/CD
 Actions, Gitea Actions, and Woodpecker. The goal is secure, fast, auditable pipelines that
 satisfy both engineering needs and compliance requirements (PCI-DSS 4.0).
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - **GitHub Actions**: ubuntu-24.04 runners (ubuntu-latest), arm64 GA, artifact v4, attestations GA
 - **GitLab CI/CD**: GitLab 18.10.3, CI/CD Catalog GA, CI Components with typed `spec: inputs`
 - **Forgejo Actions**: Forgejo v15.0, Runner v11.x (stable; check `data.forgejo.org/forgejo/runner` releases for current major tag before pinning)
@@ -95,6 +95,29 @@ every failure with file and line reference.
 - [ ] **Auto-merge gated on tests, not just lint**: Dependabot/Renovate auto-merge without test coverage of the changed area is a supply-chain shortcut.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Runner trust checked**: workflow advice distinguishes hosted, self-hosted, fork, and protected-branch execution
+- [ ] **Mutable references controlled**: actions, images, includes, and templates are pinned where supply-chain risk matters
+
+---
+
+## Performance
+
+- Key caches by lockfiles and toolchain versions; avoid broad caches that restore stale dependencies.
+- Split quick lint/unit gates from slow integration, image, and deployment jobs.
+- Use path filters and matrix limits to keep monorepo pipelines proportional to the change.
+
+
+---
+
+## Best Practices
+
+- Use OIDC or short-lived federation for cloud deploys instead of long-lived static secrets.
+- Keep pull-request workflows from forks read-only unless explicitly isolated.
+- Generate provenance or attestations for release artifacts where the forge supports it.
+
 
 ## Workflow
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -56,6 +56,29 @@ Before reporting any finding at >= 80% confidence, verify:
 - [ ] **Boundary values on numeric inputs flagged**: zero, negative, and overflow values on page numbers, sizes, counts, and indices are high-confidence findings - do not suppress with the 80% threshold
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Line references verified**: every finding points to code that exists in the reviewed diff
+- [ ] **Behavioral claim proven**: findings describe a plausible failing input, race, leak, or regression
+
+---
+
+## Performance
+
+- Start with changed public interfaces, shared utilities, migrations, and concurrency boundaries.
+- Use tests and static analysis to validate suspected issues instead of reading the entire repo linearly.
+- Merge duplicate findings into one high-signal comment with affected locations.
+
+
+---
+
+## Best Practices
+
+- Lead with bugs and risks, not style preferences.
+- Do not request rewrites unless the current structure blocks correctness or maintainability.
+- Call out missing tests only when a specific behavior or risk needs coverage.
+
 
 ## Workflow
 

--- a/skills/command-prompt/SKILL.md
+++ b/skills/command-prompt/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 Reference skill for writing commands, scripts, and configuration across Unix shells. Detects
 the target shell from context and routes to the appropriate reference.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - Zsh: 5.10
 - Bash: 5.3
 - Fish: 4.6
@@ -60,6 +60,29 @@ Before returning any generated shell script or command, verify:
 - [ ] No secrets in command history (use `read -s` or environment variables)
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Shell identified**: examples match POSIX sh, Bash, Zsh, or Fish semantics intentionally
+- [ ] **Quoting tested**: paths with spaces, empty variables, and glob characters behave safely
+
+---
+
+## Performance
+
+- Use builtins and stream processing for large inputs; avoid command substitution that buffers entire files.
+- Prefer `rg`, `fd`, and targeted file lists when available, with portable fallbacks noted.
+- Avoid spawning subshells inside tight loops when `xargs`, arrays, or shell builtins fit.
+
+
+---
+
+## Best Practices
+
+- Default to `set -euo pipefail` only when the script is written to handle those semantics.
+- Use `--` before user-controlled paths for commands that support it.
+- Preview destructive expansions before `rm`, `mv`, `chmod`, `chown`, or recursive edits.
+
 
 ## Workflow
 

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Configure, tune, design schemas, migrate, back up, and review database engines - from single-node dev setups to PCI-compliant production clusters. The goal is correct, performant, durable databases that survive failures, pass audits, and don't wake you up at 3am.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - PostgreSQL **18.3** (EOL 2030-11), previous: 17.9, 16.13
 - MongoDB **8.0.20** (GA), 8.2.6 (rapid release, EOL 2026-07)
 - MariaDB **11.8.6** (LTS, EOL 2028-06), 12.2.2 (rolling GA, EOL 2026-05)
@@ -106,6 +106,29 @@ AI tools consistently produce the same database mistakes. **Before returning any
 - [ ] Secrets (passwords, connection strings) injected via env vars or secret managers, not config files
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Engine/version checked**: SQL syntax, index options, and replication advice match the named engine and major version
+- [ ] **Data-loss path gated**: migrations, deletes, reindexes, and failovers include backup, dry-run, rollback, or maintenance-window guidance
+
+---
+
+## Performance
+
+- Use `EXPLAIN`/`EXPLAIN ANALYZE` with realistic parameters before adding indexes.
+- Tune connection pools to database capacity; more app connections can reduce throughput.
+- Batch writes and migrations in bounded chunks to avoid lock escalation, replication lag, and runaway transactions.
+
+
+---
+
+## Best Practices
+
+- Take restorable backups before schema changes and verify restore procedures periodically.
+- Separate online, background, and analytical workloads where query shape or latency differs.
+- Prefer additive migrations with backfills and compatibility windows for zero-downtime services.
+
 
 ## Workflow
 

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -19,7 +19,7 @@ security-distro workflow. Focus on Debian stable and Ubuntu LTS first, then laye
 derivative-specific behavior, PPA workflows, snap confinement, Ubuntu HWE, and explicit checks
 for derivatives that diverge on init, packaging defaults, or intended use.
 
-**Versions worth pinning** (verified April 2026):
+**Versions worth pinning** (verified May 2026):
 
 Only pin versions here when they materially affect compatibility or troubleshooting shape. For
 ordinary Debian and Ubuntu package work, prefer the live distro lane and package policy over a
@@ -98,6 +98,29 @@ Before returning Debian or Ubuntu commands, verify:
 - [ ] **Debian alternatives are checked**: when a command behaves oddly, verify `update-alternatives` for that binary.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Release support checked**: Debian/Ubuntu/Mint/Pop advice matches current lifecycle and enabled repositories
+- [ ] **Third-party repo risk handled**: PPAs, snaps, vendor repos, and pin priorities are explicit
+
+---
+
+## Performance
+
+- Use `apt-cache policy`, `apt list --upgradable`, and targeted installs before broad reinstall attempts.
+- Keep package index updates scoped; repeated `apt update` in scripts wastes time and load.
+- For slow upgrades, identify held packages and phased updates before forcing resolver choices.
+
+
+---
+
+## Best Practices
+
+- Do not mix Debian releases or Ubuntu series unless apt pinning is deliberate and documented.
+- Snapshot or back up before release upgrades, kernel changes, filesystem work, or bootloader repair.
+- Prefer distro packages for core system components; isolate vendor repos to the packages they own.
+
 
 ## Workflow
 

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -79,6 +79,29 @@ workflow (waves + persistence + routing), not just the wave dispatch phase.
 - [ ] Only skills from the iuliandita/skills collection were used - no built-in reviewers or platform audit modes
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Scope bounded**: audit waves match the repo type and user request, not every possible skill
+- [ ] **Evidence retained**: findings cite files, commands, outputs, or source docs instead of impressions
+
+---
+
+## Performance
+
+- Inventory first, then choose high-risk slices; avoid full exhaustive scans when focused evidence answers the question.
+- Run cheap global searches before expensive test suites or dynamic analysis.
+- Batch findings by subsystem and severity so review effort scales with risk.
+
+
+---
+
+## Best Practices
+
+- State residual risk and skipped areas explicitly.
+- Separate confirmed findings from hypotheses and follow-up tasks.
+- Do not mutate the repo during an audit unless the user requested fixes.
+
 
 ## Workflow
 

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -84,6 +84,29 @@ Before declaring finish-mode complete:
 - [ ] No `--no-verify`, no `--force-push`, no destructive reset - if blocked, fix the root cause
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Dirty tree protected**: unrelated user changes are identified and left intact
+- [ ] **Remote/branch target checked**: base branch, upstream, and PR target are verified before push, merge, or release
+
+---
+
+## Performance
+
+- Run the narrowest meaningful checks during iteration, then the full required gate before finishing.
+- Keep commits batch-sized by review concern so bisect and revert stay cheap.
+- Use existing project scripts instead of reconstructing ad hoc command sequences.
+
+
+---
+
+## Best Practices
+
+- Create branches before implementation edits and keep public commits free of unrelated local changes.
+- Do not force-push, squash, or merge without clear user intent.
+- Put verification evidence in PRs and final summaries, not vague claims.
+
 
 ## Workflow
 

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -20,11 +20,11 @@ metadata:
 
 Write, review, and architect Dockerfiles, Compose stacks, and container workflows - from single-service dev setups to multi-arch production pipelines with image signing and compliance gates. The goal is minimal, secure, reproducible images that a team can maintain and a QSA can audit.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - Docker Engine 29.4.0, Docker Desktop 4.66.1
 - Docker Compose v5.1.3 (Go SDK, Bake-delegated builds)
 - BuildKit v0.29.0 (bundled with Engine 29.x)
-- containerd 2.2.3 / **2.3 LTS** (April 2026, recommended for production)
+- containerd 2.2.3 / **2.3 LTS** (recommended for production after checking release notes)
 - Podman 5.8.2, Buildah 1.43.0
 - runc 1.4.1 (latest; CVE-2025-31133/52565/52881 patched since 1.4.0)
 
@@ -78,6 +78,29 @@ AI tools consistently produce the same Docker mistakes. **Before returning any g
 - [ ] **HEALTHCHECK uses available tools**: probe command uses a binary present in the final image (wget in Alpine, curl in Debian, none in scratch/distroless - use the app's own health endpoint)
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Engine/Compose syntax checked**: Dockerfile, Compose, BuildKit, and runtime flags match the installed versions
+- [ ] **Image provenance considered**: base images, registries, tags, SBOMs, and signatures are handled where risk warrants
+
+---
+
+## Performance
+
+- Order Dockerfile layers from stable to volatile and use cache mounts for package-manager caches where BuildKit is available.
+- Keep build contexts small with `.dockerignore`; accidental monorepo contexts dominate build time.
+- Use multi-stage builds and slim runtime images, but measure startup and debug needs before stripping tools aggressively.
+
+
+---
+
+## Best Practices
+
+- Pin base image digests for sensitive workloads and track rebuild cadence for security updates.
+- Run as non-root and drop capabilities unless the workload genuinely needs them.
+- Preview prune and volume-removal commands; persistent data must never be collateral cleanup.
+
 
 ## Workflow
 

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 Manage, troubleshoot, and harden OPNsense and pfSense firewalls via SSH. Both are FreeBSD-based,
 pf-powered firewall distributions - most concepts, commands, and patterns apply to both.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - OPNsense: 26.4.0 (26.4 series; 26.1.6_2 still supported on the 26.1 stable branch)
 - pfSense CE: 2.8.1 / pfSense Plus: 26.03
 - CrowdSec: v1.7.7
@@ -59,6 +59,29 @@ Before returning any firewall commands, verify:
   the firewall even if the trunk is tagged correctly
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Platform/version checked**: OPNsense, pfSense, FreeBSD, pf, and plugin commands match the appliance version
+- [ ] **Lockout path prevented**: remote firewall changes preserve management access and rollback
+
+---
+
+## Performance
+
+- Prefer rule ordering that rejects high-volume unwanted traffic early and keeps expensive inspection scoped.
+- Use aliases/tables for large address sets instead of expanding repetitive rules.
+- Check state table, DNSBL, IDS/IPS, and plugin load before blaming WAN latency.
+
+
+---
+
+## Best Practices
+
+- Export configuration before rule, NAT, VPN, CARP, or package changes.
+- Make HA changes one node at a time and verify CARP state before touching the peer.
+- Keep emergency console or out-of-band access available for management-plane changes.
+
 
 ## Workflow
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -17,7 +17,7 @@ A pragmatic, perfectionist UI engineer with strong taste. Treats interfaces as c
 
 This skill replaces the upstream generic `frontend-design` skill in this collection. The persona is the point: bland, accommodating UI advice produces bland UIs.
 
-**Target versions** (April 2026 - pinned so staleness is visible):
+**Target versions** (May 2026 - pinned so staleness is visible):
 
 - Astro 6.1.9 (Astro 5.17 also production-ready)
 - SvelteKit 2.58 + Svelte 5 runes
@@ -73,6 +73,22 @@ The skill picks the mode from the user's signal. If unclear, ask.
 | "pick a stack for", "which framework", "what should I use for" | **Stack-pick** (returns a framework + version, may precede Build) |
 
 Modes can chain: Critique then Build (replace the bad version), Build then Critique (review what was just built before shipping).
+
+---
+
+## Performance
+
+- Measure Core Web Vitals and route-level bundle/runtime cost before adding animation or heavy client state.
+- Use framework image, font, and route caching primitives instead of hand-rolled asset loading.
+- Keep interaction feedback local and cheap; do not round-trip to the server for purely visual state.
+
+---
+
+## Best Practices
+
+- Build the actual usable first screen, not a marketing shell, unless the request is explicitly for a landing page.
+- Use semantic controls, accessible names, focus states, and keyboard flows as part of the design, not a cleanup pass.
+- Avoid visual novelty that obscures product state, primary actions, or error recovery.
 
 ---
 
@@ -228,6 +244,11 @@ Before returning any built UI or critique, verify:
 - [ ] **No AI prose tells in commentary** - apply the **anti-ai-prose** vocabulary list to the persona's own writing, not just user-facing copy. Plain English
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Framework reality checked**: React, Next, Vite, Astro, SvelteKit, and Tailwind guidance matches current docs and installed packages
+- [ ] **Visual verification done**: responsive screenshots or browser checks confirm layout, assets, and interaction states
 
 ## Reference Files
 

--- a/skills/full-review/SKILL.md
+++ b/skills/full-review/SKILL.md
@@ -56,6 +56,29 @@ Verify:
 - [ ] Scope held in output: each agent's findings reference only files/modules within the requested scope. If any agent's output references out-of-scope paths, flag it in that report's header (see Step 3 scope verification)
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing explicit**: code-review, anti-slop, security-audit, and update-docs findings stay in their lanes
+- [ ] **No false coverage**: unrun tests, skipped directories, and unavailable tools are reported
+
+---
+
+## Performance
+
+- Run inventory and changed-file analysis before invoking every review mode.
+- Deduplicate cross-skill findings so the final report is readable.
+- Escalate only confirmed high-risk areas to deeper sweeps.
+
+
+---
+
+## Best Practices
+
+- Lead with actionable findings and severity; keep summaries secondary.
+- Separate code bugs, security issues, slop, and docs drift so owners can act.
+- Do not claim a full audit if the pass was sampled or tool-limited.
+
 
 ## Workflow
 

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -18,12 +18,12 @@ cut releases, and maintain audit-grade change history across GitHub, GitLab, and
 The goal is clean, signed, traceable history that satisfies both engineering standards and
 compliance requirements (PCI-DSS 4.0).
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - **git**: 2.53.x (current stable). Git 3.0 expected late 2026 (reftable default, SHA-256 default)
 - **GitHub CLI (`gh`)**: 2.91.0
 - **GitLab CLI (`glab`)**: 1.90.x
 - **Forgejo CLI (`fj`)**: 0.4.1 (March 2026). Rust-written, official community CLI at `codeberg.org/forgejo-contrib/forgejo-cli`. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
-- **Forgejo**: v15.0 (current stable, April 2026). Critical RCE (CVE-2025-68937) patched in v13.0.2+.
+- **Forgejo**: v15.0 line current at May 2026 recheck; verify the stable branch before upgrade advice. Critical RCE (CVE-2025-68937) patched in v13.0.2+.
 - **prek**: 0.3.x (Rust, recommended) or **pre-commit**: 4.6.0 (Python, largest ecosystem)
 - **git-filter-repo**: 2.47.x
 - **gitleaks**: 8.30.x (secret scanning)
@@ -86,6 +86,29 @@ verify against this list:**
 - [ ] **Forge-CLI subcommands verified.** Before scripting `fj`/`gh`/`glab`/`tea` commands in a runbook, hooks, or CI, confirm the subcommand and flags exist on the target version (`<cli> <cmd> --help`). These CLIs add, rename, and remove subcommands across minor versions; docs lag behind the binary.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Ref safety checked**: branch, remote, upstream, and worktree path are verified before history edits
+- [ ] **Recovery path known**: reflog, backup branch, or bundle exists before destructive history operations
+
+---
+
+## Performance
+
+- Use path-limited `git log`, `git diff`, and `git grep` before whole-history scans.
+- Fetch only needed remotes/branches in large repos when full prune is unnecessary.
+- Keep commits small enough for review and bisect, but not so small that they split one behavior across many commits.
+
+
+---
+
+## Best Practices
+
+- Prefer revert over history rewrite on shared branches.
+- Use signed commits/tags where the project or release process requires provenance.
+- Never run cleanup commands that delete branches, tags, or ignored files without showing the target set first.
+
 
 ## Workflow
 

--- a/skills/jekyll-hyde/SKILL.md
+++ b/skills/jekyll-hyde/SKILL.md
@@ -54,6 +54,29 @@ Before returning advice, verify:
 - [ ] **Final recommendation included**: even after Hyde, end with an actionable path or decision frame.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Decision scope held**: critique targets the decision, constraints, and tradeoffs, not unrelated strategy
+- [ ] **Evidence separated**: facts, assumptions, risks, and opinions are labeled distinctly
+
+---
+
+## Performance
+
+- Timebox adversarial review; stop once risks repeat or no longer change the decision.
+- Focus first on irreversible, expensive, regulated, or reputation-impacting choices.
+- Use short decision records for small calls and deeper matrices only for high-stakes options.
+
+
+---
+
+## Best Practices
+
+- Give the strongest constructive case before the adversarial case so tradeoffs are visible.
+- Name the condition that would change the recommendation.
+- Avoid dark-pattern advice; adversarial review should improve decisions without exploiting users.
+
 
 ## Workflow
 

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -21,7 +21,7 @@ Kali is Debian-shaped, but the places where it goes wrong are usually Kali-speci
 mixing, metapackage sprawl, stale images, persistence mistakes, hardware edge cases, or people
 using the wrong tool family for the job.
 
-**Versions worth pinning** (verified April 2026):
+**Versions worth pinning** (verified May 2026):
 
 Only pin versions or dated anchors here when they materially affect compatibility or
 troubleshooting shape. For ordinary package work, prefer the live branch and repo state over a
@@ -84,6 +84,29 @@ Before returning Kali commands or tool recommendations, verify:
 - [ ] **Diagnostic errors are not silenced**: do not hide useful failure output with `2>/dev/null` on commands whose error reason matters. Use `2>&1 || true` when gathering.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Channel checked**: kali-rolling, snapshots, metapackages, and NetHunter advice matches official docs
+- [ ] **Lab boundary explicit**: offensive tooling stays in authorized labs, CTFs, or owned systems
+
+---
+
+## Performance
+
+- Install task-specific metapackages instead of full tool collections when disk, bandwidth, or update time matters.
+- Use snapshots or pinned images for repeatable labs rather than debugging rolling drift mid-exercise.
+- Keep wordlists, captures, and VM disks outside small root partitions.
+
+
+---
+
+## Best Practices
+
+- Do not treat Kali as a hardened daily-driver server by default.
+- Snapshot before major upgrades, GPU/wireless driver work, or live persistence changes.
+- Separate client data, lab artifacts, and exploit tooling with clear storage boundaries.
+
 
 ## Workflow
 

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Create, review, and architect Kubernetes infrastructure - from raw manifests to Helm charts to multi-cluster strategy. The goal is production-ready, security-hardened, cost-aware infrastructure that a team can maintain.
 
-**Target versions** (April 2026): Kubernetes 1.34-1.36 (1.36.0 "Haru" released April 22, 2026; **1.32 is the active LTS branch with patches through April 2028**), Helm 4.1.4, Helm 3.20.x LTS (security fixes until Nov 2026).
+**Target versions** (May 2026): Kubernetes 1.34-1.36 (1.36.0 "Haru" released April 22, 2026; **1.32 is the active LTS branch with patches through April 2028**), Helm 4.1.4, Helm 3.20.x LTS (security fixes until Nov 2026).
 
 This skill covers four domains depending on context:
 - **Manifests** - raw YAML for Deployments, Services, Gateway API routes, ConfigMaps, Secrets, PVCs
@@ -65,6 +65,29 @@ This skill runs inside an AI agent. AI tools consistently produce the same K8s s
 Run generated manifests through `kube-score`, `kubelinter`, or `checkov` when available.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **API versions checked**: manifests, Helm templates, and Gateway resources match the target cluster version
+- [ ] **Cluster context verified**: namespace, context, and kubeconfig identity are shown before mutating commands
+
+---
+
+## Performance
+
+- Set requests and limits from measured workload behavior; missing requests damage scheduling and autoscaling.
+- Use server-side dry-run and diff before apply; avoid repeated full-cluster renders during tight loops.
+- Scope watches, logs, and `kubectl get` calls by namespace/labels in large clusters.
+
+
+---
+
+## Best Practices
+
+- Prefer declarative GitOps or reviewed manifests over live imperative changes for production.
+- Back up CRDs and custom resources before upgrades or operator changes.
+- Use policy gates for privileged pods, hostPath, broad RBAC, and mutable image tags.
+
 
 ## Workflow
 

--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 # Localize: App Internationalization Workflow
 
-**Target versions (April 2026):** react-i18next 15.x, vue-i18n 11.x, next-intl 4.x, i18next 25.x
+**Target versions (May 2026):** react-i18next 15.x, vue-i18n 11.x, next-intl 4.x, i18next 25.x
 
 Systematic approach to internationalizing applications. Covers two scenarios: adding
 multilingual support from scratch and auditing existing i18n for gaps. Built from real
@@ -87,6 +87,29 @@ code, catalogs, or translations, verify against this list:**
   or user preference stored and respected
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Locale data checked**: ICU message syntax, plural categories, and CLDR assumptions match the target locales
+- [ ] **Fallback behavior tested**: missing keys, pseudo-locales, RTL, and long strings are exercised
+
+---
+
+## Performance
+
+- Load locale bundles per route or language instead of shipping every catalog to every user.
+- Cache compiled ICU messages where the framework supports it.
+- Detect hardcoded strings with static scans before manual review.
+
+
+---
+
+## Best Practices
+
+- Keep source strings stable and meaningful; do not use English copy as an implicit key if text changes often.
+- Use translators' notes for placeholders, gender, tone, and domain-specific terms.
+- Never concatenate translated fragments where grammar can change by language.
+
 
 ## Workflow
 

--- a/skills/lockpick/SKILL.md
+++ b/skills/lockpick/SKILL.md
@@ -58,6 +58,29 @@ Before executing any technique or generating exploitation commands, verify:
 - [ ] **Reverse shells use authorized ports**: listener IP and port match the engagement plan
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Authorization confirmed**: scope, target, time window, and rules of engagement are explicit before privesc work
+- [ ] **Destructive paths avoided**: exploit attempts preserve evidence and avoid persistence, data damage, or lateral movement unless explicitly authorized
+
+---
+
+## Performance
+
+- Run low-noise enumeration first; expensive scanners and brute-force tools require scope and rate limits.
+- Capture command output as you go so repeated enumeration is unnecessary.
+- Prioritize likely local privesc paths from kernel, sudo, SUID, services, containers, and writable paths before broad tool dumps.
+
+
+---
+
+## Best Practices
+
+- Keep CTF shortcuts out of real pentest guidance unless the user says it is a CTF.
+- Document exact preconditions and proof for every privilege boundary crossed.
+- Do not install persistence or cleanup evidence unless the engagement explicitly requires and authorizes it.
+
 
 ## Workflow
 

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -17,7 +17,7 @@ Build, review, and debug MCP servers that expose tools, resources, and prompts t
 assistants. The goal is secure, well-structured servers that follow the protocol spec and don't
 become yet another server with preventable injection vulnerabilities.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - MCP specification: 2025-11-25 (current stable; 2026-03-15 in draft)
 - TypeScript SDK: @modelcontextprotocol/sdk 1.29.0 (1.x stable; 2.0.0-alpha in dev)
 - Python SDK: mcp 1.27.0 (v1.26.0+)
@@ -64,6 +64,29 @@ When generating or reviewing MCP server code, verify each item before presenting
 - [ ] Elicitation does not request passwords, tokens, or secrets
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Spec version checked**: transports, auth, resources, tools, and prompts match current MCP docs and SDK behavior
+- [ ] **Tool poisoning considered**: tool descriptions, dynamic metadata, and server updates cannot silently expand authority
+
+---
+
+## Performance
+
+- Keep tool schemas tight and responses small; large unstructured tool outputs waste model context.
+- Use resources for reusable context instead of returning the same large payload from every tool call.
+- Batch read-only lookups where latency matters, but keep side-effecting tools separate and auditable.
+
+
+---
+
+## Best Practices
+
+- Treat MCP servers as security boundaries: authenticate, authorize, and log side effects explicitly.
+- Make tool names and schemas stable; version breaking changes instead of changing semantics in place.
+- Require user confirmation for tools that spend money, mutate infrastructure, delete data, or expose secrets.
+
 
 ## Workflow
 

--- a/skills/networking/SKILL.md
+++ b/skills/networking/SKILL.md
@@ -17,7 +17,7 @@ Configure, troubleshoot, and optimize Linux networking infrastructure. Covers DN
 VPNs, firewalls (nftables), VLANs, subnetting, high availability, dynamic routing, and network
 performance tuning.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 
 | Tool | Version | Notes |
 |------|---------|-------|
@@ -95,6 +95,29 @@ Before returning any generated network configuration, verify:
   (`DNSStubListener=no`) or bind your server to a different port
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Topology verified**: interface names, routes, DNS resolvers, namespaces, VPN state, and firewall backend are observed before changes
+- [ ] **Rollback path preserved**: remote network changes include timed rollback, console access, or an alternate path
+
+---
+
+## Performance
+
+- Measure path, DNS, TLS, and application latency separately before tuning.
+- Use packet captures with narrow filters and time windows to avoid huge captures and privacy spill.
+- Prefer persistent nftables sets, DNS caches, and proxy connection reuse where appropriate.
+
+
+---
+
+## Best Practices
+
+- Diagnose before changing: capture current routes, rules, addresses, and resolver state.
+- Change one layer at a time: DNS, routing, firewall, proxy, VPN, or application.
+- Keep emergency access open when editing firewall, VPN, or default-route configuration remotely.
+
 
 ## Workflow
 

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -30,7 +30,7 @@ disposable dev shells, fleet-wide configuration without a separate config-manage
 and a single language for a workstation, a server, a container image, a NixOS VM, and a
 macOS laptop via nix-darwin.
 
-**Versions worth pinning** (verified April 2026):
+**Versions worth pinning** (verified May 2026):
 
 Pin versions only when they shape compatibility or troubleshooting. For ordinary package
 work, trust the live channel or flake lock over a stale table.
@@ -112,6 +112,29 @@ Before returning NixOS or Nix commands, verify:
 - [ ] **Version pins justified**: if a pinned `system.stateVersion` is suggested, explain why; do not change `stateVersion` on an existing system casually - it controls migration semantics.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Channel/flake checked**: advice matches stable, unstable, flake, home-manager, or nix-darwin context
+- [ ] **Rollback identified**: generation rollback, boot entries, and store/cache state are understood before changes
+
+---
+
+## Performance
+
+- Use binary caches and substituters deliberately; local source builds can dominate iteration time.
+- Evaluate and build targeted attributes before rebuilding entire systems where possible.
+- Garbage-collect only after confirming new generations boot and required roots are preserved.
+
+
+---
+
+## Best Practices
+
+- Keep hardware, secrets, user packages, and service modules separated enough to review changes safely.
+- Commit flake lock and configuration changes together for reproducible rebuilds.
+- Do not delete old generations or store paths until rollback is no longer needed.
+
 
 ## Workflow
 

--- a/skills/prompt-generator/SKILL.md
+++ b/skills/prompt-generator/SKILL.md
@@ -48,6 +48,29 @@ Before returning any generated or modified prompt file, verify:
 - [ ] **Model-appropriate syntax**: avoid model-specific features (assistant prefills, `\n\nHuman:` formatting) in model-agnostic prompts. XML delimiters and markdown headers are both fine for structure across models
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Injection boundary set**: untrusted source text is delimited and never treated as instructions
+- [ ] **Model lock-in avoided**: provider-specific syntax appears only when the user named that provider
+
+---
+
+## Performance
+
+- Keep prompts as short as the task allows; remove redundant role prose and repeated constraints.
+- Use variables for repeated dynamic content instead of duplicating long blocks.
+- Prefer explicit output schemas over long narrative instructions when structure matters.
+
+
+---
+
+## Best Practices
+
+- Preserve the user's intent; do not add hidden policy, tone, or scope changes.
+- Name variables consistently and define every required input.
+- Include success criteria for complex prompts so outputs can be evaluated.
+
 
 ## Workflow
 

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -19,7 +19,7 @@ fast-moving Fedora lane from the conservative enterprise lane, then account for 
 such as subscription-manager, CentOS Stream drift, Oracle UEK, Amazon's cloud-first defaults,
 and SELinux or firewalld behavior that people love to blame on the wrong layer.
 
-**Versions worth pinning** (verified April 2026):
+**Versions worth pinning** (verified May 2026):
 
 Only pin versions here when they materially affect compatibility or troubleshooting shape. For
 ordinary package work, prefer the live distro lane and repo state over a stale package table.
@@ -99,6 +99,29 @@ Before returning Fedora or RHEL-family commands, verify:
 - [ ] **Version table treated as a hint, not gospel**: if the pinned table is getting old, verify distro release and key package versions live before leaning on it.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Lifecycle checked**: RHEL, Fedora, Rocky, Alma, CentOS Stream, and Amazon Linux guidance matches the target release
+- [ ] **SELinux/firewalld context preserved**: fixes do not disable enforcement permanently as a shortcut
+
+---
+
+## Performance
+
+- Use `dnf repoquery`, `dnf history`, and targeted transactions before broad package churn.
+- Keep metadata/cache refresh intentional; repeated full refreshes slow automation.
+- For service issues, inspect journal, SELinux AVCs, and firewalld zones before reinstalling packages.
+
+
+---
+
+## Best Practices
+
+- Snapshot or back up before release upgrades, bootloader work, storage changes, or major SELinux relabels.
+- Prefer policy modules or correct labels over `setenforce 0` as a permanent fix.
+- Do not mix clone/vendor repositories without explicit priority and compatibility decisions.
+
 
 ## Workflow
 

--- a/skills/roadmap/SKILL.md
+++ b/skills/roadmap/SKILL.md
@@ -58,6 +58,11 @@ Before writing or modifying ROADMAP.md, verify:
 - [ ] **No priority inflation**: P0 items are genuine blockers, not aspirational wishes
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Evidence quality marked**: competitive intel, user feedback, and assumptions are labeled with source and confidence
+- [ ] **Backlog hygiene kept**: stale ideas are parked or deleted instead of endlessly reprioritized
 
 ## Roadmap Format
 
@@ -169,6 +174,22 @@ Read the existing structure first. If it doesn't match this format:
 - In **add** or **update** modes: work within the existing structure, don't restructure
 - In **review** mode: suggest migrating to this format if the current one is disorganized
 - If the user asks to restructure: migrate section by section, preserving all content
+
+---
+
+## Performance
+
+- Keep roadmap edits small and frequent; avoid rewriting the whole backlog for one new idea.
+- Limit active P0/P1 items so prioritization remains meaningful.
+- Group duplicate ideas and link evidence instead of copying long notes repeatedly.
+
+---
+
+## Best Practices
+
+- Tie each near-term item to a clear user, business, or technical outcome.
+- Record exit criteria before implementation starts.
+- Separate commitments from experiments so speculative work does not crowd delivery.
 
 ---
 

--- a/skills/routine-writer/SKILL.md
+++ b/skills/routine-writer/SKILL.md
@@ -17,7 +17,7 @@ Turn an unattended, repeatable task into a Claude Code routine: a saved prompt p
 
 **Why routines differ from chat prompts.** A routine runs as a full autonomous Claude Code cloud session. There is no permission-mode picker, no approval prompts, and no human to answer clarifying questions mid-run. A prompt that works fine in a conversation can stall or misfire silently inside a routine because the model has no one to ask. Every routine prompt must be self-contained, state its success criteria, and declare where output goes.
 
-**Research preview context** (April 2026): routines ship under the beta header `experimental-cc-routine-2026-04-01`. Behavior, limits, and the API surface can change. Pin any beta header references to that value and date so staleness is detectable.
+**Research preview context** (May 2026 recheck): routines ship under the beta header `experimental-cc-routine-2026-04-01`. Behavior, limits, and the API surface can change. Pin any beta header references to that value and date so staleness is detectable.
 
 ## When to use
 
@@ -56,10 +56,33 @@ Routines are high-stakes: they run unattended, consume daily allowance, and can 
 - [ ] **Safety rail present**: what the routine should NOT do (no force-push, no protected-branch changes, no destructive ops, no new connectors, no credential exfil).
 - [ ] **No injected slop**: no "certainly", "I'd be happy to", "great question", no ALL CAPS emphasis, no filler preamble. Calm imperatives only.
 - [ ] **Cron interval >= 1 hour**: scheduled triggers under one hour are rejected by the platform.
-- [ ] **Beta header pinned with date**: prose mentions of `experimental-cc-routine-2026-04-01` carry "(April 2026)" so future readers can scan for staleness. Inside code blocks the header string itself carries the date, so no parenthetical is needed.
+- [ ] **Beta header pinned with date**: prose mentions of `experimental-cc-routine-2026-04-01` carry the header date so future readers can scan for staleness. Inside code blocks the header string itself carries the date, so no parenthetical is needed.
 - [ ] **No tokens in output**: environment variable placeholders only. Never paste a real `sk-ant-oat01-...` value.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **API surface checked**: routine headers, beta names, schedule syntax, and event payloads match current official docs
+- [ ] **Unattended risk bounded**: permissions, spending, mutation scope, and notification paths are explicit
+
+---
+
+## Performance
+
+- Keep scheduled jobs narrow; split broad routines into independently observable tasks.
+- Set output contracts so downstream automation reads small structured results instead of transcripts.
+- Throttle polling and retries to avoid unnecessary API or CI load.
+
+
+---
+
+## Best Practices
+
+- Use least-privilege tokens and separate credentials per routine.
+- Make failure modes visible with logs, alerts, and idempotent retry behavior.
+- Pin beta headers with dates and revisit them during maintenance refreshes.
+
 
 ## Workflow
 
@@ -221,6 +244,6 @@ API-only and GitHub-only routines skip artifact #2 and emit a web-UI walkthrough
 5. **Branch policy off by default.** Do not recommend enabling **Allow unrestricted branch pushes** unless the prompt genuinely needs to write outside `claude/*`. Prefer opening PRs.
 6. **Never embed tokens.** Every `Authorization: Bearer` in emitted artifacts uses an env var placeholder (`$ROUTINE_FIRE_TOKEN`). Tokens are shown once in the web UI and cannot be retrieved - emitting a real one in the conversation exposes it.
 7. **Never auto-run `/schedule`.** Emit the command for the user to paste or confirm. Routines count against the daily allowance; the skill never consumes that allowance autonomously.
-8. **Pin the beta header with its date in prose.** Prose mentions of `experimental-cc-routine-2026-04-01` carry "(April 2026)" so a reader scanning the docs can spot staleness without parsing the header string. In code blocks the header string itself contains `2026-04-01`, so no extra annotation is needed. The two most recent prior header versions keep working for migration.
+8. **Pin the beta header with its date in prose.** Prose mentions of `experimental-cc-routine-2026-04-01` carry the header date so a reader scanning the docs can spot staleness without parsing the header string. In code blocks the header string itself contains `2026-04-01`, so no extra annotation is needed. The two most recent prior header versions keep working for migration.
 9. **Detect before emitting.** Before printing `/schedule` instructions, verify `claude` is on PATH. If not, emit the web-UI walkthrough instead.
 10. **Run the AI Self-Check.** Every routine prompt returned to the user passes the checklist above first.

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -17,7 +17,7 @@ Structured, multi-pass security audit. Combines automated tooling with manual pa
 
 Patterns drawn from real OSS incidents (unauthenticated admin endpoints, credential exfiltration, zip slip, auth bypass whitelists, Trivy supply chain compromise) and OpenSSF/SLSA/OWASP standards.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - Semgrep 1.161.0, Bandit 1.9.4
 - Gitleaks 8.30.1, Betterleaks 1.1.1 (successor by same author), TruffleHog 3.95.2
 - Trivy 0.70.0 (0.69.4-0.69.6 was compromised - see known incidents; 0.70.x is the safe upgrade path)
@@ -60,6 +60,29 @@ Before returning any security audit report, verify:
 - [ ] **Scope respected**: no external service probing, no DAST, repo-only analysis
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Threat model matched**: findings map to the app's actual assets, actors, trust boundaries, and deployment
+- [ ] **Exploitability stated carefully**: severity is based on reachable paths and impact, not scanner labels alone
+
+---
+
+## Performance
+
+- Run secret and dependency checks early; they are cheap and often high impact.
+- Prioritize auth, authorization, input handling, deserialization, and supply-chain paths before low-risk headers.
+- Use targeted dynamic tests for risky flows instead of broad unauthenticated crawling only.
+
+
+---
+
+## Best Practices
+
+- Separate confirmed vulnerabilities, hardening recommendations, and open questions.
+- Protect sensitive findings and reproduction data in reports.
+- Include concrete remediation and verification steps for each material finding.
+
 
 ## Workflow
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -77,6 +77,29 @@ Before returning any generated or modified skill, verify against this list:
 - [ ] **Forward-tested** (high-effort skills, when feasible): during review, a subagent used the skill on a realistic task without leaked context. This is a process check on the reviewer, not a content requirement on the skill - the skill does not need a "forward-test" section. The reviewer notes what was tested or skipped and why.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: new or edited skills do not steal triggers from better-matched existing skills
+- [ ] **Spec claims verified**: frontmatter, metadata, and compatibility guidance match the current Agent Skills specification
+
+---
+
+## Performance
+
+- Keep `SKILL.md` compact; move deep examples into references loaded on demand.
+- Prefer precise triggers over broad keyword lists that cause unnecessary skill loading.
+- Run lint/spec checks before prose polishing so structural failures surface early.
+
+
+---
+
+## Best Practices
+
+- Write skills as operational instructions, not essays about a domain.
+- Include clear When to use/When NOT to use routing and realistic AI self-checks.
+- Keep public skills tool-agnostic unless a tool is intrinsic to the skill.
+
 
 ## Workflow
 

--- a/skills/skill-refiner/SKILL.md
+++ b/skills/skill-refiner/SKILL.md
@@ -61,6 +61,24 @@ contested major flags (non-configurable).
 
 **step**: pauses after every iteration for manual review. Best for first run or learning.
 
+---
+
+## Performance
+
+- Batch similar edits and validations to reduce repeated full-collection scans.
+- Prioritize low-scoring or recently changed skills before polishing already-healthy ones.
+- Use focused diffs and line-count checks after each batch to avoid late cleanup churn.
+
+
+---
+
+## Best Practices
+
+- Snapshot evaluation criteria before editing the skills that define the criteria.
+- Revert changes that add complexity without improving behavior.
+- Keep run history factual and free of unverifiable score inflation.
+
+
 ## Workflow
 
 ### Phase 0: Setup
@@ -208,6 +226,11 @@ Before committing any skill modification, verify:
 - [ ] **ASCII only**: no non-ASCII characters introduced (except allowed emoji indicators)
 - [ ] **Immutability respected**: no phase-1 modification to evaluation criteria,
   test cases, lint scripts, skill-creator, or skill-refiner
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Score discipline kept**: changes are kept only when they improve measured quality or fix a verified defect
+- [ ] **Local-only scope respected**: public and private skills are separated before commits or release notes
 
 ## Rules
 

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Write, review, and architect Terraform/OpenTofu infrastructure - from individual resources to multi-account, PCI-compliant platform architectures. The goal is reproducible, drift-free, auditable infrastructure that passes both peer review and QSA assessment.
 
-**Target versions** (April 2026): Terraform 1.14.9 (IBM/HashiCorp, BSL; 1.15.0-rc2 in progress), OpenTofu 1.11.6 (Linux Foundation, MPL). Helm provider v3.1+, K8s provider v3.0+, AWS provider v6.x, Azure v4.x, GCP v7.x.
+**Target versions** (May 2026): Terraform 1.14.9 (IBM/HashiCorp, BSL; 1.15.0-rc2 in progress), OpenTofu 1.11.6 (Linux Foundation, MPL). Helm provider v3.1+, K8s provider v3.0+, AWS provider v6.x, Azure v4.x, GCP v7.x.
 
 This skill covers four domains depending on context:
 - **HCL** - resource configs, variables, outputs, data sources, expressions, lifecycle rules
@@ -78,6 +78,29 @@ AI tools consistently produce the same Terraform mistakes. **Before returning an
 **AI should never own `terraform apply`.** In March 2026, an AI-assisted Terraform workflow deleted production infrastructure through escalating cleanup logic. Plan output is reviewed by a human. Always.
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Provider docs checked**: resource arguments, defaults, and deprecations match pinned provider versions
+- [ ] **State impact reviewed**: imports, moves, destroys, and replacements are visible in plan output before apply
+
+---
+
+## Performance
+
+- Scope plans to changed stacks/modules during iteration, then run full plans before merge.
+- Use remote state and data sources sparingly; excessive cross-stack reads slow plans and create hidden coupling.
+- Cache providers in CI and pin versions to avoid repeated downloads and surprise upgrades.
+
+
+---
+
+## Best Practices
+
+- Never let automation apply production plans without a reviewed plan artifact and human approval.
+- Use `moved` blocks for refactors instead of delete/recreate churn.
+- Protect stateful resources with backups, `prevent_destroy`, and explicit migration steps.
+
 
 ## Workflow
 

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Write, structure, and maintain tests across unit, integration, E2E, accessibility, and performance layers. The goal is tests that catch regressions, document behavior, and run fast in CI - not tests that exist to inflate coverage numbers.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - Vitest **4.1.2**, Jest **30.3.0**
 - Playwright **1.59.0**, Cypress **15.13.0**
 - pytest **9.0.2**, pytest-cov **7.1.0**
@@ -66,6 +66,29 @@ AI tools consistently produce the same testing mistakes. **Before returning any 
 - [ ] E2E selectors use `data-testid`, `role`, or accessible names - not CSS classes or DOM structure
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Runner APIs current**: pytest, Vitest, Jest, Playwright, and Testing Library examples match current runner behavior
+- [ ] **Flake source identified**: retries are not used to hide nondeterminism without diagnosis
+
+---
+
+## Performance
+
+- Split fast unit tests from integration, browser, and performance suites.
+- Use fixtures and test data builders to avoid repeated expensive setup.
+- Shard or parallelize only after isolating shared state, ports, databases, and clocks.
+
+
+---
+
+## Best Practices
+
+- Test behavior through stable public interfaces, not implementation details.
+- Use stable roles/test IDs for UI tests; do not select generated CSS classes.
+- Every regression fix gets a failing test that would have caught the bug.
+
 
 ## Workflow
 

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -58,10 +58,33 @@ Before presenting documentation updates, verify:
 - [ ] When private and public roadmaps both exist, both are updated, with the public one carrying user-visible highlights only and the private one carrying internal detail
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Docs match code**: commands, flags, config names, screenshots, and API examples are checked against the changed implementation
+- [ ] **Audience path checked**: README, changelog, API docs, runbooks, and migration notes are updated only where users need them
 
 ## Core Principle
 
 **Document what you can't grep, in the file readers will actually check.** If it's in the source code, config files, or manifests, it usually doesn't belong in docs. Document: gotchas, decisions, failure modes, workarounds, implicit dependencies, release-facing deltas, and "the thing that took 30 minutes to figure out."
+
+---
+
+## Performance
+
+- Diff the code first, then update affected docs; avoid broad rewrites unrelated to the change.
+- Prefer generated API/schema docs where the project already has generation tooling.
+- Keep examples minimal but runnable so future verification is cheap.
+
+
+---
+
+## Best Practices
+
+- Document behavior changes, deprecations, migration steps, and rollback notes in the place users will look.
+- Remove stale instructions instead of appending contradictory notes.
+- Keep changelog entries user-facing and avoid internal implementation noise.
+
 
 ## Workflow
 

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -18,7 +18,7 @@ setups to multi-node clusters with HA, live migration, and GPU passthrough. The 
 production-ready VM infrastructure with correct storage, memory, and CPU config that won't
 bite you at 3 AM.
 
-**Target versions** (verified April 2026):
+**Target versions** (verified May 2026):
 
 | Tool | Version | Release date | Notes |
 |------|---------|-------------|-------|
@@ -89,6 +89,29 @@ generated VM config, Terraform HCL, or Packer template, verify against this list
   omit for PCI passthrough display GPUs (`x-vga=1` replaces the virtual display)
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Hypervisor/version checked**: Proxmox, QEMU/KVM, libvirt, XCP-ng, vSphere, and cloud-init advice matches the target platform
+- [ ] **Storage risk gated**: disk format, snapshot, passthrough, and migration commands preserve data and rollback
+
+---
+
+## Performance
+
+- Choose storage format and cache mode based on workload: latency, snapshots, thin provisioning, and backup behavior differ.
+- Right-size vCPU, NUMA, memory ballooning, and I/O queues from measured host pressure.
+- Use templates and cloud-init for repeatable VM creation instead of manual clone drift.
+
+
+---
+
+## Best Practices
+
+- Snapshot before guest-agent, disk, boot, passthrough, or hypervisor upgrades, but do not treat snapshots as backups.
+- Keep host, guest, and storage backups independently restorable.
+- Document PCI/GPU passthrough bindings so kernel updates do not strand the host.
+
 
 ## Workflow
 

--- a/skills/zero-day/SKILL.md
+++ b/skills/zero-day/SKILL.md
@@ -21,7 +21,7 @@ This is the *discovery* skill - it finds vulnerabilities nobody has catalogued y
 exploiting known weaknesses on live systems, use **lockpick**. For scanning code against known
 vulnerability patterns, use **security-audit**.
 
-**Target versions** (April 2026):
+**Target versions** (May 2026):
 - CodeQL CLI: v2.25.1
 - Semgrep: v1.157.0
 - Joern: v4.0.x
@@ -69,6 +69,29 @@ Before reporting any vulnerability or generating exploit code, verify:
 - [ ] **Complexity honest**: if exploitation requires unlikely conditions (specific config, race window, chained bugs), state that clearly - don't inflate impact
 
 ---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Authorization and disclosure scope checked**: targets, reproduction, and reporting stay within authorized research boundaries
+- [ ] **PoC safety reviewed**: proof code demonstrates impact without avoidable persistence, exfiltration, or wormable behavior
+
+---
+
+## Performance
+
+- Minimize repro cases before deep fuzzing so crashes triage quickly.
+- Deduplicate crashes by stack, root cause, and patch reachability before reporting counts.
+- Use coverage and corpus metrics to guide fuzzing time instead of running blind indefinitely.
+
+
+---
+
+## Best Practices
+
+- Capture exact versions, build flags, inputs, logs, and debugger state for every candidate finding.
+- Separate exploitability analysis from speculation; mark uncertainty clearly.
+- Follow the target project's disclosure policy and avoid publishing operational exploit detail prematurely.
+
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- refresh public skill guidance with May 2026 ecosystem checks
- expand AI self-checks with concrete failure modes
- add or refine Performance and Best Practices guidance across the collection

## Validation

- ./scripts/lint-skills.sh
- ./scripts/validate-spec.sh

## Release prep

- Candidate release type: minor
- Suggested release note: refreshed public skill guidance for May 2026 with stronger misuse guardrails and operational performance guidance