### PR TITLE
chore(installer): migrate legacy skill backups

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -210,6 +210,23 @@ backup_skill() {
   fi
 }
 
+migrate_legacy_backups() {
+  local dest_dir="$1"
+  local legacy_dir="$dest_dir/.backups"
+  [[ -d "$legacy_dir" || -L "$legacy_dir" ]] || return 0
+
+  local backup_parent backup_name backup_base ts dest
+  backup_parent="$(dirname "$dest_dir")"
+  backup_name="$(basename "$dest_dir")"
+  backup_base="${SKILLS_BACKUP_DIR:-$backup_parent/.skills-backups/$backup_name}"
+  ts="$(date +%Y%m%d-%H%M%S)"
+  dest="$backup_base/.legacy/$ts"
+
+  mkdir -p "$(dirname "$dest")"
+  mv "$legacy_dir" "$dest"
+  printf '  [>] legacy .backups moved to %s\n' "$dest"
+}
+
 # ── Lock file ─────────────────────────────────────────────────────────
 write_lock() {
   local lock_dir="$1"
@@ -522,6 +539,7 @@ main() {
     printf 'Installing %d skill(s) via symlink\n' "${#skills[@]}"
     printf 'Canonical: %s\n\n' "$CANONICAL_DIR"
     mkdir -p "$CANONICAL_DIR"
+    migrate_legacy_backups "$CANONICAL_DIR"
 
     # Copy all skills to canonical dir first
     local failed=0
@@ -544,6 +562,7 @@ main() {
       local tool_dir
       tool_dir="$(resolve_tool_path "$tool")"
       mkdir -p "$tool_dir"
+      migrate_legacy_backups "$tool_dir"
       printf '[%s] -> %s\n' "$tool" "$tool_dir"
       for skill in "${skills[@]}"; do
         validate_skill_name "$skill" || continue
@@ -576,6 +595,7 @@ main() {
         dest="$(resolve_tool_path "$tool")"
       fi
       mkdir -p "$dest"
+      migrate_legacy_backups "$dest"
 
       printf '[%s] -> %s\n' "$tool" "$dest"
       for skill in "${skills[@]}"; do

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -30,6 +30,30 @@ test_backups_stay_outside_skill_root() {
   trap - RETURN
 }
 
+test_legacy_backups_are_migrated_outside_skill_root() {
+  local tmp dest migrated_root
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  dest="$tmp/agent/skills"
+  mkdir -p "$dest/.backups/docker/legacy"
+  printf '%s\n' 'legacy backup' > "$dest/.backups/docker/legacy/SKILL.md"
+
+  "$ROOT/install.sh" --tool portable --dest "$dest" --no-backup docker >/dev/null
+
+  if [[ -e "$dest/.backups" ]]; then
+    fail "legacy .backups directory still exists under discovery root $dest"
+  fi
+
+  migrated_root="$tmp/agent/.skills-backups/skills/.legacy"
+  if ! find "$migrated_root" -path '*/docker/legacy/SKILL.md' -type f -print -quit 2>/dev/null | grep -q .; then
+    fail "expected migrated legacy backup under $migrated_root"
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
 test_opencode_install_allows_installed_skills() {
   local tmp config
   tmp="$(mktemp -d)"
@@ -60,5 +84,6 @@ PY
 }
 
 test_backups_stay_outside_skill_root
+test_legacy_backups_are_migrated_outside_skill_root
 test_opencode_install_allows_installed_skills
 printf 'install tests passed\n'


### PR DESCRIPTION
## Summary
- move existing `.backups` directories out of skill discovery roots during installs
- preserve legacy backup contents under the existing `.skills-backups/<target>/.legacy/` store
- add a regression test for legacy backup migration

## Test plan
- ./scripts/test-install.sh
- bash -n install.sh scripts/*.sh
- shellcheck install.sh scripts/*.sh
- git diff --check

## Release
No release intended. This is installer maintenance and uses a chore title.