### PR TITLE
docs: recover skill follow-up notes

### DIFF
--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -460,13 +460,13 @@ the OWASP Top 10 for Agentic Applications, read `references/supply-chain.md`
 ## Reference Files
 
 - `references/github-actions.md` - GitHub Actions patterns, templates, and security hardening
+- `references/forgejo-actions-troubleshooting.md` - Forgejo Actions failure triage, `fj actions tasks`, missing logs caveats, local Docker build/Trivy reproduction, private registry auth pitfalls
 - `references/forgejo-ansible-deployments.md` - Forgejo/Gitea Actions fan-out patterns for Ansible playbook deployments
 - `references/gitlab-ci.md` - GitLab CI/CD 18.x patterns, SaaS vs self-managed differences, Catalog, Components, security
 - `references/gitea-ci.md` - Gitea Actions + Woodpecker CI patterns, setup, matrix builds, Drone migration
 - `references/runners.md` - Self-hosted runners (actions-runner, gitlab-runner, forgejo-runner, act_runner, woodpecker-agent) - install, register, executor choice, Linux vs macOS, security hardening
 - `references/best-practices.md` - Dependency updates (Dependabot/Renovate), layered linting, scanning matrix (secrets/SCA/container/IaC/SAST), review gates, merge queues, rollout order
-- `references/supply-chain.md` - supply chain security, incident timeline, SHA pinning,
-  SBOM/SLSA, PCI-DSS compliance, image signing
+- `references/supply-chain.md` - supply chain security, incident timeline, SHA pinning, SBOM/SLSA, PCI-DSS compliance, image signing
 - `references/target-versions.md` - May 2026 version snapshot for forges, runners, CI systems, and supply-chain tools
 
 ## Related Skills

--- a/skills/ci-cd/references/forgejo-actions-troubleshooting.md
+++ b/skills/ci-cd/references/forgejo-actions-troubleshooting.md
@@ -1,0 +1,61 @@
+# Forgejo Actions Troubleshooting
+
+Use this when a Forgejo Actions run fails but the failure is only visible as a notification or task status, especially for scheduled Docker image builds.
+
+## Fast triage
+
+1. Identify the failed task and adjacent successful runs:
+
+```bash
+fj actions tasks -p 1
+```
+
+Compare task id, commit, event, duration, and workflow/job name. If the same workflow and same commit succeeded immediately before or after, suspect runner, network, registry, cache, or external service flake before editing code.
+
+2. Inspect the workflow file and reproduce the exact shell-visible parts locally:
+
+```bash
+sed -n '1,220p' .forgejo/workflows/<workflow>.yaml
+```
+
+For Docker build workflows, run the same build context, Dockerfile, tags, scanner image, scanner flags, and ignore file locally.
+
+3. Keep private registry state explicit. A remote image manifest probe may fail with `unauthorized` unless this machine is logged in to the registry, even if the CI runner has a working token. Treat that as an auth-state finding, not proof that the image is absent.
+
+## Docker build workflow reproduction pattern
+
+```bash
+docker build --pull -t local-debug:<name> <context>
+
+docker tag local-debug:<name> <registry>/<owner>/<image>:<tag>
+
+docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$PWD/<path>/.trivyignore:/work/.trivyignore:ro" \
+  -w /work \
+  aquasec/trivy:<version> image \
+  --severity CRITICAL,HIGH \
+  --ignore-unfixed \
+  --ignorefile /work/.trivyignore \
+  --exit-code 1 \
+  --format table \
+  <registry>/<owner>/<image>:<tag>
+```
+
+Adjust scanner flags to match the workflow exactly. If local build and scan pass, do not claim the workflow is fixed. Report the narrowed failure domain and suggest rerun only if authorized.
+
+## Forgejo API and logs caveat
+
+Some Forgejo versions expose Actions task listings through the CLI but do not expose job logs through token-friendly API endpoints, or return `403` for unauthenticated/session-only endpoints. When logs are unavailable:
+
+- use `fj actions tasks` for task metadata
+- use adjacent successful runs for comparison
+- reproduce deterministic steps locally
+- avoid guessing the exact failing step
+
+## Pitfalls
+
+- `permissions:` in Forgejo workflow YAML is parsed for compatibility but is not a reliable least-privilege boundary like GitHub Actions.
+- Scheduled Docker builds can fail from registry/buildcache/network flakes while code remains valid.
+- `docker manifest inspect <private-registry-image>` can fail locally with `unauthorized`; check local Docker login state before drawing conclusions.
+- Do not rerun, push, or merge from a bot notification unless the authorized human explicitly asked for that action.

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -201,7 +201,11 @@ General flow:
 3. **Rebase onto base**: `git fetch origin && git rebase origin/main` (or whatever the base branch is). Resolve conflicts: look for `<<<<<<<`, `=======`, `>>>>>>>` markers, keep the correct content from both sides (often both additions belong), then `git add` and `git rebase --continue`. After resolving conflicts in dependency files (`package.json`, `Cargo.toml`, `go.mod`, etc.), re-run the package manager to regenerate the lock file. Never merge the base into the feature branch. For merge strategy guidance, see `references/forge-workflows.md`.
 
    **Dependency file conflicts** (`package.json`, `go.mod`, `pyproject.toml`): keep additions from both branches; when the same dependency has conflicting version pins, take the higher compatible version conservatively and validate. Never hand-edit the lock file - always regenerate it by running the package manager (`npm install`, `go mod tidy`, `uv sync`, etc.) after resolving the manifest conflict. Do not use `--ours` or `--theirs` for dependency manifest conflicts - these silently drop one branch's additions.
-4. **Push**: `git push -u origin feat/short-description`
+4. **Push**: `git push -u origin feat/short-description`. Then verify the remote actually
+   advanced: compare `git rev-parse HEAD` with the forge PR/MR head SHA (`gh pr view ...`,
+   `glab mr view ...`, or forge API). Do not rely on a terse or aliased push wrapper alone.
+   If upstream tracking is missing or odd, push the exact refspec explicitly and re-check the
+   PR/MR head before claiming the update landed.
 5. **Create PR/MR**: with a clear title (under 70 chars), body with summary + test plan.
 6. **Review cycle**: address feedback, rebase and force-push with `--force-with-lease` (never plain `--force` on shared branches). Squash fixup commits before pushing.
 7. **Merge**: squash-merge for clean history (default), or rebase-merge if commit history is meaningful.

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -55,7 +55,7 @@ Before returning any security audit report, verify:
 - [ ] **Remediation is specific**: concrete fix per finding, not generic advice ("validate input" is insufficient)
 - [ ] **Commit SHA recorded**: report anchored to a specific point in time
 - [ ] **Report gitignored**: warned user and checked `.gitignore` for `SECURITY-AUDIT.md`
-- [ ] **Known incidents checked**: dependency audit verified against known supply chain incidents (event-stream, colors, ua-parser-js, polyfill.io, xz-utils, trivy), not just CVE databases
+- [ ] **Known incidents checked**: dependency audit verified against known supply chain incidents (event-stream, colors, ua-parser-js, polyfill.io, xz-utils, trivy, active package compromises), not just CVE databases
 - [ ] **Agentic risks covered** (when applicable): MCP servers, AI tool handlers, prompt injection surfaces audited if present
 - [ ] **Scope respected**: no external service probing, no DAST, repo-only analysis
 
@@ -131,7 +131,7 @@ Find known CVEs in dependencies and assess supply chain risk.
 - `polyfill.io` (2024 domain takeover, malicious CDN injection)
 - `xz-utils` 5.6.0-5.6.1 (2024 backdoor in compression library)
 - `trivy` 0.69.4-0.69.6 / `aquasecurity/trivy` Docker tags 0.69.5-0.69.6 / `aquasecurity/trivy-action` + `aquasecurity/setup-trivy` force-pushed tags (2026-03 TeamPCP supply chain compromise - credential-stealing malware in CI/CD pipelines)
-Any match on package name + version range is Critical severity regardless of `audit` output.
+Any match on package name + version range is Critical severity regardless of `audit` output. For active incident triage, use `references/supply-chain-incident-triage.md` for repo-wide package, IOC, local-runtime, and remote-repo checks.
 
 ### Step 4: Agentic AI & Supply Chain (Pass 3 - Manual)
 
@@ -262,6 +262,7 @@ These look like security issues but aren't (or are acceptable):
 - `references/grep-patterns.md` - fallback search patterns for secrets, auth, injection, and config review
 - `references/hardening-checklists.md` - host, container, deployment, and self-hosted app hardening checklists
 - `references/report-guide.md` - reporting format, severity mapping, and OWASP alignment
+- `references/supply-chain-incident-triage.md` - active package-compromise triage: affected versions, repo-wide searches, IOCs, local runtime checks, and remote repo propagation checks
 
 ---
 

--- a/skills/security-audit/references/supply-chain-incident-triage.md
+++ b/skills/security-audit/references/supply-chain-incident-triage.md
@@ -1,0 +1,55 @@
+# Supply Chain Incident Triage Notes
+
+Use this when a public package compromise lands and the user asks whether their repos are affected. Keep it repo-only unless the user asks for live infra or token rotation work.
+
+## Pattern: compromised package exposure check
+
+1. Verify the incident from primary sources first: upstream security advisory, package registry quarantine/yank notice, and 1-2 reputable security writeups for IOCs.
+2. Extract exact affected package names, versions, execution trigger, and remediation:
+   - import-time compromise means search dependencies and source imports
+   - install-time compromise means search locks/manifests and package lifecycle hooks
+3. Search all repo manifests and lockfiles, not only source imports:
+   - Python: `pyproject.toml`, `requirements*.txt`, `setup.py`, `setup.cfg`, `poetry.lock`, `uv.lock`, `Pipfile.lock`, conda env files
+   - Node: `package.json`, `package-lock.json`, `npm-shrinkwrap.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`
+4. Search source for runtime imports/usages that may pull dynamic dependencies:
+   - `import <package>`, `from <package>`, framework-specific import aliases
+5. Search for campaign IOCs separately from package names:
+   - payload files/directories
+   - injected lifecycle hooks
+   - suspicious branch names
+   - unusual commit authors/emails
+   - newly created mass branches after disclosure time
+6. Check local runtime environments only if relevant and low-risk, using non-importing checks first:
+   - `python3 -m pip show <pkg>`
+   - `python3 - <<'PY'` with `importlib.util.find_spec()` instead of importing the suspect package
+7. If GitHub propagation is part of the campaign, check remote repos updated since the incident:
+   - branch counts and suspicious branch names
+   - recent commits by known malicious author/email or with IOC strings
+   - avoid destructive cleanup unless explicitly authorized
+8. Report in three buckets:
+   - direct vulnerable dependency found
+   - indicators of compromise found
+   - clean/no evidence found, with scope and caveats
+
+## April 2026 Mini Shai-Hulud example
+
+Public reporting around the April 2026 campaign described these affected versions. Treat this as an example and verify current advisories before acting:
+
+- PyPI `lightning==2.6.2` and `lightning==2.6.3`
+- npm `intercom-client@7.0.4`
+- clean pins reported by public writeups: `lightning==2.6.1`, `intercom-client@7.0.3`
+
+Execution triggers:
+
+- `lightning`: import-time execution
+- `intercom-client`: install-time npm lifecycle hook
+
+Useful IOCs/patterns reported publicly:
+
+- `_runtime/`
+- `router_runtime.js`
+- suspicious package lifecycle `postinstall` changes
+- GitHub propagation using stolen tokens, including many branches per writable repo in some reports
+- commits reported with author email `claude@users.noreply.github.com`
+
+If any direct hit exists, advise treating that environment as compromised: rotate secrets, rebuild from clean state, review logs, and pin to known clean versions. If only unrelated string matches appear, call them out explicitly as false positives, e.g. `lightningcss` is not PyTorch Lightning.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-creator
 description: >
-  · Create/review skills: frontmatter, triggers, overlaps, collection consistency, descriptions. Triggers: 'skill creator', 'new skill', 'skill audit', 'skill review', 'frontmatter', 'skill overlap'.
+  · Create/review skills: frontmatter, triggers, overlaps, collection consistency, retrospective updates. Triggers: 'skill creator', 'new skill', 'skill audit', 'skill review', 'update skill library'.
 license: MIT
 compatibility: "Optional: git (for freshness and gitignore filtering)"
 metadata:
@@ -94,13 +94,16 @@ Before returning any generated or modified skill, verify against this list:
 - Write skills as operational instructions, not essays about a domain.
 - Include clear When to use/When NOT to use routing and realistic AI self-checks.
 - Keep public skills tool-agnostic unless a tool is intrinsic to the skill.
+- Treat install/copy/link steps as environment-specific. If skills are sourced directly from a
+  repo, edit and verify there instead of distributing to tool dirs unless asked.
 
 ## Workflow
 
 Before entering any mode, detect the operating context. This skill works on individual skills
 or collections, whether inside a skill collection repo, a user's own project, or standalone.
 
-**Mode routing** - pick the mode that matches the user's signal:
+**Mode routing** - pick the mode that matches the user's signal. Retrospective-update
+requests are explicit permission to edit the library, so do not stop at a report-only pass:
 
 | User signal | Mode |
 |---|---|
@@ -108,10 +111,13 @@ or collections, whether inside a skill collection repo, a user's own project, or
 | "review my skill", "improve this skill", "is this skill good" | Mode 2 (Review) |
 | "audit the collection", "check all skills", "health check skills" | Mode 3 (Audit) |
 | "fix the description", "skill isn't triggering", "trigger overlap" | Mode 4 (Optimize) |
+| "review the conversation", "update the skill library", "what did we learn" | Mode 5 (Retrospective Update) |
 
 When the signal is ambiguous (e.g., "look at my skill"), ask before committing - Create and
 Review diverge quickly and re-running wastes context. Modes can chain: Create -> Review,
 Review -> Optimize, Audit -> per-skill Review for flagged items.
+For explicit retrospective-update requests, act without asking for confirmation unless the only
+possible update is destructive or would create a new class-level skill with uncertain scope.
 
 1. **Find the collection root** (if one exists): check for a `skills/` directory (common
    convention) or any path the user specifies. Different harnesses store skills in different
@@ -297,6 +303,8 @@ Read the SKILL.md and all reference files. No skipping - the whole point is catc
 - All future-dated requirements (mandatory since March 31, 2025) reflected?
 - No hardcoded secrets in examples?
 
+**Script-runner reality check:** verify helper script input shape. If a single-skill run reports zero skills or odd output, re-run against the collection root and filter for the target.
+
 #### Step 3: Report findings
 
 Use severity ratings:
@@ -405,6 +413,12 @@ Present findings grouped by severity. Include actionable fixes for each finding.
 
 ---
 
+### Mode 5: Retrospective Update
+
+When the user asks to review a completed conversation and update the skill library, capture reusable class-level learning, not a session log. Prefer patching a loaded or existing umbrella skill; create a new skill only when no class-level fit exists. See `references/session-retrospective-updates.md`.
+
+---
+
 ### Mode 4: Optimize Skill Description
 
 The `description` field in frontmatter is the primary triggering mechanism. Optimize it for
@@ -452,7 +466,7 @@ collection, run Mode 2 Step 2 (quality checks) to verify no regressions were int
 End every run with a human-readable report, even for report-only checks:
 
 ```text
-Branch: <branch or unavailable>; Mode: <create|review|audit|optimize>; Scope: <target>
+Branch: <branch or unavailable>; Mode: <create|review|audit|optimize|retrospective>; Scope: <target>
 Score: <before> -> <after> (<delta>) or "not scored - report only"
 Changes: <files changed or none>; Findings: <critical/important/minor counts and top items>
 Verification: <lint/spec/forward-test/source checks with pass/fail>; Skipped: <what and why>
@@ -468,6 +482,8 @@ audit-only runs, report structural gate and finding counts instead of inventing 
   patterns by effort tier, style rules (ASCII, banned words), reference file organization,
   cross-skill patterns, AI Self-Check patterns, and a snapshot inventory of the upstream
   collection (useful as a reference, not an authoritative list for other repos)
+- `references/session-retrospective-updates.md` - compact workflow for reviewing a completed
+  conversation and updating the right class-level skill or reference file.
 
 ## Related Skills
 

--- a/skills/skill-creator/references/session-retrospective-updates.md
+++ b/skills/skill-creator/references/session-retrospective-updates.md
@@ -1,0 +1,35 @@
+# Session Retrospective Skill Updates
+
+Use this reference when the user asks to review the conversation and update the skill library.
+
+## Decision flow
+
+1. Identify the class of work that just happened in one sentence.
+2. Prefer a skill already loaded or consulted in the session.
+3. If no loaded skill fits, use the existing class-level umbrella skill that governs the work.
+4. Patch SKILL.md for reusable workflow, routing, preference, or pitfall changes.
+5. Add `references/` detail only when the lesson is too session-specific or bulky for SKILL.md.
+6. Create a new skill only when no class-level umbrella exists.
+
+## What counts as worth updating
+
+- User corrected style, format, verbosity, sequencing, or tooling.
+- A loaded skill was missing a step, had stale paths, or gave incomplete guidance.
+- A non-obvious repo workflow emerged, especially around canonical vs published copies.
+- Validation exposed a reusable pitfall, such as ignored instruction files or unrelated dirty work.
+
+## Repo skill-library gotchas
+
+- In the public skills repo, `AGENTS.md` may be local-only and gitignored. Read it and follow it, but do not force-add it unless the user explicitly asks.
+- When changing public skill files, stage only the intended paths. Leave unrelated dirty skill edits untouched.
+- If a skill exists both in canonical local skills and the repo, verify they match before declaring deployment done.
+- After public skill edits, run the repo validation scripts and redeploy linked tool skill dirs when the repo workflow calls for it.
+
+## Final report
+
+Keep it short:
+
+- what skill or reference changed
+- why it was updated
+- validation run
+- any overlaps noticed

--- a/skills/skill-refiner/SKILL.md
+++ b/skills/skill-refiner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-refiner
 description: >
-  · Batch-improve skill collections with evaluation loops, lint checks, behavioral tests, peer review. Triggers: 'skill refiner', 'improve skills', 'quality sweep', 'batch improve', 'skill loop'. Not for one skill (use skill-creator).
+  · Improve skill collections or a named skill with iterative scoring, lint checks, behavioral tests, peer review. Triggers: 'skill refiner', 'improve skills', 'quality sweep', 'batch improve', 'skill loop', 'target 99%'.
 license: MIT
 compatibility: "Requires: skill-creator skill, git. Optional: secondary AI harness (codex, claude, opencode) for cross-model review"
 metadata:
@@ -21,6 +21,8 @@ is available, fresh-context self-review as the minimum fallback).
 ## When to use
 
 - Batch-improving the entire skill collection after a period of manual edits
+- Targeted improvement of one named skill when the user explicitly asks for skill-refiner,
+  multiple iterations, a score target, or "no ceiling" polish
 - Running quality sweeps before a release or publish
 - Triggering a self-improvement cycle where skills bootstrap each other
 - After adding several new skills that need polish and consistency alignment
@@ -29,8 +31,8 @@ is available, fresh-context self-review as the minimum fallback).
 
 ## When NOT to use
 
-- Single skill review or improvement - use **skill-creator** (Mode 2)
 - Creating a new skill from scratch - use **skill-creator** (Mode 1)
+- Single-pass review of one skill without iteration, scoring, or peer review - use **skill-creator** (Mode 2)
 - One-off collection audit without iteration - use **skill-creator** (Mode 3)
 - Full codebase review (code, not skills) - use **full-review**
 - Style/slop audit on application code - use **anti-slop**
@@ -85,7 +87,9 @@ contested major flags (non-configurable).
 
 1. **Create feature branch**: `skill-refiner/YYYY-MM-DD-HHMMSS` from current HEAD.
    Preserve dirty worktrees; branching isolates the run, it does not imply cleanup. If already
-   on a run branch for this sweep, record it instead of nesting another branch.
+   on a run branch for this sweep, record it instead of nesting another branch. Do not mix
+   unrelated dirty files into refiner commits; isolate them with a path-limited stash only
+   when authorized.
 2. **Load run history**: read `.refiner-runs.json` from the collection root (if it exists).
    Use previous run data for: baseline score comparison (detect regressions from external
    changes), model/harness change detection (flag if the primary or secondary model changed
@@ -119,7 +123,10 @@ contested major flags (non-configurable).
      test-cases-local.md file alongside test-cases.md so they accumulate across runs.
    - Cross-model: skip on first iteration (no diff to review yet)
 7. **Log baseline scores**: record per-skill and aggregate scores
-8. **Iteration 2+**: enter adaptive focus mode
+8. **Iteration 2+**: enter adaptive focus mode. For a user-requested single-skill run,
+   treat that skill as the whole phase-1 pool, run at least the requested iteration count,
+   and keep iterating until the explicit score target is reached, quality plateaus, or a
+   circuit breaker fires.
 9. **Select targets**: identify skills scoring below the focus threshold
 10. **For each targeted skill**, run the improvement cycle:
     a. Read current SKILL.md and all reference files
@@ -212,8 +219,10 @@ contested major flags (non-configurable).
     collection root. Include: run_id, branch, date, primary/secondary harness+model+effort,
     config, pool size, termination reason, cross-model flag counts, before/after per-skill
     scores (component breakdown + composite, or clearly labeled estimates if the run used a
-    targeted manual rubric instead of the full automated sweep), and a changes summary.
-    Commit with the phase 3 summary.
+    targeted manual rubric instead of the full automated sweep), and a changes summary. When
+    updating an existing history file, append the new object without reserializing the whole
+    file; do not normalize or rewrite old entries just because a JSON writer changes escaping,
+    commas, or whitespace. Commit with the phase 3 summary.
 24. **Announce branch**: remind user to review and merge when ready
 
 ## AI Self-Check


### PR DESCRIPTION
## Summary
- recover useful skill follow-up notes from preserved stashes
- add Forgejo Actions troubleshooting and supply-chain incident triage references
- tighten git PR head verification, skill-refiner single-skill iteration guidance, and skill-creator retrospective update routing

## Review notes
- dropped/softened brittle inline incident details in core security-audit guidance
- kept exact PyTorch Lightning/intercom-client details as an example reference with current-advisory verification caveat
- no private/internal indicators found in the staged diff

## Validation
- `./scripts/lint-skills.sh skills` passes with one existing-style warning: `skill-creator/SKILL.md` is 514 lines, below hard max 600
- `./scripts/validate-spec.sh skills` passes with the same warning
- `./scripts/test-install.sh` passes
- `git diff --cached --check` passes