### PR TITLE
chore(installer): keep opencode skills visible

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,6 +75,9 @@ jobs:
         run: |
           bash -n install.sh scripts/*.sh
 
+      - name: Test installer behavior
+        run: ./scripts/test-install.sh
+
       - name: Shellcheck scripts
         run: shellcheck install.sh scripts/*.sh
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,6 +39,11 @@ git clone https://github.com/iuliandita/skills.git /tmp/skills-install
 rm -rf /tmp/skills-install
 ```
 
+For OpenCode, the installer also updates `~/.config/opencode/opencode.json` so every installed
+skill has `permission.skill.<name>: "allow"`. This keeps installs visible when the user's config
+uses a deny-by-default policy such as `"permission": { "skill": { "*": "deny" } }`. Existing
+explicit `deny` entries are left alone.
+
 ### Multi-tool with symlinks
 
 Install once to a canonical directory, symlink everywhere. Update the canonical copy and every tool sees the change.
@@ -158,6 +163,9 @@ Or check what changed first:
 ```
 
 The installer backs up existing skills before overwriting (unless `--no-backup`), so local customizations are preserved.
+Backups are stored next to the target skill directory under `.skills-backups/`, not inside the
+skill discovery root. This prevents tools such as OpenCode from indexing old backup `SKILL.md`
+files as duplicate skills.
 
 ## Checking for updates
 

--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,8 @@ declare -A TOOL_PATHS=(
   [portable]="${PORTABLE_SKILLS_DIR:-$HOME/.skills}"
 )
 
+OPENCODE_CONFIG_FILE="${OPENCODE_CONFIG_FILE:-$HOME/.config/opencode/opencode.json}"
+
 declare -A TOOL_ALIASES=(
   [claude-code]=claude
   [openai-codex]=codex
@@ -184,7 +186,10 @@ is_internal() {
 # ── Backup ────────────────────────────────────────────────────────────
 backup_skill() {
   local skill="$1" dest_dir="$2"
-  local backup_base="$dest_dir/.backups"
+  local backup_parent backup_name backup_base
+  backup_parent="$(dirname "$dest_dir")"
+  backup_name="$(basename "$dest_dir")"
+  backup_base="${SKILLS_BACKUP_DIR:-$backup_parent/.skills-backups/$backup_name}"
   local ts
   ts="$(date +%Y%m%d-%H%M%S)"
   local dest="$backup_base/$skill/$ts"
@@ -300,6 +305,75 @@ create_link() {
 
   ln -sfn "$CANONICAL_DIR/$skill" "$tool_dir/$skill"
   printf '  [+] %s linked\n' "$skill"
+}
+
+sync_opencode_permissions() {
+  local config_file="$1"
+  shift
+  local skills=("$@")
+  local synced_skills=()
+
+  for skill in "${skills[@]}"; do
+    validate_skill_name "$skill" || continue
+    [[ -d "$SKILLS_SRC/$skill" ]] || continue
+    synced_skills+=("$skill")
+  done
+
+  (( ${#synced_skills[@]} > 0 )) || return 0
+
+  if ! command -v python3 &>/dev/null; then
+    printf '  [!] OpenCode permission sync skipped: python3 not found\n'
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$config_file")"
+
+  if ! python3 - "$config_file" "${synced_skills[@]}" <<'PY'
+import json
+import os
+import sys
+
+config_path = sys.argv[1]
+skills = sys.argv[2:]
+
+if os.path.exists(config_path) and os.path.getsize(config_path) > 0:
+    with open(config_path, encoding="utf-8") as f:
+        config = json.load(f)
+else:
+    config = {}
+
+if not isinstance(config, dict):
+    raise ValueError("OpenCode config root must be a JSON object")
+
+permission = config.get("permission")
+if not isinstance(permission, dict):
+    permission = {}
+    config["permission"] = permission
+
+skill_permission = permission.get("skill")
+if not isinstance(skill_permission, dict):
+    skill_permission = {}
+    permission["skill"] = skill_permission
+
+changed = False
+for skill in skills:
+    if skill_permission.get(skill) == "deny":
+        continue
+    if skill_permission.get(skill) != "allow":
+        skill_permission[skill] = "allow"
+        changed = True
+
+if changed or not os.path.exists(config_path):
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+PY
+  then
+    printf '  [!] OpenCode permission sync skipped: could not parse %s as JSON\n' "$config_file"
+    return 0
+  fi
+
+  printf '  [=] OpenCode permissions synced\n'
 }
 
 # ── Check mode ────────────────────────────────────────────────────────
@@ -476,6 +550,9 @@ main() {
         [[ -d "$SKILLS_SRC/$skill" ]] || continue
         create_link "$skill" "$tool_dir" "$force" "$no_backup"
       done
+      if [[ "$tool" == "opencode" ]]; then
+        sync_opencode_permissions "$OPENCODE_CONFIG_FILE" "${skills[@]}"
+      fi
       printf '\n'
     done
 
@@ -514,6 +591,10 @@ main() {
         fi
         install_copy "$skill" "$dest" "$force" "$no_backup" || (( failed++ )) || true
       done
+
+      if [[ "$tool" == "opencode" ]]; then
+        sync_opencode_permissions "$OPENCODE_CONFIG_FILE" "${skills[@]}"
+      fi
 
       write_lock "$dest" "${skills[@]}"
       printf '\n'

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+test_backups_stay_outside_skill_root() {
+  local tmp dest backup_root
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  dest="$tmp/agent/skills"
+  "$ROOT/install.sh" --tool portable --dest "$dest" --no-backup docker >/dev/null
+  "$ROOT/install.sh" --tool portable --dest "$dest" --force docker >/dev/null
+
+  if find "$dest" -path '*/.backups/*/SKILL.md' -print -quit | grep -q .; then
+    fail "backup SKILL.md found under discovery root $dest"
+  fi
+
+  backup_root="$tmp/agent/.skills-backups/skills/docker"
+  if ! find "$backup_root" -mindepth 2 -name SKILL.md -type f -print -quit 2>/dev/null | grep -q .; then
+    fail "expected backup SKILL.md under $backup_root"
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_opencode_install_allows_installed_skills() {
+  local tmp config
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  config="$tmp/.config/opencode/opencode.json"
+  mkdir -p "$(dirname "$config")"
+  printf '%s\n' '{"permission":{"skill":{"*":"deny","ai-ml":"allow","docker":"deny"}}}' > "$config"
+
+  HOME="$tmp" "$ROOT/install.sh" --tool opencode --no-backup backend-api docker >/dev/null
+
+  python3 - "$config" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    config = json.load(f)
+
+skills = config["permission"]["skill"]
+assert skills["*"] == "deny"
+assert skills["ai-ml"] == "allow"
+assert skills["backend-api"] == "allow"
+assert skills["docker"] == "deny"
+PY
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_backups_stay_outside_skill_root
+test_opencode_install_allows_installed_skills
+printf 'install tests passed\n'


### PR DESCRIPTION
## Summary
- allow installed OpenCode skills in opencode.json when users run deny-by-default skill permissions
- store installer backups outside skill discovery roots to avoid duplicate SKILL.md discovery
- add installer regression tests and run them in CI

## Test plan
- ./scripts/test-install.sh
- bash -n install.sh scripts/*.sh
- shellcheck install.sh scripts/*.sh
- ./scripts/lint-skills.sh
- ./scripts/validate-spec.sh
- actionlint -color
- temp OpenCode install with permission.skill.* deny verified 41 allowlisted public skills

## Release
No release intended. This uses a chore title so release-please should not open a release PR.