### PR TITLE
fix(installer): harden skill audit workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
       - "skills/**"
       - "scripts/**"
       - "install.sh"
+      - "CHANGELOG.md"
+      - "INSTALL.md"
       - "README.md"
       - "SECURITY.md"
       - "docs/**"
@@ -19,6 +21,8 @@ on:
       - "skills/**"
       - "scripts/**"
       - "install.sh"
+      - "CHANGELOG.md"
+      - "INSTALL.md"
       - "README.md"
       - "SECURITY.md"
       - "docs/**"
@@ -118,6 +122,7 @@ jobs:
           mapfile -t markdown_files < <(
             {
               printf '%s\n' README.md SECURITY.md
+              printf '%s\n' CHANGELOG.md INSTALL.md
               find skills docs -type f -name '*.md' 2>/dev/null
             } | sort -u
           )

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -12,6 +12,8 @@
     }
   },
   "globs": [
+    "CHANGELOG.md",
+    "INSTALL.md",
     "README.md",
     "SECURITY.md",
     "skills/**/*.md",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,10 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+
+      - id: installer-regression-tests
+        name: test installer behavior
+        entry: ./scripts/test-install.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,6 +57,9 @@ git clone https://github.com/iuliandita/skills.git /tmp/skills-install
 # Check for updates later
 /tmp/skills-install/install.sh --check --link
 
+# Or check one linked tool directory directly
+/tmp/skills-install/install.sh --check --tool codex
+
 rm -rf /tmp/skills-install
 ```
 
@@ -169,7 +172,9 @@ files as duplicate skills.
 
 ## Checking for updates
 
-Each install writes a `.skills-lock.json` with content hashes. Compare against the source:
+Each install writes a `.skills-lock.json` with content hashes. In `--link` mode, the installer
+writes the lock file to both the canonical directory and each selected tool directory, so either
+canonical or tool-specific checks work after install. Compare against the source:
 
 ```bash
 ./install.sh --check                  # check default (Claude)
@@ -208,6 +213,8 @@ install.sh                # installer (25 targets, symlink mode, lock file)
 scripts/
   lint-skills.sh          # collection linter
   validate-spec.sh        # Agent Skills spec validator
+  test-install.sh         # installer regression tests
+  check-*.sh              # repository-specific safety and freshness checks
   skill-frontmatter.py    # frontmatter parser used by linters
   skill-lib.sh            # shared shell helpers
 ```

--- a/install.sh
+++ b/install.sh
@@ -196,7 +196,7 @@ backup_skill() {
   mkdir -p "$dest"
 
   if [[ -L "$dest_dir/$skill" ]]; then
-    cp -rL "$dest_dir/$skill/." "$dest/"
+    cp -P "$dest_dir/$skill" "$dest/"
   else
     cp -r "$dest_dir/$skill/." "$dest/"
   fi

--- a/install.sh
+++ b/install.sh
@@ -569,6 +569,7 @@ main() {
         [[ -d "$SKILLS_SRC/$skill" ]] || continue
         create_link "$skill" "$tool_dir" "$force" "$no_backup"
       done
+      write_lock "$tool_dir" "${skills[@]}"
       if [[ "$tool" == "opencode" ]]; then
         sync_opencode_permissions "$OPENCODE_CONFIG_FILE" "${skills[@]}"
       fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -83,7 +83,20 @@ PY
   trap - RETURN
 }
 
+test_link_mode_writes_tool_lock() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  HOME="$tmp" "$ROOT/install.sh" --tool codex --link --no-backup >/dev/null
+  HOME="$tmp" "$ROOT/install.sh" --check --tool codex >/dev/null
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
 test_backups_stay_outside_skill_root
 test_legacy_backups_are_migrated_outside_skill_root
 test_opencode_install_allows_installed_skills
+test_link_mode_writes_tool_lock
 printf 'install tests passed\n'

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -95,8 +95,35 @@ test_link_mode_writes_tool_lock() {
   trap - RETURN
 }
 
+test_backup_preserves_top_level_symlink() {
+  local tmp dest private backup_root
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  dest="$tmp/agent/skills"
+  private="$tmp/private"
+  mkdir -p "$dest" "$private"
+  printf '%s\n' 'do not copy' > "$private/secret.txt"
+  ln -s "$private" "$dest/docker"
+
+  "$ROOT/install.sh" --tool portable --dest "$dest" --force docker >/dev/null
+
+  backup_root="$tmp/agent/.skills-backups/skills/docker"
+  if find "$backup_root" -type f -name secret.txt -print -quit 2>/dev/null | grep -q .; then
+    fail "backup followed top-level symlink and copied external files"
+  fi
+
+  if ! find "$backup_root" -type l -name docker -print -quit 2>/dev/null | grep -q .; then
+    fail "expected backup to preserve top-level symlink"
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
 test_backups_stay_outside_skill_root
 test_legacy_backups_are_migrated_outside_skill_root
 test_opencode_install_allows_installed_skills
 test_link_mode_writes_tool_lock
+test_backup_preserves_top_level_symlink
 printf 'install tests passed\n'

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: databases
 description: >
-  · Configure/tune/migrate PostgreSQL, MongoDB, MySQL/MariaDB, MSSQL. Triggers: 'database', 'postgres', 'mysql', 'mongodb', 'schema', 'migration', 'pgbouncer', 'EXPLAIN'.
+  · Configure/tune/migrate PostgreSQL, MongoDB, MySQL/MariaDB, MSSQL. Triggers: 'database', 'postgres', 'mysql', 'mongodb', 'schema', 'migration', 'pgbouncer', 'EXPLAIN'. Not for HTTP APIs (use backend-api).
 license: MIT
 compatibility: "Requires one or more of: psql, mongosh, mysql, or sqlcmd"
 metadata:

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git
 description: >
-  · Handle git branches, commits, remotes, conflicts, hooks, signing, releases, PR/MR workflows. Triggers: 'git', 'commit', 'branch', 'merge', 'rebase', 'tag', 'push', 'PR', 'MR', 'gh', 'glab'.
+  · Handle git branches, commits, remotes, conflicts, hooks, signing, releases, PR/MR workflows. Triggers: 'git', 'commit', 'branch', 'merge', 'rebase', 'tag', 'push', 'PR', 'MR', 'gh', 'glab'. Not for CI pipelines (use ci-cd).
 license: MIT
 compatibility: "Requires git. Optional: gh (GitHub CLI), glab (GitLab CLI), fj (Forgejo CLI)"
 metadata:

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kubernetes
 description: >
-  · Write/review Kubernetes manifests, Helm, Kustomize, Gateway API, ArgoCD, sealed secrets. Triggers: 'kubernetes', 'k8s', 'helm', 'kubectl', 'deployment', 'pod', 'ingress', 'gateway'.
+  · Write/review Kubernetes manifests, Helm, Kustomize, Gateway API, ArgoCD, sealed secrets. Triggers: 'kubernetes', 'k8s', 'helm', 'kubectl', 'deployment', 'pod', 'ingress', 'gateway'. Not for Dockerfiles (use docker).
 license: MIT
 compatibility: "Requires kubectl. Optional: helm, kustomize, kube-score, cosign"
 metadata:

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -223,32 +223,18 @@ Run through the AI Self-Check above. Then:
 
 #### Step 6: Forward-test
 
-Forward-testing is stress-testing a skill by having a subagent use it on a realistic task without
-knowing it's being evaluated. This catches issues that static review misses - confusing
-instructions, missing context, steps that only work when you already know the answer.
+Forward-testing has a subagent use the skill on realistic tasks without seeing your diagnosis.
+Use it for high-effort skills and for medium-effort skills with multi-step or scripted workflows.
+Skip it for low-effort wrappers, unavailable subagents, production-only access, long-running
+infra, missing credentials, or explicit user opt-out; note the skip reason.
 
-**When to forward-test:**
-- Always for high-effort skills
-- For medium-effort skills if the workflow has >3 steps or uses scripts
-- Skip for low-effort skills unless they're tricky
+1. Pick 2-3 realistic tasks, including one edge case.
+2. Launch with a real-user prompt and raw artifacts only.
+3. Check whether the agent followed the workflow, missed steps, or hallucinated.
+4. Clean up artifacts between iterations.
 
-**How to forward-test:**
-1. Pick 2-3 realistic tasks the skill should handle, including one edge case.
-2. Launch a subagent with a real-user prompt, not a diagnostic prompt that leaks expected findings.
-3. Pass raw artifacts, not your diagnosis or expected output.
-4. Review whether the agent followed the workflow, missed steps, or hallucinated.
-5. Clean up artifacts between iterations to avoid context contamination.
-
-**Decision rule:** if forward-testing only succeeds when subagents see leaked context, the skill
-needs tightening - not the test setup.
-
-**Skip forward-testing when:**
-- It would require live production access, long-running infra, or user credentials
-- The harness disallows subagent delegation (e.g., Codex `exec`, restricted sandboxes)
-- The user explicitly asks to skip it
-- The skill is a trivial wrapper or meta-skill (e.g., full-review orchestrator)
-
-In these cases, note what was skipped and why so the user can test manually.
+If forward-testing only succeeds with leaked context, tighten the skill instead of weakening
+the test.
 
 ---
 
@@ -467,15 +453,9 @@ collection, run Mode 2 Step 2 (quality checks) to verify no regressions were int
 
 ## Run Report
 
-End every run with a human-readable report, even for report-only checks:
-
-```text
-Branch: <branch or unavailable>; Mode: <create|review|audit|optimize|retrospective>; Scope: <target>
-Score: <before> -> <after> (<delta>) or "not scored - report only"
-Changes: <files changed or none>; Findings: <critical/important/minor counts and top items>
-Verification: <lint/spec/forward-test/source checks with pass/fail>; Skipped: <what and why>
-Next: <recommended action>
-```
+End every run with a human-readable report, even for report-only checks. Include branch, mode,
+scope, score or "not scored - report only", changed files, finding counts, verification results,
+skipped checks, and recommended next action.
 
 For edited skills, score the checklist pass rate plus behavioral or forward-test results. For
 audit-only runs, report structural gate and finding counts instead of inventing a composite.

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: terraform
 description: >
-  · Write/review Terraform/OpenTofu HCL, modules, state, policy-as-code. Triggers: 'terraform', 'opentofu', 'hcl', 'tfvars', 'tfstate', 'module', 'terraform plan', 'tflint'.
+  · Write/review Terraform/OpenTofu HCL, modules, state, policy-as-code. Triggers: 'terraform', 'opentofu', 'hcl', 'tfvars', 'tfstate', 'module', 'terraform plan', 'tflint'. Not for Kubernetes manifests (use kubernetes).
 license: MIT
 compatibility: "Requires terraform or tofu CLI. Optional: tflint, checkov, conftest"
 metadata:


### PR DESCRIPTION
## Summary
- resolve skill audit findings and tighten routing descriptions
- fix linked-install lock refresh and symlink backup handling
- expand quality gates to cover top-level docs and installer regression tests
- document link-mode check behavior in INSTALL.md

## Verification
- ./scripts/lint-skills.sh
- ./scripts/validate-spec.sh
- ./scripts/test-install.sh
- ./install.sh --check --tool codex
- ./scripts/check-deep-audit-coverage.sh
- ./scripts/check-private-skill-leaks.sh
- ./scripts/check-protected-overlay.sh
- ./scripts/check-freshness-dates.sh
- actionlint -color
- bash -n install.sh scripts/*.sh
- shellcheck install.sh scripts/*.sh
- gitleaks detect --source . --redact
- semgrep scan --config auto --error install.sh scripts .github/workflows
- trivy fs --scanners vuln,secret,misconfig --skip-dirs node_modules --skip-dirs .git --skip-dirs skills/cluster-health/protected .