### PR TITLE
ci(links): ignore generated release compares

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -13,5 +13,6 @@ exclude = [
   "^https?://(?:[A-Za-z0-9-]+\\.)?example\\.(?:com|org)",
   "^https?://example-store\\.com",
   "^https?://internal\\.example\\.com",
-  "^https?://claude\\.ai"
+  "^https?://claude\\.ai",
+  "^https://github\\.com/iuliandita/skills/compare/v[0-9]+\\.[0-9]+\\.[0-9]+\\.\\.\\.v[0-9]+\\.[0-9]+\\.[0-9]+$"
 ]


### PR DESCRIPTION
## Summary
- exclude generated semver compare links from lychee
- keep CHANGELOG.md in the markdown and link-check file set so other links remain covered

## Verification
- `/home/id/.local/bin/lychee --config lychee.toml /tmp/skills-release-link.md`
- full local lychee sweep over README, SECURITY, CHANGELOG, INSTALL, skills, and docs