### PR TITLE
Grow skill discovery and publish generic cluster health

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
       - "README.md"
       - "SECURITY.md"
       - "docs/**"
+      - ".pre-commit-config.yaml"
       - ".markdownlint-cli2.jsonc"
       - "lychee.toml"
       - ".github/workflows/**"
@@ -21,6 +22,7 @@ on:
       - "README.md"
       - "SECURITY.md"
       - "docs/**"
+      - ".pre-commit-config.yaml"
       - ".markdownlint-cli2.jsonc"
       - "lychee.toml"
       - ".github/workflows/**"
@@ -33,6 +35,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check protected overlay guardrail
+        run: ./scripts/check-protected-overlay.sh
+
+      - name: Check private cluster-health leak patterns
+        run: ./scripts/check-private-skill-leaks.sh
 
       - name: Lint skill collection
         run: ./scripts/lint-skills.sh
@@ -59,12 +67,10 @@ jobs:
 
       - name: Check shell syntax
         run: |
-          bash -n install.sh
-          bash -n scripts/lint-skills.sh
-          bash -n scripts/validate-spec.sh
+          bash -n install.sh scripts/*.sh
 
       - name: Shellcheck scripts
-        run: shellcheck install.sh scripts/lint-skills.sh scripts/validate-spec.sh scripts/skill-lib.sh
+        run: shellcheck install.sh scripts/*.sh
 
       - name: Check Python helper syntax
         run: python3 -m py_compile scripts/skill-frontmatter.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Check private cluster-health leak patterns
         run: ./scripts/check-private-skill-leaks.sh
 
+      - name: Check freshness date markers
+        run: ./scripts/check-freshness-dates.sh
+
       - name: Lint skill collection
         run: ./scripts/lint-skills.sh
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Check freshness date markers
         run: ./scripts/check-freshness-dates.sh
 
+      - name: Check deep-audit skill coverage
+        run: ./scripts/check-deep-audit-coverage.sh
+
       - name: Lint skill collection
         run: ./scripts/lint-skills.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 CLAUDE.md
 AGENTS.md
 publish.sh
-skills/cluster-health/
+skills/cluster-health/protected/
 docs/superpowers/
 docs/prompts/
 SECURITY-AUDIT.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,13 @@ repos:
         pass_filenames: false
         stages: [pre-commit, pre-push]
 
+      - id: deep-audit-coverage-check
+        name: deep-audit accounts for public skills
+        entry: ./scripts/check-deep-audit-coverage.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit, pre-push]
+
       - id: skill-collection-lint
         name: lint skill collection
         entry: ./scripts/lint-skills.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: local
+    hooks:
+      - id: protected-cluster-health-overlay
+        name: protected cluster-health overlay stays private
+        entry: ./scripts/check-protected-overlay.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit, pre-push]
+
+      - id: private-cluster-health-leak-check
+        name: private cluster-health pattern leak check
+        entry: ./scripts/check-private-skill-leaks.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit, pre-push]
+
+      - id: skill-collection-lint
+        name: lint skill collection
+        entry: ./scripts/lint-skills.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: agent-skills-spec-validation
+        name: validate Agent Skills spec
+        entry: ./scripts/validate-spec.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,13 @@ repos:
         pass_filenames: false
         stages: [pre-commit, pre-push]
 
+      - id: freshness-date-check
+        name: freshness markers use current collection month
+        entry: ./scripts/check-freshness-dates.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit, pre-push]
+
       - id: skill-collection-lint
         name: lint skill collection
         entry: ./scripts/lint-skills.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,6 +85,8 @@ pre-commit install --hook-type pre-commit --hook-type pre-push
 
 The hooks enforce that `skills/cluster-health/protected/` remains ignored and untracked, and they scan public files for protected private patterns when the local overlay is present.
 
+They also check freshness markers in public skills. Lines that claim currentness, such as `Target versions`, `verified <month year>`, `recheck`, `snapshot`, or `as of <month year>`, must use the current collection label. Override the expected label during a refresh with `SKILLS_FRESHNESS_LABEL="June 2026" ./scripts/check-freshness-dates.sh`.
+
 ### Manual
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,13 +61,29 @@ Override the canonical directory with `SKILLS_CANONICAL_DIR`:
 SKILLS_CANONICAL_DIR=~/my-skills ./install.sh --tool claude,roo --link
 ```
 
-### Local private skills
+### Local private overlays
 
 Skills declaring `metadata.internal: true` and gitignored locally are skipped by default. Pass `--include-internal` to install them too.
 
 ```bash
 ./install.sh --tool claude,codex,opencode --link --include-internal --force
 ```
+
+The public `cluster-health` skill can also have a local protected overlay at `skills/cluster-health/protected/`. That directory is gitignored and must stay untracked. Use it for private lab, homelab, work, or customer cluster aliases, kube contexts, CWD mappings, namespaces, dashboards, runbooks, and local thresholds. You can ask an agent to create or update files there, typically `registry.md`, `private-patterns.txt`, and one `<cluster-or-env>.md` profile per environment.
+
+When present in a local checkout, normal copy installs and `--link` installs copy the overlay into the installed `cluster-health` skill. In symlink mode, tool-specific skill directories point at the canonical copy, so Claude, Codex, OpenCode, and other linked tools all see the same protected overlay. Public GitHub installs do not include the overlay because it is not tracked.
+
+`cluster-health` is public, so it no longer needs `--include-internal`; that flag is only for separate gitignored skills with `metadata.internal: true`.
+
+Before committing local changes, install the repository hooks with either `prek` or `pre-commit`:
+
+```bash
+prek install --hook-type pre-commit --hook-type pre-push
+# or:
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+The hooks enforce that `skills/cluster-health/protected/` remains ignored and untracked, and they scan public files for protected private patterns when the local overlay is present.
 
 ### Manual
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-39 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
+41 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-open_standard-blue.svg)](https://agentskills.io)
@@ -23,7 +23,7 @@ AI coding tools used to mean prompts. Prompts don't compose, don't carry between
 
 Then Karpathy pointed an agent at a 630-line training script overnight. It edited the code, ran a 5-minute training, kept changes that improved the score, discarded the rest. 700 runs, 20 wins, on one GPU. The pattern works on anything you can score.
 
-This repo applies that pattern conservatively to 39 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
+This repo applies that pattern conservatively to 41 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
 
 ## The autoresearch loop
 
@@ -44,7 +44,7 @@ The goal is not magic self-repair. The goal is a repeatable maintenance loop wit
 
 ## Quality evidence
 
-Current repository gates pass for all 39 public skills:
+Current repository gates pass for all 41 public skills:
 
 ```bash
 ./scripts/lint-skills.sh
@@ -72,7 +72,7 @@ That's it. For specific skills, alternative tools, the bundled installer, or sym
 
 ## What's in here
 
-39 skills covering infra (Kubernetes, Terraform, Docker, Ansible), distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, and meta-tooling (the skill creator, refiner, and full-review orchestrator).
+41 skills covering infra (Kubernetes, Terraform, Docker, Ansible), cluster health diagnostics, distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, and meta-tooling (the skill creator, refiner, router, and full-review orchestrator).
 
 Browse [`skills/`](skills/) for the full list, or query it:
 

--- a/docs/superpowers/specs/2026-05-01-skills-growth-design.md
+++ b/docs/superpowers/specs/2026-05-01-skills-growth-design.md
@@ -1,0 +1,364 @@
+# Skills Growth Design
+
+Date: 2026-05-01
+Repository: `/home/id/priv/code/gh.id/skills`
+
+## Purpose
+
+Use the observed skills.sh download signal to grow the collection in areas with clear demand:
+skill discovery, frontend design, browser automation, prompt generation, and Kubernetes cluster
+health diagnostics.
+
+This is one umbrella design for five related workstreams. Implementation should be staged so
+lower-risk public skill updates can move independently from the more sensitive `cluster-health`
+public/private migration.
+
+## Scope
+
+In scope:
+
+- Add a new public `skill-router` skill.
+- Expand the existing public `frontend-design`, `browse`, and `prompt-generator` skills.
+- Convert `cluster-health` from private-only to a public generic skill with protected local overlays.
+- Update repo tooling and docs where needed so protected overlays stay out of public commits.
+- Validate with `scripts/lint-skills.sh`, `scripts/validate-spec.sh`, targeted privacy checks, and
+  focused diff review.
+
+Out of scope:
+
+- Implementing the skill edits as part of this design step.
+- Rewriting the whole collection.
+- Publishing current private cluster names, kube contexts, domains, namespaces, service names,
+  commands, node names, employer-specific architecture, or private thresholds.
+- Importing third-party skills from skills.sh directly.
+- Changing the installer model beyond what `cluster-health` needs.
+
+## Current Repository Facts
+
+- Public skills live under `skills/`.
+- Canonical local skills live under `/home/id/.agents/skills/`.
+- `skill-router` does not currently exist.
+- `frontend-design`, `browse`, and `prompt-generator` already exist and should be expanded in place.
+- `cluster-health` currently exists locally under `skills/cluster-health/`, is gitignored, and has
+  `metadata.internal: true`.
+- `.gitignore` currently ignores the entire `skills/cluster-health/` directory.
+- `scripts/lint-skills.sh` currently treats `cluster-health` as a private skill that public skills
+  must not reference.
+- Public `SKILL.md` files should stay below the 600-line hard max, with a target below 500 lines.
+
+## Approach
+
+Use a staged public-growth plan:
+
+1. Create `skill-router` first, because it improves discovery across the full collection.
+2. Expand `frontend-design`, `browse`, and `prompt-generator` with demand-backed guidance while
+   preserving their current boundaries.
+3. Migrate `cluster-health` last, because it requires privacy review, `.gitignore` changes, and
+   linter policy updates.
+
+The design is one spec for coherence. The implementation plan should split the work into focused
+commits or PR sections.
+
+## Workstream 1: `skill-router`
+
+Create a new public skill for choosing the right skill from an installed collection.
+
+### Goal
+
+Help agents route a user request to the smallest useful skill set, explain the choice, and avoid
+loading adjacent skills unnecessarily.
+
+### Expected behavior
+
+- Read the user request and available skill metadata.
+- Select one primary skill when possible.
+- Return a short ranked set when the request genuinely spans multiple skills.
+- Name near misses when useful, with a concise reason they were not selected.
+- Hand off creation, review, and batch improvement work to `skill-creator` or `skill-refiner`.
+
+### Boundaries
+
+`skill-router` should not:
+
+- Rewrite skills.
+- Audit the whole collection.
+- Perform competitive research.
+- Replace `skill-creator`, `skill-refiner`, `roadmap`, or domain-specific skills.
+
+### Likely structure
+
+- Frontmatter: public, medium effort, source `iuliandita/skills`.
+- `When to use`: skill selection, routing conflicts, "which skill should I use", trigger tuning.
+- `When NOT to use`: creating skills, reviewing skills, full collection audits, implementation work.
+- Workflow:
+  1. Parse user intent.
+  2. Identify hard triggers and exclusions.
+  3. Check adjacent skills for overlap.
+  4. Pick one primary skill or a minimal ordered set.
+  5. Explain the routing decision and next action.
+- References:
+  - Optional `references/routing-patterns.md` if examples would make `SKILL.md` too long.
+
+## Workstream 2: `frontend-design`
+
+Expand the existing opinionated UI skill without diluting its identity.
+
+### Goal
+
+Make `frontend-design` better aligned with visible skills.sh demand for frontend, React, web design,
+shadcn, and UI/UX guidance.
+
+### Additions
+
+- React, Tailwind, and shadcn guidance as reference material, not a rewrite of the main skill.
+- App shell and dashboard patterns for operational tools.
+- Form, settings, onboarding, and empty-state guidance.
+- Responsive QA workflow with desktop/mobile checks.
+- Visual regression and screenshot review guidance.
+- Stronger rules against common AI UI tells.
+
+### Boundaries
+
+Keep routing clear:
+
+- Code correctness stays with `code-review`.
+- Test authoring and E2E test debugging stay with `testing`.
+- Localization stays with `localize`.
+- Backend/API design stays with `backend-api`.
+
+### Likely file changes
+
+- Update `skills/frontend-design/SKILL.md` with compact routing and workflow refinements.
+- Add or expand references, likely:
+  - `references/frameworks.md`
+  - `references/ai-tells.md`
+  - new `references/app-ui-patterns.md`
+  - new or expanded responsive/QA reference material
+
+## Workstream 3: `browse`
+
+Expand the browser automation skill around practical web tasks.
+
+### Goal
+
+Make `browse` useful for modern read, scrape, screenshot, authenticated, and interactive browsing
+tasks while keeping token cost and source quality under control.
+
+### Additions
+
+- Task-mode routing:
+  - static fetch
+  - JavaScript-rendered read-only pages
+  - interactive browsing
+  - authenticated browsing
+  - screenshots
+  - structured extraction
+- Clearer source attribution rules for facts likely to change.
+- Rate-limit and politeness guidance.
+- Session isolation and cookie/storage cleanup rules.
+- Selector strategy for interaction: semantic roles first, brittle CSS last.
+- Screenshot/DOM decision rules so agents do not overuse expensive browser output.
+
+### Boundaries
+
+Keep routing clear:
+
+- E2E test automation stays with `testing`.
+- MCP browser server development stays with `mcp`.
+- Network/DNS/proxy debugging stays with `networking`.
+- RAG ingestion pipelines stay with `ai-ml`.
+
+### Likely file changes
+
+- Update `skills/browse/SKILL.md`.
+- Add or expand references:
+  - `references/tool-setup.md`
+  - new `references/extraction-patterns.md`
+  - new `references/authenticated-browsing.md`
+
+## Workstream 4: `prompt-generator`
+
+Expand the prompt structuring skill into clearer prompt families.
+
+### Goal
+
+Strengthen an already popular skill by making it better at turning rough input into reusable,
+model-agnostic prompts without becoming a brainstorming or skill-authoring workflow.
+
+### Additions
+
+- Prompt family patterns:
+  - system prompts
+  - one-off task prompts
+  - reusable templates
+  - evaluator prompts
+  - code-review prompts
+  - agent delegation prompts
+- Injection-boundary guidance for untrusted source text.
+- Variable naming and schema consistency rules.
+- Model-specific adaptation rules only when the user names a provider.
+- Examples that stay compact and avoid creating a giant prompt library.
+
+### Boundaries
+
+Keep routing clear:
+
+- Creative ideation stays with brainstorming workflows.
+- Skill creation stays with `skill-creator`.
+- Routine prompts stay with `routine-writer`.
+- LLM application code stays with `ai-ml`.
+- Prompt injection security review stays with `security-audit`.
+
+### Likely file changes
+
+- Update `skills/prompt-generator/SKILL.md`.
+- Consider adding:
+  - `references/prompt-families.md`
+  - `references/evaluator-prompts.md`
+
+## Workstream 5: Public-Safe `cluster-health`
+
+Convert the private `cluster-health` skill into a public generic Kubernetes health check skill while
+moving private infrastructure details into protected local files.
+
+### Goal
+
+Publish a useful generic cluster diagnostics skill without exposing private infrastructure. Local
+installs should still support the existing personalized registry and checks.
+
+### Public skill model
+
+Public tracked files should include:
+
+- `skills/cluster-health/SKILL.md`
+- generic references such as:
+  - `references/kubernetes-core.md`
+  - `references/helm-gitops.md`
+  - `references/networking-ingress.md`
+  - `references/storage.md`
+  - `references/monitoring-logs.md`
+  - `references/security.md`
+
+The public skill should work with no overlay by asking for an explicit kube context or using the
+current context only after confirmation. It should define read-only generic checks for nodes,
+workloads, events, logs, Helm releases, GitOps state, certificates, ingress, storage, monitoring,
+and security signals.
+
+### Protected local overlay model
+
+Protected local files should live under:
+
+- `skills/cluster-health/protected/registry.md`
+- optional `skills/cluster-health/protected/<cluster>.md`
+
+Protected files may contain:
+
+- cluster aliases
+- kube contexts
+- CWD detection patterns
+- domains
+- namespaces
+- app names
+- node names
+- SSH hosts
+- private thresholds
+- custom commands
+- organization-specific architecture
+
+The public skill should say:
+
+1. If `protected/registry.md` exists, load it.
+2. If the registry maps the request or CWD to a cluster, use that protected profile.
+3. If no protected overlay exists, ask for the kube context or run the generic read-only sweep
+   against an explicitly confirmed context.
+4. Never guess a cluster target.
+
+### Git and tooling changes
+
+Required changes:
+
+- Replace `.gitignore` entry `skills/cluster-health/` with `skills/cluster-health/protected/`.
+- Remove or revise the hardcoded private-skill rule for `cluster-health` in `scripts/lint-skills.sh`.
+- Add a privacy-check script that prevents tracked files from referencing protected cluster details.
+- Update docs that describe excluded skills, since `cluster-health` would no longer be excluded as
+  a whole skill.
+- Remove `metadata.internal: true` from public `cluster-health` frontmatter.
+- Change `metadata.source` from `custom` to `iuliandita/skills` when public.
+
+### Privacy migration
+
+Before publishing:
+
+- Move every current private alias, kube context, domain, namespace, service name, node name, SSH
+  host, CWD pattern, and organization-specific command into `protected/`.
+- Replace current cluster-specific references with generic examples.
+- Review tracked files with a private-term grep before committing.
+- Confirm `git status --short` does not show protected files.
+
+## Verification
+
+Implementation should run:
+
+```bash
+rtk scripts/lint-skills.sh
+rtk scripts/validate-spec.sh
+rtk git diff --check
+rtk git check-ignore -v skills/cluster-health/protected/registry.md
+```
+
+Implementation should also run a targeted privacy check against tracked files. The exact patterns
+should come from the current private `cluster-health` files before migration. At minimum, check for
+known private aliases, kube contexts, domains, namespaces, app/service names, node names, SSH hosts,
+and organization names.
+
+Before PR, review:
+
+```bash
+rtk git diff -- skills/cluster-health .gitignore scripts README.md
+rtk git status --short --ignored=matching skills/cluster-health
+```
+
+Acceptance criteria:
+
+- `skill-router` exists and validates as a public skill.
+- `frontend-design`, `browse`, and `prompt-generator` have stronger demand-aligned guidance without
+  trigger overlap regressions.
+- `cluster-health` is public, generic, and useful without protected files.
+- Protected cluster overlays are ignored by git.
+- Public tracked files contain no private infrastructure details.
+- Existing install behavior still works for public skills.
+- Local protected overlays remain usable from the repo working tree with `./install.sh --tool
+  claude,codex,opencode --link --force`; `--include-internal` should no longer be required for
+  `cluster-health` after it becomes public.
+
+## Implementation Order
+
+1. Branch from current `main`.
+2. Add `skill-router`.
+3. Expand `prompt-generator`.
+4. Expand `browse`.
+5. Expand `frontend-design`.
+6. Migrate `cluster-health` into public generic files plus protected local overlays.
+7. Update `.gitignore`, linter policy, and docs.
+8. Run validation and privacy checks.
+9. Review focused diffs.
+10. Commit in logical chunks and prepare PR text.
+
+## Risks
+
+- `cluster-health` can leak private information if migration is incomplete.
+- `skill-router` can overlap too much with `skill-creator` or `skill-refiner` if its boundary is
+  not explicit.
+- `frontend-design` can grow beyond the line target if all examples are placed in `SKILL.md`.
+- `browse` can encourage expensive browser usage if the cheapest-tool-first rule is weakened.
+- `prompt-generator` can become a brainstorming workflow unless its "structure existing intent"
+  boundary stays clear.
+
+## Decisions For Implementation Planning
+
+- The new discovery skill is named `skill-router`.
+- `cluster-health` protected overlays remain under `skills/cluster-health/protected/` in the repo
+  working tree, ignored by git.
+- Privacy checking should be implemented as a script, not an ad hoc command.
+- The work should land as one PR with logical commits unless the `cluster-health` migration becomes
+  risky enough to split.

--- a/scripts/check-deep-audit-coverage.sh
+++ b/scripts/check-deep-audit-coverage.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+mapfile -t public_skills < <(
+  git -C "$ROOT" ls-files 'skills/*/SKILL.md' \
+    | sed 's#^skills/##; s#/SKILL.md$##' \
+    | sort
+)
+
+wave_skills=(
+  ai-ml
+  ansible
+  anti-ai-prose
+  anti-slop
+  arch-btw
+  backend-api
+  ci-cd
+  code-review
+  command-prompt
+  databases
+  debian-ubuntu
+  docker
+  firewall-appliance
+  frontend-design
+  git
+  kubernetes
+  localize
+  mcp
+  networking
+  nixos-btw
+  rhel-fedora
+  roadmap
+  security-audit
+  terraform
+  testing
+  update-docs
+  virtualization
+  zero-day
+)
+
+excluded_skills=(
+  browse
+  cluster-health
+  deep-audit
+  dev-cycle
+  full-review
+  jekyll-hyde
+  kali-linux
+  lockpick
+  prompt-generator
+  routine-writer
+  skill-creator
+  skill-refiner
+  skill-router
+)
+
+errors=0
+
+contains() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+for skill in "${public_skills[@]}"; do
+  if ! contains "$skill" "${wave_skills[@]}" && ! contains "$skill" "${excluded_skills[@]}"; then
+    echo "ERROR: deep-audit does not cover public skill: $skill"
+    errors=$((errors + 1))
+  fi
+done
+
+for skill in "${wave_skills[@]}" "${excluded_skills[@]}"; do
+  if ! contains "$skill" "${public_skills[@]}"; then
+    echo "ERROR: deep-audit references missing public skill: $skill"
+    errors=$((errors + 1))
+  fi
+done
+
+if (( errors > 0 )); then
+  exit 1
+fi
+
+printf 'Deep-audit coverage accounts for %d public skills (%d wave, %d excluded).\n' \
+  "${#public_skills[@]}" "${#wave_skills[@]}" "${#excluded_skills[@]}"

--- a/scripts/check-freshness-dates.sh
+++ b/scripts/check-freshness-dates.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRESHNESS_LABEL="${SKILLS_FRESHNESS_LABEL:-May 2026}"
+
+mapfile -t files < <(
+  git -C "$ROOT" ls-files \
+    | grep -E '^(skills/|README[.]md$|INSTALL[.]md$).*[.]md$' \
+    | grep -v '^skills/cluster-health/protected/' || true
+)
+
+errors=0
+
+stale_claim_re='(as of|verified|recheck|snapshot|current as of|Pinned to|Research preview context|Key facts \(|Skill Inventory \(|Target versions|Versions worth pinning)'
+freshness_line_re='(^\*\*Target versions|^\*\*Versions worth pinning|^#+ .*Target versions|^#+ .*Versions worth pinning|Research preview context|Key facts \([A-Z][a-z]+ 20[0-9]{2}\)|Skill Inventory \([A-Z][a-z]+ 20[0-9]{2}\)|current as of|as of [A-Z][a-z]+ 20[0-9]{2}|verified [A-Z][a-z]+ 20[0-9]{2}|[A-Z][a-z]+ 20[0-9]{2} recheck|[A-Z][a-z]+ 20[0-9]{2} snapshot|Pinned to [A-Z][a-z]+ 20[0-9]{2})'
+
+for file in "${files[@]}"; do
+  path="$ROOT/$file"
+  [[ -f "$path" ]] || continue
+  line_no=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_no=$((line_no + 1))
+    [[ "$line" =~ $stale_claim_re ]] || continue
+    [[ "$line" =~ $freshness_line_re ]] || continue
+    [[ "$line" == *"Month Year"* ]] && continue
+    if [[ "$line" != *"$FRESHNESS_LABEL"* ]]; then
+      printf 'ERROR: stale freshness marker in %s:%d\n' "$file" "$line_no"
+      printf '  expected marker: %s\n' "$FRESHNESS_LABEL"
+      printf '  line: %s\n' "$line"
+      errors=$((errors + 1))
+    fi
+  done < "$path"
+done
+
+if (( errors > 0 )); then
+  exit 1
+fi
+
+printf 'Freshness markers use %s.\n' "$FRESHNESS_LABEL"

--- a/scripts/check-private-skill-leaks.sh
+++ b/scripts/check-private-skill-leaks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROTECTED_DIR="$ROOT/skills/cluster-health/protected"
+PATTERN_FILE="$PROTECTED_DIR/private-patterns.txt"
+
+if [[ ! -f "$PATTERN_FILE" ]]; then
+  echo "No protected cluster-health overlay found; skipping private leak check."
+  exit 0
+fi
+
+mapfile -t tracked_files < <(git -C "$ROOT" ls-files)
+mapfile -t patterns < <(grep -vE '^[[:space:]]*(#|$)' "$PATTERN_FILE")
+
+errors=0
+for pattern in "${patterns[@]}"; do
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    if grep -qiF -- "$pattern" "$ROOT/$file"; then
+      echo "ERROR: private pattern '$pattern' found in tracked file $file"
+      errors=$((errors + 1))
+    fi
+  done < <(printf '%s\n' "${tracked_files[@]}")
+done
+
+if (( errors > 0 )); then
+  exit 1
+fi
+
+echo "No private cluster-health patterns found in tracked files."

--- a/scripts/check-private-skill-leaks.sh
+++ b/scripts/check-private-skill-leaks.sh
@@ -10,22 +10,52 @@ if [[ ! -f "$PATTERN_FILE" ]]; then
   exit 0
 fi
 
-mapfile -t tracked_files < <(git -C "$ROOT" ls-files)
-mapfile -t patterns < <(grep -vE '^[[:space:]]*(#|$)' "$PATTERN_FILE")
+mapfile -t candidate_files < <(
+  git -C "$ROOT" ls-files --cached --others --exclude-standard \
+    | grep -v '^skills/cluster-health/protected/' || true
+)
 
-errors=0
-for pattern in "${patterns[@]}"; do
-  while IFS= read -r file; do
-    [[ -z "$file" ]] && continue
-    if grep -qiF -- "$pattern" "$ROOT/$file"; then
-      echo "ERROR: private pattern '$pattern' found in tracked file $file"
-      errors=$((errors + 1))
+if (( ${#candidate_files[@]} == 0 )); then
+  echo "No public files found to scan."
+  exit 0
+fi
+
+tmp_patterns="$(mktemp)"
+tmp_matches="$(mktemp)"
+trap 'rm -f "$tmp_patterns" "$tmp_matches"' EXIT
+
+grep -vE '^[[:space:]]*(#|$)' "$PATTERN_FILE" > "$tmp_patterns"
+if [[ ! -s "$tmp_patterns" ]]; then
+  echo "No private cluster-health patterns configured."
+  exit 0
+fi
+
+cd "$ROOT"
+if command -v rg >/dev/null 2>&1; then
+  if rg --files-with-matches --ignore-case --fixed-strings \
+    -f "$tmp_patterns" -- "${candidate_files[@]}" > "$tmp_matches"; then
+    :
+  else
+    status=$?
+    if (( status > 1 )); then
+      exit "$status"
     fi
-  done < <(printf '%s\n' "${tracked_files[@]}")
-done
+  fi
+else
+  while IFS= read -r pattern; do
+    while IFS= read -r file; do
+      [[ -f "$file" ]] || continue
+      if grep -qiF -- "$pattern" "$file"; then
+        printf '%s\n' "$file" >> "$tmp_matches"
+      fi
+    done < <(printf '%s\n' "${candidate_files[@]}")
+  done < "$tmp_patterns"
+fi
 
-if (( errors > 0 )); then
+if [[ -s "$tmp_matches" ]]; then
+  echo "ERROR: private cluster-health patterns found in public files:"
+  sort -u "$tmp_matches" | sed 's/^/  /'
   exit 1
 fi
 
-echo "No private cluster-health patterns found in tracked files."
+echo "No private cluster-health patterns found in public files."

--- a/scripts/check-protected-overlay.sh
+++ b/scripts/check-protected-overlay.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROTECTED_REL="skills/cluster-health/protected"
+PROTECTED_SENTINEL="$PROTECTED_REL/registry.md"
+
+errors=0
+
+if ! git -C "$ROOT" check-ignore -q "$PROTECTED_SENTINEL" 2>/dev/null; then
+  echo "ERROR: $PROTECTED_REL is not gitignored."
+  echo "Expected .gitignore to protect the cluster-health private overlay."
+  errors=$((errors + 1))
+fi
+
+mapfile -t tracked_files < <(git -C "$ROOT" ls-files -- "$PROTECTED_REL" "$PROTECTED_REL/*")
+if (( ${#tracked_files[@]} > 0 )); then
+  echo "ERROR: protected cluster-health files are tracked:"
+  printf '  %s\n' "${tracked_files[@]}"
+  errors=$((errors + 1))
+fi
+
+mapfile -t staged_files < <(git -C "$ROOT" diff --cached --name-only -- "$PROTECTED_REL" "$PROTECTED_REL/*")
+if (( ${#staged_files[@]} > 0 )); then
+  echo "ERROR: protected cluster-health files are staged:"
+  printf '  %s\n' "${staged_files[@]}"
+  errors=$((errors + 1))
+fi
+
+if (( errors > 0 )); then
+  exit 1
+fi
+
+echo "Protected cluster-health overlay is ignored and untracked."

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -18,7 +18,7 @@ warn()  { echo "  WARN:  $1"; (( warnings++ )) || true; }
 
 # Private skills: present locally (gitignored) but must not be referenced
 # by public skills. They can reference public skills freely.
-PRIVATE_SKILLS=(cluster-health)
+PRIVATE_SKILLS=()
 
 # ── Private skill reference check ──────────────────────────────────────
 check_private_refs() {

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -64,6 +64,17 @@ Detect what's available and pick the cheapest tool that handles the task.
 If the page works without JavaScript, don't use a browser. If you only need to read content,
 don't use interactive tools. Escalate only when the cheaper option fails.
 
+### Task modes
+
+| Mode | Use when | First tool |
+|---|---|---|
+| Static fetch | Content is in HTML | WebFetch, curl, or Lightpanda fetch |
+| JS read-only | Content requires rendering | Lightpanda or Playwright markdown |
+| Interactive | Click, fill, or navigate statefully | MCP browser tools |
+| Authenticated | User-approved account context is required | Existing authenticated browser session |
+| Screenshot | Visual layout matters | Browser screenshot after DOM snapshot |
+| Structured extraction | Tables, JSON-LD, prices, metadata | API, JSON-LD, DOM selectors, then browser |
+
 **Tool availability check**: before starting, verify what's available. If the best tool for
 the task isn't present, skip straight to the next tier rather than failing mid-workflow.
 
@@ -74,14 +85,17 @@ the task isn't present, skip straight to the next tier rather than failing mid-w
 - Prefer official APIs, sitemaps, or static fetches before launching a browser.
 - Extract only required page regions; avoid dumping full DOMs, screenshots, or network logs into context.
 - Reuse browser sessions for multi-step flows, but clear cookies/storage between unrelated accounts or tenants.
+- Use screenshots only when visual layout or rendered state matters.
 
 ---
 
 ## Best Practices
 
 - Use stable selectors and semantic roles before brittle CSS paths.
-- Record source URLs and timestamps for facts likely to change.
-- Do not automate destructive account actions unless the user explicitly requested the exact action and target.
+- Record URL and access date for facts likely to change.
+- Clear cookies/storage between unrelated accounts or tenants.
+- Do not automate destructive account actions unless the user names the exact action and target.
+- Use semantic roles before CSS selectors.
 
 ---
 
@@ -346,6 +360,9 @@ periodically by verifying a known authenticated-only element is still visible.
 - **Lightpanda CLI fetch**: no persistence between calls (use `serve` mode for multi-step auth)
 - **agent-browser**: session-based with `--session` flag
 
+For session isolation, CSRF-sensitive actions, and multi-tenant account handling, read
+`references/authenticated-browsing.md`.
+
 ---
 
 ## Missing Tools
@@ -388,6 +405,12 @@ MCP tool parameter details (full tool tables with token costs), engine-specific 
 or known limitations of a backend. The main SKILL.md covers workflow and strategy; the
 reference file covers tool-specific depth.
 
+Read `references/extraction-patterns.md` for static, JavaScript-rendered, screenshot, table,
+pagination, and attribution patterns.
+
+Read `references/authenticated-browsing.md` before using saved sessions, cookies, or
+account-specific pages.
+
 ## Related Skills
 
 - **testing** - E2E test automation with Playwright. This skill handles ad-hoc browsing and
@@ -408,6 +431,11 @@ Before returning any browsing result, verify:
 - [ ] Stripped boilerplate (nav, ads, footers) before returning content to the user
 - [ ] Scoped extraction to the relevant section, not the whole page
 - [ ] Did not hardcode credentials - used env vars, secret manager, or user prompt
+- [ ] Cleared or isolated cookies/storage between unrelated accounts or tenants
+- [ ] Used semantic roles before CSS selectors for interaction targets
+- [ ] Used screenshots only when visual layout or rendered state mattered
+- [ ] Recorded URL and access date for facts likely to change
+- [ ] Did not automate destructive account actions unless the user named the exact action and target
 - [ ] Re-extracted page state after any click or form submission before making decisions
 - [ ] Escalated to the next tool tier on failure rather than retrying the same tool
 
@@ -432,6 +460,10 @@ Before returning any browsing result, verify:
    or user prompts.
 6. **Re-extract after interaction.** Page state changes after clicks and form submissions.
    Always get a fresh view before making decisions based on page content.
-7. **Respect robots.txt and rate limits.** Use `--obey-robots` with Lightpanda when scraping.
+7. **Semantic selectors first.** Use roles, accessible names, labels, and stable text before
+   brittle CSS selectors.
+8. **Screenshots are for visuals.** Take screenshots only when layout, rendered state, or
+   visual evidence matters.
+9. **Respect robots.txt and rate limits.** Use `--obey-robots` with Lightpanda when scraping.
    Add a 1-2 second delay between requests when batch-fetching multiple pages from the same
    domain. Don't hammer sites with rapid sequential requests.

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -17,9 +17,9 @@ Every browsing action has a token cost - this skill minimizes it through progres
 smart format selection, and backend-aware strategies.
 
 **Target versions** (May 2026):
-- Lightpanda: 0.2.8
-- @playwright/mcp: 0.0.70
-- agent-browser: 0.24.0
+- Lightpanda: 0.2.9
+- @playwright/mcp: 0.0.72
+- agent-browser: 0.26.0
 
 ## When to use
 
@@ -95,7 +95,6 @@ the task isn't present, skip straight to the next tier rather than failing mid-w
 - Record URL and access date for facts likely to change.
 - Clear cookies/storage between unrelated accounts or tenants.
 - Do not automate destructive account actions unless the user names the exact action and target.
-- Use semantic roles before CSS selectors.
 
 ---
 
@@ -358,7 +357,7 @@ periodically by verifying a known authenticated-only element is still visible.
 **Session persistence by backend:**
 - **Lightpanda MCP / Playwright MCP**: session persists within the MCP connection
 - **Lightpanda CLI fetch**: no persistence between calls (use `serve` mode for multi-step auth)
-- **agent-browser**: session-based with `--session` flag
+- `agent-browser`: session-based with `--session` flag
 
 For session isolation, CSRF-sensitive actions, and multi-tenant account handling, read
 `references/authenticated-browsing.md`.
@@ -373,7 +372,7 @@ fastest path to full browsing capability with minimal overhead.
 **Lightpanda MCP setup** (one-time, ~30 seconds):
 ```bash
 # Install the binary (see references/tool-setup.md for other architectures)
-curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.8/lightpanda-x86_64-linux
+curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.9/lightpanda-x86_64-linux
 chmod +x lightpanda && mv lightpanda ~/.local/bin/
 ```
 

--- a/skills/browse/references/authenticated-browsing.md
+++ b/skills/browse/references/authenticated-browsing.md
@@ -1,0 +1,33 @@
+# Authenticated Browsing
+
+## User Consent
+
+Use account context only when the user asked for an authenticated page or explicitly approved using
+an existing session. Authentication grants read access, not broad permission to mutate account
+state.
+
+## Session Reuse
+
+Reuse a session for a single task flow. Before acting, verify which account, tenant, workspace, or
+organization is active if the page exposes that information.
+
+## Cookie Isolation
+
+Clear cookies, local storage, and session storage between unrelated accounts or tenants. Do not mix
+personal and work sessions in one browser context.
+
+## CSRF-Sensitive Actions
+
+Authentication grants read access, not permission to mutate account state. Treat saves, deletes,
+purchases, posts, messages, and permission changes as destructive unless the user explicitly asked
+for that exact action.
+
+## Multi-Tenant Accounts
+
+Confirm the tenant selector, organization name, or workspace before extracting tenant-specific
+data. If the target tenant is ambiguous, ask rather than guessing from the current page.
+
+## Cleanup
+
+After the task, close the browser context or clear storage when the session is no longer needed.
+Never print cookies, bearer tokens, CSRF tokens, or recovery codes in the final answer.

--- a/skills/browse/references/extraction-patterns.md
+++ b/skills/browse/references/extraction-patterns.md
@@ -1,0 +1,39 @@
+# Extraction Patterns
+
+## Static Extraction
+
+Use WebFetch, curl, or `lightpanda fetch` when content is present in the initial HTML. Strip
+navigation and boilerplate before returning results.
+
+If a site exposes JSON-LD, OpenGraph metadata, a documented API, or a downloadable CSV, prefer that
+structured source before scraping rendered text.
+
+## JavaScript Extraction
+
+Use a rendering backend when static fetch returns an empty shell or missing data. Wait for a
+specific selector when possible; use network idle only when the page has no stable target.
+
+## Screenshots
+
+Take screenshots when layout, rendered state, charts, maps, or visual defects matter. Capture a DOM
+or accessibility snapshot first so the screenshot has a clear target and can be scoped.
+
+## Structured Data
+
+Prefer documented APIs, JSON-LD, OpenGraph, embedded JSON, or DOM selectors over scraping prose.
+Return normalized fields with source URL and access date when the values can change.
+
+## Tables
+
+Look for downloadable CSV/XLSX links first. If scraping a table, preserve headers, units, row order,
+and footnotes. Avoid regex over rendered markdown when DOM rows are available.
+
+## Pagination
+
+Extract one page, process it, then advance using the visible next control or stable query
+parameter. Cap page count and stop when the requested data is found or no new rows appear.
+
+## Source Attribution
+
+For facts likely to change, record the URL, access date, and whether the value came from an API,
+metadata, DOM extraction, screenshot, or rendered text.

--- a/skills/browse/references/tool-setup.md
+++ b/skills/browse/references/tool-setup.md
@@ -13,15 +13,15 @@ Headless browser built from scratch in Zig with V8. Single static binary, no dep
 
 ```bash
 # Linux x86_64
-curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.8/lightpanda-x86_64-linux
+curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.9/lightpanda-x86_64-linux
 chmod +x lightpanda && sudo mv lightpanda /usr/local/bin/
 
 # Linux aarch64
-curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.8/lightpanda-aarch64-linux
+curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.9/lightpanda-aarch64-linux
 chmod +x lightpanda && sudo mv lightpanda /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.8/lightpanda-aarch64-macos
+curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.9/lightpanda-aarch64-macos
 chmod +x lightpanda && sudo mv lightpanda /usr/local/bin/
 
 # Docker
@@ -125,7 +125,7 @@ or WebKit. Higher token cost than Lightpanda but complete Web API coverage.
 ```bash
 # As Claude Code plugin (if available in your plugin marketplace)
 # Or standalone:
-npx @playwright/mcp@0.0.70
+npx @playwright/mcp@0.0.72
 ```
 
 ### Key Tools
@@ -180,7 +180,7 @@ built-in reasoning.
 ### Installation
 
 ```bash
-npx agent-browser@0.24.0
+npx agent-browser@0.26.0
 # or: npm install -g agent-browser
 ```
 

--- a/skills/browse/references/tool-setup.md
+++ b/skills/browse/references/tool-setup.md
@@ -109,6 +109,10 @@ Resources: `mcp://page/html`, `mcp://page/markdown`
 - AGPL-3.0 license - share source if running as a modified service
 - Telemetry enabled by default (`LIGHTPANDA_DISABLE_TELEMETRY=true` to disable)
 
+For authenticated work, prefer the MCP or CDP server modes over one-shot `fetch` so cookies,
+local storage, redirects, and CSRF tokens stay in one browser context. Clear storage between
+unrelated tenants or accounts.
+
 ---
 
 ## Playwright MCP
@@ -153,6 +157,9 @@ npx @playwright/mcp@0.0.70
 - File upload/download
 - Dialog handling (alert, confirm, prompt)
 - Sites that block non-standard user agents
+
+For screenshots, take a DOM or accessibility snapshot first and screenshot only the page or
+element that needs visual evidence. Avoid base64 screenshots when text extraction is enough.
 
 ### Token cost comparison
 

--- a/skills/cluster-health/SKILL.md
+++ b/skills/cluster-health/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: cluster-health
+description: >
+  · Check Kubernetes cluster health with read-only diagnostics. Triggers: 'cluster health',
+  'health check', 'cluster status', 'diagnostics', 'post-maintenance check', 'node status'.
+  Not for manifests or IaC (use kubernetes).
+license: MIT
+compatibility: "Requires kubectl. Optional: helm, jq, openssl, dig, ssh"
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-03-30"
+  effort: high
+  argument_hint: "[context-or-alias] [timewindow]"
+---
+
+# Cluster Health
+
+Run read-only Kubernetes health checks and report cluster status with evidence. This skill works
+without private overlays by requiring an explicit kube context or confirmed current context.
+Local users may add ignored protected overlays for aliases and environment-specific checks.
+
+## When to use
+
+- User asks to check cluster health, status, diagnostics, node status, or post-maintenance state
+- Verifying cluster-wide symptoms after upgrades, reboots, Helm changes, GitOps syncs, or incidents
+- Gathering read-only evidence across nodes, workloads, events, ingress, storage, logs, and policy
+- Producing a short traffic-light report from Kubernetes and related observability signals
+
+## When NOT to use
+
+- Writing or reviewing Kubernetes manifests - use **kubernetes**
+- Writing Helm charts, Kustomize overlays, or IaC - use **kubernetes** or **terraform**
+- Changing resources, restarting pods, deleting objects, or applying fixes - ask for explicit escalation
+- Debugging one application deeply after the broad sweep identifies it - use the relevant domain skill
+
+---
+
+## AI Self-Check
+
+Before running checks or reporting results, verify:
+
+- [ ] Target context is explicit or the current context was confirmed
+- [ ] Every `kubectl` command includes `--context <context>`
+- [ ] Every `helm` command includes `--kube-context <context>`
+- [ ] Commands are read-only: no apply, patch, delete, edit, rollout restart, scale, cordon, drain, or exec unless the user explicitly escalates
+- [ ] Output is capped with `head`, `tail`, `--since`, `--field-selector`, or selectors
+- [ ] Time window is bounded and stated in the report
+- [ ] Protected registry contents are not printed unless the user asks for those exact details
+- [ ] Findings include evidence, impact, and next action
+
+---
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Cluster target explicit**: kubeconfig context, namespace, and environment are named before any query
+- [ ] **Read-only posture kept**: health checks do not mutate resources or restart workloads unless the user explicitly escalates
+
+## Cluster Registry
+
+This public skill has no built-in private cluster registry.
+
+1. If `protected/registry.md` exists, read it and use its alias, context, CWD pattern, and reference
+   mappings.
+2. If no protected registry exists, require an explicit kube context or ask before using the current
+   context.
+3. Never guess a cluster from a vague request.
+4. Never print protected registry contents in public reports unless the user asks for those exact
+   details.
+
+## Usage
+
+```
+cluster-health [context-or-alias] [timewindow]
+```
+
+- `context-or-alias` is a kube context, current-context confirmation, or protected overlay alias.
+- `timewindow` defaults to `2h`; use bounded values such as `30m`, `1h`, `2h`, `6h`, or `24h`.
+
+## Workflow
+
+### Step 1: Resolve target
+
+If a protected registry maps the request or current directory to an alias, use that mapping. If no
+mapping exists, require an explicit kube context or ask whether to use `kubectl config current-context`.
+
+### Step 2: Confirm read-only scope
+
+State the context and time window before running commands. Do not run mutation commands as part of
+this skill.
+
+### Step 3: Run the generic sweep
+
+Start with the cluster-wide checks in `references/kubernetes-core.md`, then load additional
+references based on the symptom:
+
+- networking or certificate symptoms -> `references/networking-ingress.md`
+- release or reconciliation symptoms -> `references/helm-gitops.md`
+- pending pods or volume symptoms -> `references/storage.md`
+- noisy errors or alert symptoms -> `references/monitoring-logs.md`
+- policy, RBAC, or image-risk symptoms -> `references/security.md`
+
+### Step 4: Classify findings
+
+Use GREEN for healthy signals, YELLOW for degraded or ambiguous state, and RED for user-visible
+outage, data-risk, or control-plane risk. Distinguish transient rollout noise from persistent
+degradation.
+
+### Step 5: Report
+
+Return a concise report:
+
+```markdown
+# Cluster Health Report - <context> (<timewindow>, YYYY-MM-DD HH:MM)
+
+## Summary
+- STATUS: GREEN|YELLOW|RED
+- Scope: <contexts, namespaces, time window>
+- Key findings: <short bullets>
+
+## Evidence
+- <area>: <command or source> -> <observed signal>
+
+## Next Actions
+- <read-only follow-up or explicit escalation request>
+```
+
+## Reference Files
+
+- `references/kubernetes-core.md` - nodes, workloads, events, namespaces, and resource pressure
+- `references/helm-gitops.md` - Helm releases, GitOps controllers, and reconciliation state
+- `references/networking-ingress.md` - services, ingress, load balancers, DNS, and certificates
+- `references/storage.md` - PVs, PVCs, CSI drivers, storage classes, and volume attachment
+- `references/monitoring-logs.md` - alerts, metrics availability, log triage, and noisy namespaces
+- `references/security.md` - read-only checks for RBAC, secrets exposure signals, image risk, and policy engines
+
+## Related Skills
+
+- **kubernetes** - write or review manifests, Helm charts, Kustomize, and GitOps config
+- **networking** - debug DNS, routing, proxies, VPNs, and Linux networking
+- **security-audit** - review security controls or vulnerability posture beyond read-only cluster signals
+- **terraform** - change infrastructure definitions or state
+
+## Rules
+
+1. Read only. Do not mutate cluster state unless the user explicitly changes the task.
+2. Use `--context <context>` on every `kubectl` command and `--kube-context <context>` on every `helm` command.
+3. Cap output before putting it in context.
+4. Never guess a cluster target from a vague request.
+5. Keep protected overlay details out of public reports unless the user asks for those exact details.
+6. Report failed checks as findings; do not hide missing tools, missing CRDs, or permission errors.

--- a/skills/cluster-health/SKILL.md
+++ b/skills/cluster-health/SKILL.md
@@ -59,13 +59,31 @@ Before running checks or reporting results, verify:
 
 This public skill has no built-in private cluster registry.
 
-1. If `protected/registry.md` exists, read it and use its alias, context, CWD pattern, and reference
-   mappings.
-2. If no protected registry exists, require an explicit kube context or ask before using the current
+Users may create local-only overlays under `skills/cluster-health/protected/` for private lab,
+homelab, work, or customer cluster details. The directory is gitignored by this collection. If it
+exists in the installed skill, read it while using this skill. A user can ask their agent to create
+or update these files.
+
+Suggested local layout:
+
+```text
+protected/
+  registry.md            # aliases, kube contexts, CWD patterns, profile mappings
+  private-patterns.txt   # terms that must never appear in public files
+  <cluster-or-env>.md    # local namespaces, runbooks, dashboards, thresholds
+```
+
+1. If `protected/registry.md` exists, read it first and use its alias, context, CWD pattern, and
+   reference mappings.
+2. If the registry maps the target to `protected/<cluster-or-env>.md`, read that profile before
+   running checks.
+3. If no protected registry exists, require an explicit kube context or ask before using the current
    context.
-3. Never guess a cluster from a vague request.
-4. Never print protected registry contents in public reports unless the user asks for those exact
+4. Never guess a cluster from a vague request.
+5. Never print protected registry contents in public reports unless the user asks for those exact
    details.
+6. Treat gitignored as local privacy, not encryption. Do not put protected overlays in shared logs,
+   issues, PR comments, or public reports.
 
 ## Usage
 

--- a/skills/cluster-health/references/helm-gitops.md
+++ b/skills/cluster-health/references/helm-gitops.md
@@ -1,0 +1,32 @@
+# Helm and GitOps
+
+## Purpose
+
+Check release state, failed upgrades, and GitOps reconciliation without changing resources.
+
+## Commands
+
+```bash
+helm --kube-context <context> list -A --all --max 100
+helm --kube-context <context> history <release> -n <namespace> --max 10
+kubectl --context <context> get applications.argoproj.io -A 2>/dev/null | head -n 80 || true
+kubectl --context <context> get kustomizations.toolkit.fluxcd.io -A 2>/dev/null | head -n 80 || true
+kubectl --context <context> get helmreleases.helm.toolkit.fluxcd.io -A 2>/dev/null | head -n 80 || true
+kubectl --context <context> get events -A --field-selector type=Warning --sort-by=.lastTimestamp | tail -n 80
+```
+
+## Criteria
+
+- GREEN: releases deployed, GitOps resources synced or ready, no recent warning burst.
+- YELLOW: one failed or pending release with no broad user impact; reconciliation delayed.
+- RED: repeated failed reconciliations, failed release for critical workloads, widespread drift.
+
+## Common False Positives
+
+- CRDs absent because the cluster does not use that GitOps controller.
+- Intentionally suspended GitOps resources.
+- Helm history showing old failed revisions after a later successful rollback or upgrade.
+
+## Output Caps
+
+Use `--max`, `head`, and `tail`. Inspect one release at a time after the broad list identifies it.

--- a/skills/cluster-health/references/kubernetes-core.md
+++ b/skills/cluster-health/references/kubernetes-core.md
@@ -1,0 +1,34 @@
+# Kubernetes Core
+
+## Purpose
+
+Check generic cluster health: nodes, namespaces, workloads, events, and resource pressure.
+
+## Commands
+
+```bash
+kubectl --context <context> get nodes -o wide
+kubectl --context <context> describe nodes | tail -n 120
+kubectl --context <context> get namespaces
+kubectl --context <context> get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded | head -n 80
+kubectl --context <context> get events -A --sort-by=.lastTimestamp | tail -n 80
+kubectl --context <context> top nodes 2>/dev/null || true
+kubectl --context <context> top pods -A --containers 2>/dev/null | head -n 80 || true
+```
+
+## Criteria
+
+- GREEN: nodes Ready, no broad pending/crashing workload pattern, recent events are routine.
+- YELLOW: isolated NotReady node, repeated warnings in one namespace, metrics unavailable.
+- RED: multiple NotReady nodes, control-plane symptoms, many CrashLoopBackOff or Pending pods.
+
+## Common False Positives
+
+- Short-lived rollout pods during deployments.
+- Completed jobs outside the requested time window.
+- Metrics server missing on small clusters.
+
+## Output Caps
+
+Use `head -n 80`, `tail -n 120`, label selectors, and field selectors. Avoid full `describe` output
+unless narrowing to one namespace, pod, or node.

--- a/skills/cluster-health/references/monitoring-logs.md
+++ b/skills/cluster-health/references/monitoring-logs.md
@@ -1,0 +1,32 @@
+# Monitoring and Logs
+
+## Purpose
+
+Check alert signals, metrics availability, recent logs, and noisy namespaces with bounded output.
+
+## Commands
+
+```bash
+kubectl --context <context> get pods -A | grep -Ei 'prometheus|grafana|alertmanager|loki|tempo|metrics' | head -n 80 || true
+kubectl --context <context> top nodes 2>/dev/null || true
+kubectl --context <context> top pods -A 2>/dev/null | head -n 80 || true
+kubectl --context <context> logs -n <namespace> deploy/<app> --since=<timewindow> --tail=120 2>/dev/null || true
+kubectl --context <context> get events -A --field-selector type=Warning --sort-by=.lastTimestamp | tail -n 100
+```
+
+## Criteria
+
+- GREEN: metrics available, monitoring pods healthy, logs show no repeated current errors.
+- YELLOW: metrics unavailable, one noisy namespace, alerting stack partially degraded.
+- RED: monitoring unavailable during incident, repeated errors from critical workloads, alert flood.
+
+## Common False Positives
+
+- Metrics APIs absent in small or local clusters.
+- Normal startup warnings during rolling updates.
+- Log lines from previous container instances outside the requested time window.
+
+## Output Caps
+
+Always use `--since=<timewindow>` and `--tail`. Summarize repeated lines with counts instead of
+including full logs.

--- a/skills/cluster-health/references/networking-ingress.md
+++ b/skills/cluster-health/references/networking-ingress.md
@@ -1,0 +1,33 @@
+# Networking and Ingress
+
+## Purpose
+
+Check services, ingress, load balancers, DNS, and certificates using read-only commands.
+
+## Commands
+
+```bash
+kubectl --context <context> get svc -A -o wide | head -n 120
+kubectl --context <context> get ingress -A -o wide | head -n 120
+kubectl --context <context> describe ingress -n <namespace> <ingress> | tail -n 120
+kubectl --context <context> get endpointslices -A | head -n 120
+kubectl --context <context> get events -A --field-selector type=Warning --sort-by=.lastTimestamp | tail -n 80
+dig +short <hostname> 2>/dev/null || true
+echo | openssl s_client -servername <hostname> -connect <hostname>:443 2>/dev/null | openssl x509 -noout -dates -issuer -subject
+```
+
+## Criteria
+
+- GREEN: services have endpoints, ingress addresses exist, DNS resolves, certificates are valid.
+- YELLOW: one ingress missing address, stale endpoint on non-critical service, certificate near expiry.
+- RED: no endpoints for a critical service, DNS failure, expired certificate, or load balancer absent.
+
+## Common False Positives
+
+- Headless services intentionally have no load balancer.
+- Internal-only hostnames may not resolve from the current network.
+- Certificate checks fail when split-horizon DNS requires running from inside the network.
+
+## Output Caps
+
+Use `head -n 120` for broad lists and `describe` only the suspect ingress, service, or endpoint.

--- a/skills/cluster-health/references/security.md
+++ b/skills/cluster-health/references/security.md
@@ -1,0 +1,34 @@
+# Security
+
+## Purpose
+
+Run read-only checks for RBAC, secret exposure signals, image risk, and policy engines.
+
+## Commands
+
+```bash
+kubectl --context <context> auth can-i --list --as=system:serviceaccount:<namespace>:<serviceaccount> -n <namespace> | head -n 120
+kubectl --context <context> get clusterrolebindings,rolebindings -A | head -n 120
+kubectl --context <context> get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{range .spec.containers[*]}{.image}{" "}{end}{"\n"}{end}' | head -n 120
+kubectl --context <context> get networkpolicies -A | head -n 120
+kubectl --context <context> get validatingadmissionpolicies,mutatingadmissionpolicies 2>/dev/null | head -n 80 || true
+kubectl --context <context> get constrainttemplates,constraints -A 2>/dev/null | head -n 80 || true
+kubectl --context <context> get policies.kyverno.io,clusterpolicies.kyverno.io -A 2>/dev/null | head -n 80 || true
+```
+
+## Criteria
+
+- GREEN: expected policy engines healthy, no obvious privileged binding sprawl, images pinned enough for review.
+- YELLOW: broad bindings need review, policy engine CRDs absent, many mutable image tags.
+- RED: unexpected cluster-admin bindings, public secret exposure indicators, policy engine down when required.
+
+## Common False Positives
+
+- Cluster-admin bindings used by managed control-plane components.
+- Mutable tags in development namespaces.
+- Missing policy CRDs on clusters that intentionally do not use that engine.
+
+## Output Caps
+
+Use `head` and namespace filters. Never print secret values; list secret names and metadata only when
+needed.

--- a/skills/cluster-health/references/storage.md
+++ b/skills/cluster-health/references/storage.md
@@ -1,0 +1,33 @@
+# Storage
+
+## Purpose
+
+Check PVs, PVCs, storage classes, CSI components, and volume attachment state.
+
+## Commands
+
+```bash
+kubectl --context <context> get storageclass
+kubectl --context <context> get pv | head -n 120
+kubectl --context <context> get pvc -A | head -n 120
+kubectl --context <context> get volumeattachments.storage.k8s.io | head -n 120
+kubectl --context <context> get pods -A -o wide | grep -Ei 'csi|storage|provisioner' | head -n 80 || true
+kubectl --context <context> get events -A --field-selector type=Warning --sort-by=.lastTimestamp | grep -Ei 'volume|mount|attach|provision' | tail -n 80 || true
+```
+
+## Criteria
+
+- GREEN: PVCs Bound, PVs Available or Bound as expected, CSI pods healthy.
+- YELLOW: isolated Pending PVC, warning events for one namespace, old Released PV needing review.
+- RED: many Pending PVCs, attach/mount failures for active workloads, CSI controller degraded.
+
+## Common False Positives
+
+- Released PVs retained intentionally by reclaim policy.
+- Pending PVCs from disabled or paused workloads.
+- Storage events from completed jobs outside the requested time window.
+
+## Output Caps
+
+Use `head`, `tail`, and namespace filters. Do not describe every PV or PVC unless the broad list
+identifies a small suspect set.

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 # Deep Audit: Wave-Based Repo Orchestrator
 
-Run up to 27 custom skills against a repo in 5 sequential waves, presenting results
+Run up to 28 custom skills against a repo in 5 sequential waves, presenting results
 progressively. Wave 1 detects the tech stack. Waves 2-5 dispatch only the skills that
 match. Each wave completes and reports before the next begins.
 
@@ -117,7 +117,7 @@ If the user specified a scope, pass it as the script's first argument to filter 
 to that subtree (`git ls-files -- path/to/scope` instead of the full repo).
 
 After detection, present the recon summary before proceeding. Compute
-`{unmatched_skills}` as the 19 Wave 3 candidates minus the matched set.
+`{unmatched_skills}` as the 20 Wave 3 candidates minus the matched set.
 Compute `{count}` by summing: 3 (Wave 2) + matched Wave 3 skills + 2 (Wave 4) +
 3 (Wave 5). Example: if 6 Wave 3 skills match, count = 3 + 6 + 2 + 3 = 14.
 
@@ -151,19 +151,19 @@ Skills that will run:
 Total agents: {count}
 ```
 
-Concrete example for a Node+Postgres+Docker+K8s repo with i18n and GitHub Actions (8 Wave 3 skills matched out of 19):
+Concrete example for a Node+Postgres+Docker+K8s repo with i18n, frontend code, and GitHub Actions (9 Wave 3 skills matched out of 20):
 
 ```
 Repo: myorg/api @ a3f91c2 (main)  |  Files: 412  |  Scope: full codebase
 Languages: TypeScript, SQL, YAML
 
 Wave 2 (always): code-review, anti-slop, anti-ai-prose
-Wave 3 (detected): testing, command-prompt, databases, backend-api, localize, docker, kubernetes, ci-cd
+Wave 3 (detected): testing, command-prompt, databases, backend-api, frontend-design, localize, docker, kubernetes, ci-cd
 Wave 3 (skipped): terraform, ansible, networking, ai-ml, mcp, arch-btw, debian-ubuntu, rhel-fedora, nixos-btw, firewall-appliance, virtualization
 Wave 4 (always): security-audit, zero-day
 Wave 5 (always): update-docs, roadmap, git
 
-Total agents: 3 + 8 + 2 + 3 = 16
+Total agents: 3 + 9 + 2 + 3 = 17
 ```
 
 ### Step 2: Code Quality (Wave 2)
@@ -234,6 +234,7 @@ Scope: {scope}. Return the complete report.
 |-------|---------|
 | `testing` | Audit test quality, coverage gaps, flaky test patterns, and missing test scenarios. Do not write new tests - report only. |
 | `command-prompt` | Audit shell scripts, dotfile config, and .env patterns for correctness, portability, and security. |
+| `frontend-design` | Audit frontend UI/UX implementation, visual hierarchy, accessibility, responsive behavior, framework drift, and AI design tells. Do not redesign or edit - report only. |
 | `localize` | Audit i18n completeness. Find hardcoded user-facing strings, validate locale catalogs, check for missing translations. |
 | `ci-cd` | Audit pipeline config for security (SHA pinning, secret exposure), efficiency, and correctness. |
 
@@ -242,7 +243,7 @@ All other skills use the generic prompt.
 Present results:
 
 ```markdown
-## Wave 3: Domain-Specific [{N} of 19 skills matched]
+## Wave 3: Domain-Specific [{N} of 20 skills matched]
 
 ### {Skill Display Name}
 {report verbatim}
@@ -470,7 +471,7 @@ but preserves the wave ordering.
 - **code-review**, **anti-slop**, **anti-ai-prose** - Wave 2 participants.
 - **security-audit**, **zero-day** - Wave 4 participants.
 - **update-docs**, **roadmap**, **git** - Wave 5 participants.
-- **testing**, **command-prompt**, **databases**, **backend-api**, **localize**, **ai-ml**, **mcp**, **docker**, **kubernetes**, **terraform**, **ansible**, **ci-cd**, **networking**, **arch-btw**, **debian-ubuntu**, **rhel-fedora**, **nixos-btw**, **firewall-appliance**, **virtualization** - Wave 3 candidates (conditional).
+- **testing**, **command-prompt**, **databases**, **backend-api**, **frontend-design**, **localize**, **ai-ml**, **mcp**, **docker**, **kubernetes**, **terraform**, **ansible**, **ci-cd**, **networking**, **arch-btw**, **debian-ubuntu**, **rhel-fedora**, **nixos-btw**, **firewall-appliance**, **virtualization** - Wave 3 candidates (conditional).
 - **skill-creator** - audits the skill collection. This skill audits application repos.
 
 Read `references/exclusions.md` before changing Wave 3 routing.

--- a/skills/deep-audit/references/detection-patterns.md
+++ b/skills/deep-audit/references/detection-patterns.md
@@ -17,6 +17,7 @@ its domain isn't actually present.
 | command-prompt | `*.sh`, `*.bash`, `*.zsh`, `Makefile`, `justfile`, `.envrc`, `scripts/` | Shebang detection (`#!/bin/bash` in extensionless files) is not implemented in the script - file-extension and directory patterns cover the common cases |
 | databases | `*.sql`, `migrations/`, `*.prisma`, `schema.prisma`, `knexfile.*`, `alembic/`, `alembic.ini`, `flyway/`, `drizzle.config.*`, `mongod.conf`, `my.cnf`, `pg_hba.conf`, `pgbouncer.ini` | `sequelize`, `typeorm`, `prisma`, `knex`, `drizzle-orm`, `mongoose`, `pg`, `mysql2` |
 | backend-api | `openapi.*`, `swagger.*` | `fastapi`, `flask`, `django`, `express`, `@nestjs/core`, `hono`, `elysia`, `@hono/node-server` |
+| frontend-design | `astro.config.*`, `svelte.config.*`, `next.config.*`, `vite.config.*`, `tailwind.config.*`, `src/app/`, `src/pages/`, `src/routes/`, `app/`, `pages/`, `components/`, `*.css`, `*.scss`, `*.sass`, `*.tsx`, `*.jsx`, `*.svelte`, `*.astro`, `*.vue` | `astro`, `@sveltejs/kit`, `svelte`, `next`, `react`, `vue`, `vite`, `tailwindcss`, `@vitejs/plugin-react`, `@astrojs/*` |
 | localize | `locales/`, `i18n/`, `*.po`, `*.pot`, `*.xliff`, `*.xlf`, `messages.*.json`, `messages.*.yaml` | `react-i18next`, `vue-i18n`, `next-intl`, `@formatjs/intl`, `i18next` |
 | ai-ml | - | `anthropic`, `openai`, `langchain`, `llama-index`, `llama_index`, `transformers`, `torch`, `tensorflow`, `ollama`, `chromadb`, `pinecone-client`, `weaviate-client`, `qdrant-client` |
 | mcp | `.mcp.json`, `mcp.json` | `@modelcontextprotocol/sdk`, `fastmcp` |
@@ -72,6 +73,10 @@ echo "$files" | grep -qE '\.sql$|migrations/|\.prisma$|knexfile\.|alembic|flyway
 # backend-api (file patterns)
 echo "$files" | grep -qE 'openapi\.|swagger\.' \
   && matched+=(backend-api)
+
+# frontend-design
+echo "$files" | grep -qE 'astro\.config|svelte\.config|next\.config|vite\.config|tailwind\.config|(^|/)(src/)?(app|pages|routes)/|(^|/)components/|\.(css|scss|sass|tsx|jsx|svelte|astro|vue)$' \
+  && matched+=(frontend-design)
 
 # localize
 echo "$files" | grep -qE 'locales/|i18n/|\.po$|\.pot$|\.xliff$|\.xlf$|messages\.[a-z].*\.json$|messages\.[a-z].*\.yaml$' \
@@ -153,6 +158,7 @@ check_manifest() {
 }
 
 check_manifest backend-api 'fastapi|flask|django|"express"|@nestjs/core|"hono"|"elysia"'
+check_manifest frontend-design 'astro|@sveltejs/kit|"svelte"|next|react|vue|vite|tailwindcss|@vitejs/plugin-react|@astrojs/'
 check_manifest databases 'sequelize|typeorm|prisma|"knex"|drizzle-orm|mongoose|"pg"|mysql2'
 check_manifest localize 'react-i18next|vue-i18n|next-intl|@formatjs|i18next'
 check_manifest ai-ml 'anthropic|openai|langchain|llama[-_]index|transformers|torch|tensorflow|ollama|chromadb|pinecone|weaviate|qdrant'

--- a/skills/deep-audit/references/exclusions.md
+++ b/skills/deep-audit/references/exclusions.md
@@ -6,11 +6,14 @@ so future contributors do not re-add them by reflex.
 | Skill | Reason for exclusion |
 |---|---|
 | **browse** | Operational tool (fetch a page, fill a form). Not an audit lens. |
+| **cluster-health** | Live Kubernetes diagnostics. Requires an explicit cluster context and may load local protected overlays; repo-side K8s files are covered by kubernetes in Wave 3. |
 | **dev-cycle** | Workflow orchestrator (start-to-finish dev: branch -> ship). Acts on the repo; does not audit it. |
 | **prompt-generator** | Creative authoring of LLM prompts. Produces content; does not evaluate code. |
 | **routine-writer** | Creative authoring of cloud-routine prompts. Same shape as prompt-generator. |
 | **skill-creator** | Audits the skill collection itself, not application code. Use Mode 3 of skill-creator separately. |
 | **skill-refiner** | Batch-improves skill collections via eval loops. Same domain as skill-creator. |
+| **skill-router** | Meta routing helper for choosing skills. Deep-audit already owns dispatch routing. |
+| **jekyll-hyde** | Strategic decision review. Useful after audit results exist, but not a file-pattern audit lens. |
 | **lockpick** | Offensive security / CTF / privesc. Different threat model from defensive audit; security-audit + zero-day cover the defensive side. |
 | **kali-linux** | Live-system administration of Kali. Kali is Debian-based, so repo-side packaging concerns are caught by debian-ubuntu in Wave 3. The skill itself is for running Kali, not auditing repos. |
 | **full-review** | Alternate orchestrator (the smaller 4-skill version). Mutually exclusive with deep-audit by design. |

--- a/skills/docker/references/alternative-runtimes.md
+++ b/skills/docker/references/alternative-runtimes.md
@@ -245,10 +245,10 @@ skopeo list-tags docker://ghcr.io/org/myapp
 
 Low-level container runtime. Kubernetes uses it directly. Docker Engine uses it under the hood.
 
-### Key facts (March 2026)
+### Key facts (May 2026)
 
-- **containerd 2.2.2** is the latest stable release (March 2026)
-- **containerd 2.3** (April 2026) will be the first annual LTS release, supported for 2+ years
+- **containerd 2.3.0** was released in April 2026 as the first annual LTS release, supported for 2+ years
+- **containerd 2.2.3** remains a supported 2.2 patch release through November 2026
 - **K8s 1.36+** will require containerd 2.0+ (1.x support dropped)
 - containerd 2.0 removed Docker-schemaV1 image support, CRI v1alpha2, and several deprecated APIs
 - Migration from 1.6/1.7 to 2.0 is supported with built-in migration tools

--- a/skills/docker/references/dockerfile-patterns.md
+++ b/skills/docker/references/dockerfile-patterns.md
@@ -117,7 +117,7 @@ Attestations are stored in the registry alongside the image. Requires `--push`.
 
 \* Chainguard dev variants include shell; prod variants don't.
 
-**Choose Chainguard** for: zero-CVE at build time, built-in SBOM + Sigstore, nightly rebuilds, glibc compat, PCI/regulatory compliance. 2000+ images available as of Feb 2026.
+**Choose Chainguard** for: zero-CVE at build time, built-in SBOM + Sigstore, nightly rebuilds, glibc compat, PCI/regulatory compliance. 2000+ images available as of May 2026 recheck.
 
 **Choose Alpine** when: you need a shell, all deps work with musl, image size is top priority.
 

--- a/skills/firewall-appliance/references/plugins.md
+++ b/skills/firewall-appliance/references/plugins.md
@@ -6,7 +6,7 @@ inspect via `pkg info <name>` and check `/usr/local/etc/` for their configs.
 ## Security
 
 ### os-crowdsec (CrowdSec)
-Local LAPI + bouncer (v1.7.6 as of March 2026). Parses logs locally, applies local bans + crowd-sourced blocklists.
+Local LAPI + bouncer (verify OPNsense package with `pkg info os-crowdsec`; upstream CrowdSec v1.7.7 as of May 2026 recheck). Parses logs locally, applies local bans + crowd-sourced blocklists.
 
 **Two separate enforcement layers:**
 - **Local decisions** (`crowdsec_blacklists` pf table): IPs your firewall detected and banned

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -19,12 +19,12 @@ This skill replaces the upstream generic `frontend-design` skill in this collect
 
 **Target versions** (May 2026 - pinned so staleness is visible):
 
-- Astro 6.1.9 (Astro 5.17 also production-ready)
-- SvelteKit 2.58 + Svelte 5 runes
+- Astro 6.2.1 (Astro 5.17 also production-ready)
+- SvelteKit 2.58.0 + Svelte 5.55.5 runes
 - Tailwind CSS v4.2.4
-- Vite 8.0
-- React 19.2 + Next.js 16 (heavier option, only when team is React-locked)
-- @use-gesture/react (modern; Hammer.js considered legacy)
+- Vite 8.0.10
+- React 19.2.5 + Next.js 16.2.4 (heavier option, only when team is React-locked)
+- @use-gesture/react 10.3.1 (modern; Hammer.js considered legacy)
 
 ## When to use
 
@@ -44,9 +44,8 @@ This skill replaces the upstream generic `frontend-design` skill in this collect
 - Prose tells in copy and docs - use **anti-ai-prose**
 - Backend API design (REST, OpenAPI, pagination) - use **backend-api**
 - Localization, i18n catalogues, hardcoded strings - use **localize**
-- Frontend testing strategy (Playwright, Vitest, a11y tests) - use **testing**
-- Playwright test authoring belongs to **testing**; this skill owns visual QA expectations and
-  screenshot review for UI changes
+- Frontend testing strategy and Playwright test authoring - use **testing**. This skill owns
+  visual QA expectations and screenshot review for UI changes
 
 ---
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -34,6 +34,8 @@ This skill replaces the upstream generic `frontend-design` skill in this collect
 - Picking a frontend stack for a small-to-medium project
 - Designing dark+light theme architecture together (not retrofitting one from the other)
 - Reviewing mobile + touch behavior on a desktop-first design
+- Designing React, Tailwind, or shadcn-based app UI without default-template drift
+- Designing app shells, dashboards, settings, forms, onboarding, and empty states
 
 ## When NOT to use
 
@@ -43,6 +45,8 @@ This skill replaces the upstream generic `frontend-design` skill in this collect
 - Backend API design (REST, OpenAPI, pagination) - use **backend-api**
 - Localization, i18n catalogues, hardcoded strings - use **localize**
 - Frontend testing strategy (Playwright, Vitest, a11y tests) - use **testing**
+- Playwright test authoring belongs to **testing**; this skill owns visual QA expectations and
+  screenshot review for UI changes
 
 ---
 
@@ -220,7 +224,20 @@ Severity scale:
 
 The rant section captures the persona's voice for the user; tickets are clean and actionable. Never ship a rant as tickets.
 
-### Step 7: Self-check before returning
+### Step 7: Responsive QA
+
+For any visual change, check:
+
+1. Desktop viewport - information density, hierarchy, and hover states
+2. Mobile viewport - touch targets, navigation, forms, and text wrapping
+3. Keyboard navigation - tab order, focus-visible, dialogs, and escape paths
+4. Dark and light theme - contrast, native controls, charts, and empty states
+5. Text overflow - long labels, narrow containers, translated-length copy, and button text
+6. Screenshot review - compare the rendered result against the intended hierarchy
+
+Test authoring lives in **testing**. This skill defines what visual QA must prove.
+
+### Step 8: Self-check before returning
 
 Run through the AI Self-Check below.
 
@@ -240,6 +257,8 @@ Before returning any built UI or critique, verify:
 - [ ] **Real framework verified** - Astro / SvelteKit / Vite / Next versions match the Target versions block. No "Next 14" or "Astro 4" in build output unless the user explicitly asked for legacy
 - [ ] **Files separated** - HTML / CSS / JS in their own files unless an explicit single-file constraint is stated in a code comment
 - [ ] **No invented CSS properties or framework APIs** - only verified Tailwind v4 utilities, real Svelte 5 runes (`$state`, `$derived`, `$effect`, `$props`), real Astro directives. AI invents `.bg-glass-700` and `$reactive` constantly
+- [ ] **App UI patterns fit the domain** - app shells, dashboards, settings, forms, onboarding, and empty states prioritize user work over marketing composition
+- [ ] **Responsive QA completed** - desktop, mobile, keyboard, dark+light, text overflow, and screenshot review checked when visual changes were made
 - [ ] **Critique mode: max 10 tickets** - RED + GREEN priority. Rant is filtered, not shipped raw
 - [ ] **No AI prose tells in commentary** - apply the **anti-ai-prose** vocabulary list to the persona's own writing, not just user-facing copy. Plain English
 
@@ -257,6 +276,7 @@ Before returning any built UI or critique, verify:
 - `references/themes.md` - dark+light architecture, CSS custom properties pattern, no-FOUC theme toggle. Read when starting any new build
 - `references/glitch-effects.md` - copy-paste CSS for tasteful glitch accents (RGB split, scanlines, type displacement) with reduced-motion fallbacks. Read when an interface is technical and glitch is appropriate
 - `references/mobile-touch.md` - Pointer Events, scroll-snap, swipe / pinch / long-press, `@use-gesture/react`, 44 px targets. Read for any UI with mobile or touch as a real surface
+- `references/app-ui-patterns.md` - app shells, dashboards, forms, settings, onboarding, and empty states. Read for logged-in tools or operational interfaces
 - `references/critique-template.md` - rant -> filter -> ticket flow. Read in critique mode
 
 ## Related Skills

--- a/skills/frontend-design/references/ai-tells.md
+++ b/skills/frontend-design/references/ai-tells.md
@@ -132,6 +132,17 @@ Each entry has: the tell, why it's a tell, and the specific replacement.
 
 **Replacement.** Skeleton loaders for content shape, spinner for unknown duration, progress bar for known duration. No sparkles unless an LLM is actually generating.
 
+### 12.5. shadcn default stack
+
+**Tell.** Every app becomes the same default shadcn cards, muted text, tables, and dropdowns with no
+domain-specific hierarchy.
+
+**Why.** shadcn is a component starting point, not a product direction. Unedited defaults make
+operations tools feel interchangeable.
+
+**Replacement.** Keep the accessible primitives, then redesign hierarchy, density, spacing, and
+state treatment around the actual domain.
+
 ---
 
 ## Iconography Tells

--- a/skills/frontend-design/references/app-ui-patterns.md
+++ b/skills/frontend-design/references/app-ui-patterns.md
@@ -1,0 +1,28 @@
+# App UI Patterns
+
+## App Shells
+
+Use stable navigation, predictable page titles, persistent primary actions, and constrained content
+widths. Avoid marketing hero structure inside logged-in tools.
+
+## Dashboards
+
+Prioritize scan speed, comparison, filtering, and drill-down paths. Show freshness and empty states.
+
+## Forms
+
+Use labels, inline validation, preserved user input, disabled/loading states, and clear recovery from
+server errors.
+
+## Settings
+
+Group by user mental model, make dangerous actions explicit, and separate read-only account facts
+from editable preferences.
+
+## Onboarding
+
+Focus on the first successful action. Avoid tours that describe obvious UI.
+
+## Empty States
+
+State what is empty, why it matters, and the next action. Do not use decorative card grids.

--- a/skills/frontend-design/references/frameworks.md
+++ b/skills/frontend-design/references/frameworks.md
@@ -1,6 +1,6 @@
 # Framework Picker
 
-Pinned to April 2026. Update versions when refreshing the skill. Hallucinating "Next.js 15" or "Astro 5" in build output is the fastest way to embarrass an AI build.
+Pinned to May 2026. Update versions when refreshing the skill. Hallucinating "Next.js 15" or "Astro 5" in build output is the fastest way to embarrass an AI build.
 
 The persona's bias: minimalist first. Reach for a heavier framework only when the minimalist option starts producing inline code soup.
 
@@ -9,10 +9,10 @@ The persona's bias: minimalist first. Reach for a heavier framework only when th
 ## Decision tree
 
 1. **No-build, single HTML file demo, codepen-style?** -> Plain HTML + CSS + JS, no framework. State the constraint at the top of the file.
-2. **Static content, marketing site, blog, docs?** -> **Astro 6.1.9** (or **Astro 5.17** if Astro 6 hasn't shipped a feature you need)
-3. **Interactive app, bundle size matters, you want runes?** -> **SvelteKit 2.58** + Svelte 5
-4. **Small app, no SSR needed, want Vite directly?** -> **Vite 8.0** + plain TypeScript or a thin layer (Lit, Solid, vanilla)
-5. **Team is React-locked or you genuinely need React's ecosystem?** -> **Next.js 16** + **React 19.2**
+2. **Static content, marketing site, blog, docs?** -> **Astro 6.2.1** (or **Astro 5.17** if Astro 6 hasn't shipped a feature you need)
+3. **Interactive app, bundle size matters, you want runes?** -> **SvelteKit 2.58.0** + Svelte 5.55.5
+4. **Small app, no SSR needed, want Vite directly?** -> **Vite 8.0.10** + plain TypeScript or a thin layer (Lit, Solid, vanilla)
+5. **Team is React-locked or you genuinely need React's ecosystem?** -> **Next.js 16.2.4** + **React 19.2.5**
 
 The persona pushes back on Next.js as a default. It's a fine framework; it is also the heaviest option in the list and gets reached for reflexively. If the answer to "why Next" is "because everyone uses it", that's not a reason.
 
@@ -21,7 +21,7 @@ when they fit.
 
 ---
 
-## Astro 6.1.9 (Cloudflare-owned since January 16, 2026)
+## Astro 6.2.1 (Cloudflare-owned since January 16, 2026)
 
 **When.** Content-heavy: marketing pages, docs, blogs, portfolios, landing sites, hybrid sites with islands of interactivity.
 
@@ -50,7 +50,7 @@ bun create astro@latest
 
 ---
 
-## SvelteKit 2.58 + Svelte 5
+## SvelteKit 2.58.0 + Svelte 5.55.5
 
 **When.** Interactive apps where bundle size and runtime cost matter. Apps where the team wants explicit reactivity.
 
@@ -89,7 +89,7 @@ bun create svelte@latest
 
 ---
 
-## Vite 8.0 + plain TS
+## Vite 8.0.10 + plain TS
 
 **When.** Small apps, demos, tools where you want a build but no framework opinions. Single-page tools, internal dashboards with one or two views.
 
@@ -116,7 +116,7 @@ bun create vite@latest
 
 ---
 
-## Next.js 16 + React 19.2
+## Next.js 16.2.4 + React 19.2.5
 
 **When.** Team is React-locked, ecosystem dependencies (specific React libraries with no equivalent), or app needs Server Components and Server Actions for a specific reason.
 
@@ -125,7 +125,7 @@ bun create vite@latest
 **Strengths.**
 
 - Turbopack stable (default bundler in Next 16) - dev startup ~50% faster
-- React Server Components, Server Actions; React 19.2 features (View Transitions, useEffectEvent, Activity)
+- React Server Components, Server Actions; React 19.2.5 features (View Transitions, useEffectEvent, Activity)
 - Cache Components with Partial Pre-Rendering and the `"use cache"` directive
 - Largest ecosystem of components, hooks, libraries
 - Vercel-tier hosting integration
@@ -137,7 +137,7 @@ bun create vite@latest
 - You want explicit reactivity (Svelte 5 runes are clearer)
 - Bundle size matters (Next is the heaviest in this list)
 
-**Note.** Next.js 15 is still maintained but Next.js 16 stable shipped October 21, 2025; 16.2 (March 18, 2026) is the latest. Use 16 for new projects. Middleware was renamed to `proxy.ts` in 16 to clarify the network boundary.
+**Note.** Next.js 15 is still maintained but Next.js 16 stable shipped October 21, 2025. Use 16.2.4 for new projects. Middleware was renamed to `proxy.ts` in 16 to clarify the network boundary.
 
 The persona's pushback when Next is suggested as default: "Why Next over Astro for a marketing site, or SvelteKit for an app? If the answer is 'we always use Next', the answer is wrong."
 

--- a/skills/frontend-design/references/frameworks.md
+++ b/skills/frontend-design/references/frameworks.md
@@ -16,6 +16,9 @@ The persona's bias: minimalist first. Reach for a heavier framework only when th
 
 The persona pushes back on Next.js as a default. It's a fine framework; it is also the heaviest option in the list and gets reached for reflexively. If the answer to "why Next" is "because everyone uses it", that's not a reason.
 
+React/Next is appropriate when the product or team is React-locked; otherwise choose lighter stacks
+when they fit.
+
 ---
 
 ## Astro 6.1.9 (Cloudflare-owned since January 16, 2026)

--- a/skills/git/references/forge-workflows.md
+++ b/skills/git/references/forge-workflows.md
@@ -253,8 +253,8 @@ does not cover yet (e.g. branch protection management).
 | Any with Rust | `cargo install forgejo-cli` or `cargo binstall forgejo-cli` |
 | Binaries | Releases tab on Codeberg (x86_64 Linux/Windows) |
 
-Verify: `fj --version` (should report 0.4.1+ as of March 2026; earlier releases have a PKCE
-bug that breaks `fj auth login`).
+Verify: `fj --version` (prefer 0.5.x or newer as of May 2026 recheck; releases before 0.4.1
+have a PKCE bug that breaks `fj auth login`).
 
 ### `fj` authentication
 

--- a/skills/git/references/forge-workflows.md
+++ b/skills/git/references/forge-workflows.md
@@ -246,7 +246,7 @@ does not cover yet (e.g. branch protection management).
 | Platform | Command |
 |----------|---------|
 | Arch / CachyOS (AUR) | `paru -S forgejo-cli` (or `cargo install forgejo-cli`) |
-| Debian sid / Ubuntu 25.10+ | `sudo apt install forgejo-cli` (not in Debian stable or Ubuntu LTS as of April 2026) |
+| Debian sid / Ubuntu 25.10+ | `sudo apt install forgejo-cli` (not in Debian stable or Ubuntu LTS as of May 2026 recheck) |
 | Fedora | `sudo dnf copr enable lihaohong/forgejo-cli && sudo dnf install forgejo-cli` |
 | macOS | `brew install forgejo-cli` |
 | Nix | `nix profile install nixpkgs#forgejo-cli` |

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -30,7 +30,7 @@ stale package table.
 | Component | Version or date | Why it matters |
 |-----------|-----------------|----------------|
 | **Current dated Kali image release** | 2026.1 | current image baseline and release notes |
-| Branch docs | 2026-04 / verify live | branch behavior and safe lane selection matter more than a single package version |
+| Branch docs | May 2026 recheck / verify live | branch behavior and safe lane selection matter more than a single package version |
 | Metapackage docs | 2025-07 / verify live | tool-family grouping and install scope matter more than memorizing one package list |
 | Kali 2026.1 kernel lane | 6.18 | release-image baseline for hardware and driver expectations |
 

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -41,6 +41,7 @@ This skill covers four domains depending on context:
 - Security audits of application code (use security-audit)
 - Provisioning the cluster itself via IaC (use terraform)
 - Database engine configuration running on K8s (use databases)
+- Broad read-only cluster health checks, status reports, and post-maintenance diagnostics (use **cluster-health**)
 
 ---
 
@@ -459,6 +460,8 @@ PCI-DSS 4.0 is the only active version (3.2.1 retired March 2024). 51 future-dat
   and Helm charts; ci-cd covers the pipeline stages that apply them.
 - **terraform** - for provisioning the cluster itself (EKS, GKE, AKS, bare-metal node pools).
   Terraform creates the cluster; kubernetes configures what runs on it.
+- **cluster-health** - for read-only cluster status checks, node/workload diagnostics, events,
+  ingress/storage/log sweeps, and post-maintenance reports.
 - **databases** - for deploying databases on K8s (StatefulSets, operators, PVCs). Kubernetes
   owns the manifest pattern; databases owns the engine configuration within.
 - **ansible** - can deploy to K8s via `kubernetes.core` collection, but manifest and Helm

--- a/skills/kubernetes/references/architecture.md
+++ b/skills/kubernetes/references/architecture.md
@@ -109,7 +109,7 @@ spec:
 - Multi-source Applications (mature since ArgoCD 2.6) for separating chart version from env values.
 - `ignoreMissingValueFiles: true` for default/override patterns with ApplicationSets.
 - OCI charts: omit `oci://` prefix in ArgoCD's `repoURL`.
-- Wildcard valueFiles (ArgoCD v3.4+, RC as of March 2026): `valueFiles: ["values/*.yaml"]`.
+- Wildcard valueFiles (documented in current Argo CD docs as of May 2026 recheck): `valueFiles: ["values/*.yaml"]`.
 - **Anti-pattern**: `randAlphaNum` or other random functions in Helm templates - causes perpetual OutOfSync.
 
 ### Promotion Strategy

--- a/skills/networking/SKILL.md
+++ b/skills/networking/SKILL.md
@@ -55,6 +55,7 @@ performance tuning.
 - OPNsense/pfSense firewall appliance management (use **firewall-appliance**)
 - Web browsing, scraping, or headless page interaction - use **browse**
 - Kubernetes networking: NetworkPolicy, Gateway API, service mesh, CNI (use **kubernetes**)
+- Broad Kubernetes cluster health checks, node status, and post-maintenance diagnostics (use **cluster-health**)
 - Docker/container networking: bridge, overlay, Compose networks (use **docker**)
 - Cloud VPCs, security groups, managed load balancers (use **terraform**)
 - Network config management at scale via playbooks (use **ansible**)
@@ -373,6 +374,8 @@ Network configuration touches several PCI-DSS requirements:
   mentions pfctl, CARP, or OPNsense/pfSense hostnames, route to firewall-appliance.
 - **kubernetes** - owns K8s networking (NetworkPolicy, Gateway API, service mesh, CNI). This
   skill covers general DNS and proxy config; K8s-specific networking goes to kubernetes.
+- **cluster-health** - owns read-only Kubernetes cluster diagnostics. If the request is
+  "is the cluster healthy?" rather than "configure DNS/proxy/routing", route there.
 - **docker** - owns container networking (bridge, Compose networks, port mapping). This skill
   covers host-level Linux networking.
 - **terraform** - owns cloud infrastructure (VPCs, security groups, cloud LBs, Route53). This

--- a/skills/prompt-generator/SKILL.md
+++ b/skills/prompt-generator/SKILL.md
@@ -19,7 +19,8 @@ Take the user's rough thoughts, scattered notes, or half-formed ideas and turn t
 
 - User has rough notes, bullet points, or a brain dump they want turned into a clean LLM prompt
 - Refining, rewriting, or optimizing an existing prompt that isn't performing well
-- Structuring a system prompt or task prompt from scattered requirements
+- Structuring a system prompt, one-off task prompt, reusable template, evaluator prompt,
+  code-review prompt, or delegation prompt from scattered requirements
 - Creating prompt templates with variable placeholders for repeated use
 - User says anything like "write me a prompt for...", "turn this into a prompt", "system prompt for..."
 
@@ -27,6 +28,7 @@ Take the user's rough thoughts, scattered notes, or half-formed ideas and turn t
 
 - Brainstorming features or creative ideation - this skill structures prompts, not ideas
 - Creating reusable skill files or agent instruction bundles (use **skill-creator**)
+- Creating scheduled or unattended automation routines (use **routine-writer**)
 - Writing inline prompt strings inside application code - that's just coding
 - The user wants code that calls an LLM API (use **ai-ml** for SDK integration)
 - Security review of prompts for injection risks (use **security-audit**)
@@ -43,8 +45,11 @@ Before returning any generated or modified prompt file, verify:
 - [ ] **Structure matches complexity**: simple tasks get plain prose, not XML-tagged multi-section prompts
 - [ ] **Variables consistent**: every `{{PLACEHOLDER}}` in the prompt body appears in the Variables table and vice versa
 - [ ] **No injected instructions**: didn't add error handling, safety disclaimers, or output constraints the user didn't request
+- [ ] **Untrusted text delimited**: source text, user examples, logs, web pages, and documents are clearly fenced or labeled before the prompt tells the model what to do
 - [ ] **No slop phrases**: no "certainly", "I'd be happy to", "great question", or other filler in the prompt text
 - [ ] **Output format specified**: if the prompt expects structured output, the format is explicit (JSON schema, XML tags, delimiters)
+- [ ] **Evaluator criteria explicit**: evaluator prompts define pass/fail criteria, required evidence, and common failure modes
+- [ ] **Delegation contract clear**: delegation prompts define ownership, scope, files, allowed edits, and expected final answer shape
 - [ ] **Model-appropriate syntax**: avoid model-specific features (assistant prefills, `\n\nHuman:` formatting) in model-agnostic prompts. XML delimiters and markdown headers are both fine for structure across models
 
 ---
@@ -70,6 +75,8 @@ Before returning any generated or modified prompt file, verify:
 - Preserve the user's intent; do not add hidden policy, tone, or scope changes.
 - Name variables consistently and define every required input.
 - Include success criteria for complex prompts so outputs can be evaluated.
+- Match the prompt family to the intended use; see `references/prompt-families.md`.
+- For evaluator prompts, use a rubric with observable evidence; see `references/evaluator-prompts.md`.
 
 
 ## Workflow
@@ -98,6 +105,9 @@ Most of the time, skip this step entirely.
    - **Simple** (one task, no variables): plain prose, 3-10 lines. No XML, no sections.
    - **Medium** (multiple steps or constraints): numbered steps, clear sections.
    - **Complex** (agentic, multi-document, behavioral rules): clear section delimiters, variable placeholders, explicit output format.
+   - **Reusable template**: include a variables table and stable `{{VARIABLE_NAME}}` placeholders.
+   - **Evaluator prompt**: define rubric dimensions, pass/fail threshold, failure examples, and required evidence.
+   - **Delegation prompt**: define task, ownership, files in scope, files out of scope, allowed edits, and output contract.
 2. **Present the prompt in conversation for review. Don't write files yet.**
 3. On approval, save to file (see Output Format below).
 4. Revisions: edit in place, don't create new files.
@@ -148,6 +158,10 @@ Optional frontmatter additions: `tags: [...]`, `related: [NNN-other.md]` - only 
 ## Structuring Guidelines
 
 These are for YOU when structuring the user's notes. Not a knowledge dump - just the non-obvious stuff.
+
+**Route by prompt family.** Simple task prompts should stay inline. Reusable prompts need variables.
+Evaluator prompts need rubrics and failure cases. Delegation prompts need ownership and return
+shape. Code-review prompts lead with findings and require file and line references.
 
 **Match complexity to content.** A 3-line task doesn't need XML tags and numbered steps. A multi-document agentic system prompt does. The user's rough notes give you the complexity signal.
 
@@ -250,6 +264,8 @@ Note: simple task, so plain prose - no XML sections, no numbered steps, no bloat
 - **skill-creator** - creates reusable skill files (SKILL.md) for AI tools and coding agents. Skills are
   structured prompts, but they follow different conventions (frontmatter, workflow sections,
   rules) than standalone prompts. If someone says "create a skill", use skill-creator.
+- **routine-writer** - creates unattended or scheduled automation routine prompts. Use it when the
+  user mentions schedules, triggers, recurring runs, `/schedule`, or `/fire`.
 - Application code - if the user needs a prompt string inside application code (for example a
   TypeScript `const systemPrompt = ...`), that's coding, not this skill.
 - **anti-slop** - if the user asks to "clean up" or "simplify" a prompt embedded in code, that's

--- a/skills/prompt-generator/references/evaluator-prompts.md
+++ b/skills/prompt-generator/references/evaluator-prompts.md
@@ -1,0 +1,17 @@
+# Evaluator Prompts
+
+## Structure
+
+An evaluator prompt needs: input boundary, scoring dimensions, pass/fail threshold, failure
+examples, and required evidence.
+
+## Rubric Shape
+
+Use 3-5 dimensions. Each dimension gets an explicit score range and observable criteria.
+
+## Failure Modes
+
+- Rewarding verbosity instead of correctness
+- Accepting unsupported claims
+- Letting style preferences override stated requirements
+- Scoring without citing evidence from the evaluated artifact

--- a/skills/prompt-generator/references/prompt-families.md
+++ b/skills/prompt-generator/references/prompt-families.md
@@ -1,0 +1,24 @@
+# Prompt Families
+
+## System Prompts
+
+Use for durable behavior, role, boundaries, and output contracts. Keep task-specific data out of
+the system prompt unless it is stable across runs.
+
+## Task Prompts
+
+Use for one-off work. Put source material in fenced blocks and state whether it is trusted or
+untrusted.
+
+## Reusable Templates
+
+Use `{{VARIABLE_NAME}}` placeholders, define each variable once, and keep variable names stable.
+
+## Code-Review Prompts
+
+Lead with findings, require file and line references, and ask for severity ordering.
+
+## Delegation Prompts
+
+Include task ownership, files or modules in scope, files out of scope, expected final answer, and
+whether edits are allowed.

--- a/skills/routine-writer/references/automation.md
+++ b/skills/routine-writer/references/automation.md
@@ -6,7 +6,7 @@ How to emit `/schedule` invocations, `/fire` curl templates, and GitHub Actions 
 
 ## What is automatable, and what is not
 
-The routines API surface, as of April 2026, is asymmetric:
+The routines API surface, as of May 2026 recheck, is asymmetric:
 
 | Action | Automatable? | How |
 |---|---|---|

--- a/skills/routine-writer/references/trigger-guide.md
+++ b/skills/routine-writer/references/trigger-guide.md
@@ -2,7 +2,7 @@
 
 Per-trigger specifics: cron rules, API fire semantics, GitHub event catalogue, filter fields, and how triggers combine.
 
-All details below reflect the research preview as of April 2026. The beta header is `experimental-cc-routine-2026-04-01`. Shapes, limits, and behavior can change; pin the beta header date so staleness is detectable.
+All details below reflect the research preview as of May 2026 recheck. The beta header is `experimental-cc-routine-2026-04-01`. Shapes, limits, and behavior can change; pin the beta header date so staleness is detectable.
 
 ---
 
@@ -60,7 +60,7 @@ The `routine_id` in the URL is prefixed `trig_`, not `routine_`. The full URL an
 | Header | Value |
 |---|---|
 | `Authorization` | `Bearer sk-ant-oat01-...` (per-routine token) |
-| `anthropic-beta` | `experimental-cc-routine-2026-04-01` (April 2026) |
+| `anthropic-beta` | `experimental-cc-routine-2026-04-01` (header dated 2026-04-01; verified May 2026) |
 | `anthropic-version` | `2023-06-01` |
 | `Content-Type` | `application/json` (when body is present) |
 

--- a/skills/skill-creator/references/conventions.md
+++ b/skills/skill-creator/references/conventions.md
@@ -16,7 +16,7 @@ when creating or reviewing skills to ensure consistency.
 7. AI Self-Check Patterns
 7.5. Diagnostic Skill Pitfalls
 8. Trigger Description Patterns
-9. Skill Inventory (April 2026)
+9. Skill Inventory (May 2026)
 
 ---
 
@@ -499,7 +499,7 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 
 ---
 
-## 9. Skill Inventory (April 2026)
+## 9. Skill Inventory (May 2026)
 
 ### Published skills (39)
 

--- a/skills/skill-refiner/references/test-cases.md
+++ b/skills/skill-refiner/references/test-cases.md
@@ -733,7 +733,7 @@ Quality signals:
 - Declares minimum scope: repos, connectors (Slack + GitHub), env vars
 - Detects claude binary on PATH before emitting /schedule invocation
 - Never embeds real API tokens - uses $ROUTINE_FIRE_TOKEN placeholder
-- Beta header pinned with (April 2026) annotation in prose
+- Beta header pinned with header date and May 2026 verification annotation in prose
 
 **Test 2: API-triggered routine from CI**
 Prompt: "I want to fire a Claude routine from our GitHub Actions deploy job to generate release notes. How do I wire it up?"

--- a/skills/skill-router/SKILL.md
+++ b/skills/skill-router/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: skill-router
+description: >
+  · Route user requests to the right installed skill with minimal loading. Triggers: 'which skill',
+  'skill routing', 'choose skill', 'skill overlap', 'trigger conflict'. Not for creating skills (use skill-creator).
+license: MIT
+compatibility: "None - works with any Agent Skills collection"
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-05-01"
+  effort: medium
+  argument_hint: "<request-or-skill-list>"
+---
+
+# Skill Router
+
+Route a user request to the smallest useful skill set. Prefer one primary skill. Use a short
+ordered set only when the request genuinely spans independent domains.
+
+## When to use
+
+- User asks which skill applies to a request
+- A request appears to match multiple skill descriptions
+- A skill description or trigger list is causing routing confusion
+- You need to explain why one adjacent skill is a better fit than another
+
+## When NOT to use
+
+- Creating or rewriting a skill - use **skill-creator**
+- Batch improving a collection - use **skill-refiner**
+- Capturing feature ideas or competitive backlog items - use **roadmap**
+- Implementing domain work after routing - use the selected domain skill
+
+---
+
+## AI Self-Check
+
+Before returning a routing decision, verify:
+
+- [ ] User intent is stated in one sentence
+- [ ] Hard trigger words were checked against the available skill descriptions
+- [ ] "Not for" routing hints were checked before choosing
+- [ ] One primary skill is selected unless the task truly spans multiple domains
+- [ ] Near misses are explained only when useful
+- [ ] The next action is clear: invoke a skill, ask a question, or proceed without a skill
+
+---
+
+## Performance
+
+- Read skill metadata first; open full `SKILL.md` files only for close matches.
+- Prefer two or three near matches over scanning every reference file.
+- Stop once the selected skill has enough confidence for the next action.
+
+## Best Practices
+
+- Route by the user's intended work, not by incidental keywords.
+- Respect explicit user skill requests even if another skill might also apply.
+- Use ordered skill sets when process skills must precede domain skills.
+
+## Workflow
+
+### Step 1: Restate intent
+
+Reduce the request to one concrete task statement.
+
+### Step 2: Identify hard matches
+
+Check skill names, trigger words, file types, tools, and explicit user mentions.
+
+### Step 3: Apply exclusions
+
+Read "When NOT to use" and "Not for" hints for close matches. Remove skills whose exclusions fit
+the request.
+
+### Step 4: Choose the route
+
+Return one of:
+
+- `Primary: <skill>` when one skill is enough
+- `Ordered: <skill-1> -> <skill-2>` when a process skill must run before a domain skill
+- `Parallel: <skill-a>, <skill-b>` when independent domains can be worked separately
+- `No skill` when no available skill materially helps
+
+### Step 5: Explain briefly
+
+Give the reason in one or two sentences. Include near misses only if they prevent confusion.
+
+For examples, see `references/routing-patterns.md`.
+
+## Rules
+
+1. Prefer one primary skill.
+2. Do not load reference files during routing unless the main skill file is ambiguous.
+3. Do not invent skills that are not installed.
+4. Do not let broad words like "review", "test", or "frontend" override explicit exclusions.
+5. After routing, stop routing and let the selected skill govern the next work.

--- a/skills/skill-router/references/routing-patterns.md
+++ b/skills/skill-router/references/routing-patterns.md
@@ -1,0 +1,26 @@
+# Routing Patterns
+
+## Single Skill
+
+Request: "Review this PR for bugs."
+Route: `code-review`
+Reason: The user asked for bug-focused review. Do not use `anti-slop` unless the request names
+AI-generated code quality.
+
+## Ordered Skills
+
+Request: "Design and build a new dashboard."
+Route: `superpowers:brainstorming` -> `frontend-design`
+Reason: Creative feature work needs design shaping before frontend implementation.
+
+## Parallel Skills
+
+Request: "Audit this Dockerized API for security and CI issues."
+Route: `security-audit`, `ci-cd`, `docker`
+Reason: The request spans independent security, pipeline, and container domains.
+
+## Near Miss
+
+Request: "Turn these rough notes into a system prompt."
+Route: `prompt-generator`
+Near miss: `skill-creator` is only for reusable Agent Skills, not ordinary prompts.

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -42,6 +42,7 @@ IBM acquired HashiCorp for $6.4B (closed Feb 2025). Terraform stays BSL 1.1; Ope
 ## When NOT to use
 
 - Kubernetes manifests or Helm charts (use **kubernetes**)
+- Read-only Kubernetes cluster health checks after provisioning or maintenance (use **cluster-health**)
 - Ansible playbooks or configuration management (use **ansible**)
 - Docker/container optimization (use **docker**)
 - CI/CD pipeline design (use **ci-cd**)
@@ -474,6 +475,8 @@ Read `references/production-checklist.md` for the full pre-deploy checklist cove
 - **ansible** - for day-2 configuration of provisioned resources. Terraform provisions the VM;
   Ansible configures what runs on it. No `provisioner` blocks - use Ansible instead.
 - **kubernetes** - K8s manifests and Helm charts. Terraform provisions the cluster; kubernetes configures what runs on it.
+- **cluster-health** - read-only cluster diagnostics after provisioning, upgrades, or maintenance.
+  Terraform changes infrastructure; cluster-health checks the running cluster state.
 - **databases** - engine tuning and operations. Terraform provisions managed databases; databases skill tunes the engine.
 - **ci-cd** - pipeline design that runs `terraform plan/apply`. Terraform covers HCL; ci-cd covers the pipeline stages.
 - **docker** - container image patterns. Terraform provisions container infrastructure but Dockerfile design belongs in docker.


### PR DESCRIPTION
## Summary

- add `skill-router` for skill discovery and routing
- expand `prompt-generator`, `browse`, and `frontend-design`
- publish generic `cluster-health` with gitignored protected overlays
- add private leak checking for cluster-health migration

## Validation

- `./scripts/check-private-skill-leaks.sh`
- `./scripts/lint-skills.sh`
- `./scripts/validate-spec.sh`
- `git diff --check`
