### PR TITLE
fix(skills): refresh audit and supply-chain guidance

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Test installer behavior
         run: ./scripts/test-install.sh
 
+      - name: Test lint behavior
+        run: ./scripts/test-lint-skills.sh
+
       - name: Shellcheck scripts
         run: shellcheck install.sh scripts/*.sh
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,10 +1,10 @@
 # Gitleaks configuration - allowlist for false positives in skill examples.
-# Skills contain example commands with placeholder credentials (key:secret,
-# your-key-here, etc.) that are not real secrets.
+# Keep allowlists content-specific. Do not exclude whole skill/reference paths.
 
-[allowlist]
-  paths = [
-    '''skills/.*/references/.*\.md''',
-  ]
+[extend]
+  useDefault = true
+
+[[allowlists]]
+  description = "Non-secret placeholder used in documentation examples"
   regexTarget = "match"
   regexes = ['''key:secret''']

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -137,23 +137,30 @@ check_length() {
 # ── Reference file checks ──────────────────────────────────────────────
 check_references() {
   local file="$1" name="$2" dir="$3"
-  # Check that referenced files exist (only in own references/ dir)
-  # Skip template examples (e.g., references/<topic-file>) and
-  # cross-skill references (lines mentioning other skill names)
-  local refs
-  refs=$(grep -oP '`references/[^`]+`' "$file" | sed "s/\`//g" || true)
-  for ref in $refs; do
-    # Skip template placeholders
-    [[ "$ref" == *"<"* ]] && continue
-    if [[ ! -f "$dir/$ref" ]]; then
-      # Check if this line mentions another skill (cross-reference)
-      local line
-      line=$(grep -F "$ref" "$file" | head -1)
-      if echo "$line" | grep -qP '\*\*[a-z][-a-z0-9]+\*\*'; then
-        continue  # cross-skill reference, not a local file
-      fi
-      error "$name: referenced file '$ref' does not exist"
-    fi
+  # Check that referenced files exist (only in own references/ dir).
+  # Scan SKILL.md and references/*.md, but ignore fenced examples.
+  local source_files=("$file")
+  for ref_file in "$dir"/references/*.md; do
+    [[ -f "$ref_file" ]] && source_files+=("$ref_file")
+  done
+
+  local source line_no line refs ref rel_source
+  for source in "${source_files[@]}"; do
+    rel_source="${source#"$dir"/}"
+    while IFS=$'\t' read -r line_no line; do
+      refs=$(grep -oP '`references/[^`]+`' <<< "$line" | sed "s/\`//g" || true)
+      for ref in $refs; do
+        # Skip template placeholders.
+        [[ "$ref" == *"<"* ]] && continue
+        if [[ ! -f "$dir/$ref" ]]; then
+          # Cross-skill references should name the other skill in bold.
+          if grep -qP '\*\*[a-z][-a-z0-9]+\*\*' <<< "$line"; then
+            continue
+          fi
+          error "$name: referenced file '$ref' does not exist in $rel_source:$line_no"
+        fi
+      done
+    done < <(awk '/^```/{skip=!skip; next} !skip{print NR "\t" $0}' "$source")
   done
 }
 

--- a/scripts/test-lint-skills.sh
+++ b/scripts/test-lint-skills.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+write_minimal_skill() {
+  local skill_dir="$1" name="$2"
+  mkdir -p "$skill_dir/references"
+  cat > "$skill_dir/SKILL.md" <<EOF
+---
+name: $name
+description: >
+  · Test fixture skill for lint behavior. Triggers: 'lint fixture'. Not for production use.
+license: MIT
+metadata:
+  source: custom
+  date_added: "2026-05-19"
+  effort: low
+---
+
+# Test Fixture
+
+## When to use
+
+- Testing lint behavior.
+
+## When NOT to use
+
+- Real work.
+
+## Workflow
+
+1. Run the lint fixture.
+
+## Rules
+
+1. Keep the fixture minimal.
+EOF
+}
+
+test_reference_files_are_scanned() {
+  local tmp skill_dir output status
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  skill_dir="$tmp/skills/lint-fixture"
+  write_minimal_skill "$skill_dir" "lint-fixture"
+  printf '%s\n' 'Read `references/missing.md` for missing details.' > "$skill_dir/references/details.md"
+
+  status=0
+  output="$("$ROOT/scripts/lint-skills.sh" "$tmp/skills" 2>&1)" || status=$?
+  if (( status == 0 )); then
+    printf '%s\n' "$output" >&2
+    fail "lint-skills.sh passed despite a missing reference from references/details.md"
+  fi
+  if [[ "$output" != *"referenced file 'references/missing.md' does not exist"* ]]; then
+    printf '%s\n' "$output" >&2
+    fail "lint-skills.sh did not report the missing reference file"
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_reference_examples_are_ignored() {
+  local tmp skill_dir
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  skill_dir="$tmp/skills/lint-fixture"
+  write_minimal_skill "$skill_dir" "lint-fixture"
+  cat > "$skill_dir/references/details.md" <<'EOF'
+```markdown
+Read `references/example.md` for detailed patterns.
+```
+EOF
+
+  "$ROOT/scripts/lint-skills.sh" "$tmp/skills" >/dev/null
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_reference_files_are_scanned
+test_reference_examples_are_ignored
+printf 'lint tests passed\n'

--- a/skills/ai-ml/references/target-versions.md
+++ b/skills/ai-ml/references/target-versions.md
@@ -1,23 +1,24 @@
 # AI/ML Target Versions
 
-May 2026 snapshot. Verify current releases before pinning.
+May 2026 snapshot. Verified 2026-05-19 against PyPI, npm, and upstream GitHub release APIs.
+Verify current releases before pinning.
 
 | Component | Version | Notes |
 |-----------|---------|-------|
-| Anthropic Python SDK | 0.87.0 | Claude models, streaming, tool use, structured output |
-| Anthropic TS SDK | 0.81.0 | Same capabilities, TypeScript-first |
-| Claude Agent SDK (TS) | 0.2.117 | Programmatic agent building with Claude Code capabilities |
-| OpenAI Python SDK | 2.32.0 | GPT/o-series models, Responses API |
-| OpenAI Agents SDK | 0.13.3 | Multi-agent orchestration, tracing, sessions |
-| Vercel AI SDK | 6.0.142 | Unified provider interface, ToolLoopAgent, streaming |
-| LangChain | 1.2.15 | Orchestration framework, langchain-core 1.2.24 |
-| LangGraph | 1.1.8 | Stateful agent graphs, cycles, persistence |
-| LlamaIndex | 0.14.21 | RAG framework, 300+ integrations |
-| Transformers | 5.4.0 | Model inference, fine-tuning, PyTorch 2.4+ required |
-| vLLM | 0.18.1 | High-throughput serving, continuous batching |
-| Ollama | 0.20.0 | Local inference, MLX backend on Apple Silicon |
+| Anthropic Python SDK | 0.102.0 | Claude models, streaming, tool use, structured output |
+| Anthropic TS SDK | 0.96.0 | Same capabilities, TypeScript-first |
+| Claude Agent SDK (TS) | 0.3.143 | Programmatic agent building with Claude Code capabilities |
+| OpenAI Python SDK | 2.37.0 | GPT/o-series models, Responses API |
+| OpenAI Agents SDK | 0.17.2 | Multi-agent orchestration, tracing, sessions |
+| Vercel AI SDK | 6.0.185 | Unified provider interface, ToolLoopAgent, streaming |
+| LangChain | 1.3.1 | Orchestration framework |
+| LangGraph | 1.2.0 | Stateful agent graphs, cycles, persistence |
+| LlamaIndex | 0.14.22 | RAG framework, 300+ integrations |
+| Transformers | 5.8.1 | Model inference, fine-tuning, PyTorch 2.4+ required |
+| vLLM | 0.21.0 | High-throughput serving, continuous batching |
+| Ollama | 0.24.0 | Local inference, MLX backend on Apple Silicon |
 | pgvector | 0.8.2 | PostgreSQL extension, HNSW + IVFFlat |
-| Qdrant | 1.17.1 | Self-hosted vector DB, hybrid search |
-| Pinecone (Python) | 8.1.0 | Managed vector DB |
-| ChromaDB | 1.5.5 | Lightweight vector DB, local-first |
-| promptfoo | 0.121.3 | LLM eval framework, red teaming |
+| Qdrant | 1.18.0 | Self-hosted vector DB, hybrid search |
+| Pinecone (Python) | 9.0.0 | Managed vector DB |
+| ChromaDB | 1.5.9 | Lightweight vector DB, local-first |
+| promptfoo | 0.121.11 | LLM eval framework, red teaming |

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -203,43 +203,9 @@ See "What NOT to Flag" below for domain exceptions (horticulture `landscape`, ch
 
 #### AI fallback character names (fiction)
 
-A documented tell across Claude, ChatGPT, Gemini, DeepSeek, and most open-source models: when asked to invent character names without strong setting constraints, models converge on a small "no-baggage" set. The 2025 Name of the Year (per Namerology) is **Elara** specifically because of AI saturation. A high-school teacher's grading rubric now docks 99 points for protagonist=Elara. The phenomenon is well enough documented that the name from the fallback set is itself the tell.
-
-**The fallback set** (incomplete; the phonetic pattern below is more reliable than the list):
-
-| Slot | Common picks |
-|---|---|
-| Female / femme-coded | Elara, Elena, Elana, Lena, Lyra, Aria, Aurora, Nova, Luna, Selene, Althea, Anya, Mira, Clara, Evelyn, Isabella, Seraphina, Isolde, Lily |
-| Male / masc-coded | Kael, Kaelan, Kaleb, Vale, Vance, Cassius, Caspian, Adrian, Orion, Atlas, Phoenix, Rylan, Theron, Damon, Silas, Ezra, Malachi, Jax, Dax, Rook |
-| Surnames | Voss, Vasquez, Thorne, Vale, Vance, Black, Hart, Cross, Reed, Knox, Stone, Hawk, Rourke |
-| Composite sci-fi | Elara Voss (DeepSeek), Elena Vasquez / Elana Vasquez (Claude Opus 4), Dr. Thorne / Dr. Aris Thorne (Gemini 2.5 Pro; 204 instances across 26 books in the 10,000-title Kaggle sci-fi corpus) |
-
-**The phonetic tell** (more reliable than memorizing the list):
-
-- 2 syllables, soft, vowel-heavy
-- A / L / R / N consonants, often clustered
-- no cultural, class, regional, ethnic, religious, or period anchor
-- one-syllable curt variants (`Jax`, `Rook`) for "tough" types
-- Latin / Greek roots (`Cassius`, `Orion`, `Aurora`) for "noble" types
-- biblical roots (`Silas`, `Malachi`, `Ezra`) for "serious" types
-- `Dr. <single-syllable>` for sci-fi authority figures
-
-**Why it happens:** models filter names with demographic baggage to avoid offense or distraction. Brittany sounds millennial; Karen carries political residue; Mohammed signals Muslim; Mihai signals Romanian. What's left is the no-baggage set -- names so unfamiliar that they cannot insult anyone, which is exactly why they keep recurring. Per the ChuckMcSneed HuggingFace experiment, instruct models showed up to 77% skew toward their top 10 names while base models stayed near 4% -- the phenomenon is an artifact of alignment, not raw capability.
-
-**Detect:**
-
-- generated character names that match the fallback set OR the phonetic pattern
-- multiple invented characters in the same piece with names from the same phonological family
-- proper names that resist being placed in any real demographic, period, region, or culture
-- the composite sci-fi patterns (`<female fallback> <sharp surname>`, `Dr. <single-syllable>`)
-
-**Fix:** anchor names to the setting's actual population -- culture, class, region, period, religion, ethnicity. For invented worlds, build a coherent in-world linguistic system (consistent phonetic rules, prefix/suffix patterns) rather than grabbing soft phonemes. For sci-fi authority figures, let the role carry the slot (`the medic`, `the supervisor`) rather than reaching for `Dr. Thorne`.
-
-**Exception:** these names are not banned, only suspect. A setting whose population organically produces Aurora or Cassius can use them. The failure is the model reaching for these names because it had no other ideas, not the names themselves. For prior-draft characters whose names were chosen deliberately, do not rename without explicit permission.
-
-For fiction-specific handling with mechanism and fix detail, see the `short-form-fiction` skill's `ai-slop-fiction.md` reference (section: AI fallback character names).
-
-Sources: Namerology (2025 Name of the Year is Elara); ChuckMcSneed, "Name Diversity in LLMs Experiment" (HuggingFace); Guillaume Laforge, "The Sci-Fi Naming Problem" (glaforge.dev, 2025).
+Generated fiction often converges on soft, no-baggage names such as `Elara`, `Kael`, or
+`Voss`. If a prose audit includes invented character names, read
+`references/fiction-name-tells.md` for the fallback-name pattern, exceptions, and fix guidance.
 
 ### 2. Syntax Tells (Noise + Soul)
 

--- a/skills/anti-ai-prose/references/fiction-name-tells.md
+++ b/skills/anti-ai-prose/references/fiction-name-tells.md
@@ -1,0 +1,60 @@
+# Fiction Name Tells
+
+## AI fallback character names
+
+A documented tell across Claude, ChatGPT, Gemini, DeepSeek, and most open-source models:
+when asked to invent character names without strong setting constraints, models converge on a
+small "no-baggage" set. The 2025 Name of the Year (per Namerology) is **Elara** specifically
+because of AI saturation. A high-school teacher's grading rubric now docks 99 points for
+protagonist=Elara. The phenomenon is well enough documented that the name from the fallback set
+is itself the tell.
+
+**The fallback set** (incomplete; the phonetic pattern below is more reliable than the list):
+
+| Slot | Common picks |
+|---|---|
+| Female / femme-coded | Elara, Elena, Elana, Lena, Lyra, Aria, Aurora, Nova, Luna, Selene, Althea, Anya, Mira, Clara, Evelyn, Isabella, Seraphina, Isolde, Lily |
+| Male / masc-coded | Kael, Kaelan, Kaleb, Vale, Vance, Cassius, Caspian, Adrian, Orion, Atlas, Phoenix, Rylan, Theron, Damon, Silas, Ezra, Malachi, Jax, Dax, Rook |
+| Surnames | Voss, Vasquez, Thorne, Vale, Vance, Black, Hart, Cross, Reed, Knox, Stone, Hawk, Rourke |
+| Composite sci-fi | Elara Voss (DeepSeek), Elena Vasquez / Elana Vasquez (Claude Opus 4), Dr. Thorne / Dr. Aris Thorne (Gemini 2.5 Pro; 204 instances across 26 books in the 10,000-title Kaggle sci-fi corpus) |
+
+**The phonetic tell** (more reliable than memorizing the list):
+
+- 2 syllables, soft, vowel-heavy
+- A / L / R / N consonants, often clustered
+- no cultural, class, regional, ethnic, religious, or period anchor
+- one-syllable curt variants (`Jax`, `Rook`) for "tough" types
+- Latin / Greek roots (`Cassius`, `Orion`, `Aurora`) for "noble" types
+- biblical roots (`Silas`, `Malachi`, `Ezra`) for "serious" types
+- `Dr. <single-syllable>` for sci-fi authority figures
+
+**Why it happens:** models filter names with demographic baggage to avoid offense or
+distraction. Brittany sounds millennial; Karen carries political residue; Mohammed signals
+Muslim; Mihai signals Romanian. What's left is the no-baggage set - names so unfamiliar that
+they cannot insult anyone, which is exactly why they keep recurring. Per the ChuckMcSneed
+HuggingFace experiment, instruct models showed up to 77% skew toward their top 10 names while
+base models stayed near 4% - the phenomenon is an artifact of alignment, not raw capability.
+
+**Detect:**
+
+- generated character names that match the fallback set OR the phonetic pattern
+- multiple invented characters in the same piece with names from the same phonological family
+- proper names that resist being placed in any real demographic, period, region, or culture
+- the composite sci-fi patterns (`<female fallback> <sharp surname>`, `Dr. <single-syllable>`)
+
+**Fix:** anchor names to the setting's actual population - culture, class, region, period,
+religion, ethnicity. For invented worlds, build a coherent in-world linguistic system
+(consistent phonetic rules, prefix/suffix patterns) rather than grabbing soft phonemes. For
+sci-fi authority figures, let the role carry the slot (`the medic`, `the supervisor`) rather
+than reaching for `Dr. Thorne`.
+
+**Exception:** these names are not banned, only suspect. A setting whose population organically
+produces Aurora or Cassius can use them. The failure is the model reaching for these names
+because it had no other ideas, not the names themselves. For prior-draft characters whose names
+were chosen deliberately, do not rename without explicit permission.
+
+For fiction-specific handling with mechanism and fix detail, see the `short-form-fiction`
+skill's `ai-slop-fiction.md` reference (section: AI fallback character names).
+
+Sources: Namerology (2025 Name of the Year is Elara); ChuckMcSneed, "Name Diversity in LLMs
+Experiment" (HuggingFace); Guillaume Laforge, "The Sci-Fi Naming Problem" (glaforge.dev, 2025).

--- a/skills/backend-api/references/http-api-patterns.md
+++ b/skills/backend-api/references/http-api-patterns.md
@@ -131,7 +131,7 @@ Typical pattern:
 
 ```http
 POST /payments
-Idempotency-Key: 77a5e517-0b63-42c2-8fb7-d4df0f1e30e6
+Idempotency-Key: <uuid>
 ```
 
 Rules:

--- a/skills/ci-cd/references/best-practices.md
+++ b/skills/ci-cd/references/best-practices.md
@@ -227,8 +227,8 @@ Both are good. Pick one per pipeline and stick with it.
 
 - **Trivy** - one binary, scans images + filesystems + IaC + secrets + licenses. Good
   default for teams who want fewer tools. After the 2025 TeamPCP incident, pin to a
-  verified version (`v0.69.3` or later from a trusted source; avoid `v0.69.4/5/6` which
-  were compromised).
+  verified version (`v0.70.0+` from official releases; `v0.69.3` was the March 2026
+  rollback version; avoid `v0.69.4/5/6` which were compromised).
 - **Grype** - vulnerability-matching only, but has **risk scoring** that combines CVSS
   + EPSS (exploit probability) + CISA KEV. Better signal-to-noise on severity gates -
   a critical CVE with 0.1% EPSS is not the same as a high CVE in CISA KEV with 95% EPSS,

--- a/skills/ci-cd/references/github-actions.md
+++ b/skills/ci-cd/references/github-actions.md
@@ -530,8 +530,10 @@ security:
         sarif_file: trivy.sarif
 ```
 
-**Trivy safe versions (March 2026)**: binary v0.69.3, `trivy-action@v0.35.0`,
-`setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6 (compromised by TeamPCP).
+**Trivy safe versions (May 2026)**: use binary v0.70.0+ from official releases and pin
+actions to full commit SHAs. The March 2026 rollback set was binary v0.69.3,
+`trivy-action@v0.35.0`, and `setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6
+(compromised by TeamPCP).
 
 ---
 

--- a/skills/ci-cd/references/gitlab-ci.md
+++ b/skills/ci-cd/references/gitlab-ci.md
@@ -491,7 +491,7 @@ include:
 trivy-scan:
   stage: scan
   image:
-    name: aquasec/trivy:0.69.3    # known safe - do NOT use 0.69.4/5/6
+    name: aquasec/trivy:0.70.0@sha256:<digest>    # pin digest; do NOT use 0.69.4/5/6
   script:
     - trivy image --exit-code 1 --severity HIGH,CRITICAL $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
   allow_failure: true    # non-blocking for dev/staging; set to false for release pipelines (PCI 6.2.1)
@@ -840,7 +840,7 @@ build-worker:
 scan:
   stage: scan
   image:
-    name: aquasec/trivy:0.69.3
+    name: aquasec/trivy:0.70.0@sha256:<digest>
   script:
     - |
       for svc in api web worker; do

--- a/skills/ci-cd/references/supply-chain.md
+++ b/skills/ci-cd/references/supply-chain.md
@@ -37,10 +37,11 @@ they inform every recommendation in this document.
 - Downstream: stolen credentials used to compromise dozens of npm packages distributing **CanisterWorm** (self-propagating worm)
 - **Lesson**: even security tools' own CI is a target. "We trust our scanning tool" is circular reasoning.
 
-**Known safe Trivy versions (as of 2026-03-24)**:
-- Binary: v0.69.2, v0.69.3
-- `trivy-action`: **v0.35.0** (verify SHA, not tag)
-- `setup-trivy`: v0.2.6
+**Known safe Trivy versions**:
+- Current new pins (May 2026): binary v0.70.0+ from official releases, pinned by checksum or image digest
+- March 2026 rollback: binary v0.69.2 or v0.69.3
+- `trivy-action`: **v0.35.0** was the March rollback tag; pin the verified commit SHA, not the tag
+- `setup-trivy`: v0.2.6 was the March rollback tag; pin the verified commit SHA, not the tag
 - **DO NOT USE**: v0.69.4, v0.69.5, v0.69.6
 
 **IOC**: check for a repo named `tpcp-docs` in your org - its presence indicates the fallback
@@ -82,14 +83,14 @@ image: aquasec/trivy:latest
 
 # DO
 image:
-  name: aquasec/trivy:0.69.3@sha256:<digest>
+  name: aquasec/trivy:0.70.0@sha256:<digest>
 ```
 
 ### How (Docker images in any CI)
 
 ```bash
 # Get the digest
-docker inspect --format='{{index .RepoDigests 0}}' aquasec/trivy:0.69.3
+docker inspect --format='{{index .RepoDigests 0}}' aquasec/trivy:0.70.0
 
 # Pin to digest
 image: aquasec/trivy@sha256:abc123def456...

--- a/skills/ci-cd/references/target-versions.md
+++ b/skills/ci-cd/references/target-versions.md
@@ -1,10 +1,11 @@
 # CI/CD Target Versions
 
-May 2026 snapshot. Verify current releases before pinning.
+May 2026 snapshot. Verified 2026-05-19 against GitLab/Gitea/Forgejo APIs, GitHub releases,
+and supply-chain tool releases. Verify current releases before pinning.
 
 - **GitHub Actions**: ubuntu-24.04 runners (ubuntu-latest), arm64 GA, artifact v4, attestations GA
-- **GitLab CI/CD**: GitLab 18.10.3, CI/CD Catalog GA, CI Components with typed `spec: inputs`
-- **Forgejo Actions**: Forgejo v15.0, Runner v11.x (stable; check `data.forgejo.org/forgejo/runner` releases for current major tag before pinning)
-- **Gitea Actions**: Gitea v1.26.0, act runner v0.2.x (GA since Gitea 1.21, March 2024)
-- **Woodpecker CI**: v3.13.x (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)
-- **Supply chain**: cosign v3.x (Sigstore), Syft/Trivy for SBOM, SLSA v1.1
+- **GitLab CI/CD**: GitLab 18.11.2 current patch line; 18.10.5 for the 18.10 line. CI/CD Catalog GA, CI Components with typed `spec: inputs`
+- **Forgejo Actions**: Forgejo v15.0.2, Runner v12.10.1 (check `data.forgejo.org/forgejo/runner` releases before pinning)
+- **Gitea Actions**: Gitea v1.26.1, act runner v1.0.4 (GA since Gitea 1.21, March 2024)
+- **Woodpecker CI**: v3.14.1 (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)
+- **Supply chain**: cosign v3.0.6 (Sigstore), Syft v1.44.0, Trivy v0.70.0, SLSA v1.1

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -129,7 +129,7 @@ docker scout cves --only-severity critical,high <image>
 cosign verify --key <key> <image>     # verify signature
 syft <image> -o spdx-json             # generate SBOM
 grype <image>                         # vulnerability scan (alternative to Scout)
-trivy image <image>                   # use v0.69.3 ONLY (v0.69.4-6 COMPROMISED)
+trivy image <image>                   # use v0.70.0+; never v0.69.4-6
 ```
 
 ## Dockerfile
@@ -270,7 +270,7 @@ Read `references/security-and-compliance.md` for the full PCI-DSS 4.0 container 
 | CVE-2025-31133 | runc | High | Container escape via /dev/null symlink race | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
 | CVE-2025-52565 | runc | High | Container escape via /dev/console mount race | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
 | CVE-2025-52881 | runc | High | Host procfs writes via /proc redirect (DoS/escape) | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
-| CVE-2026-33634 | Trivy | Critical | Supply chain - malware in Docker Hub images (v0.69.4-6) | Trivy v0.69.3 (safe) |
+| CVE-2026-33634 | Trivy | Critical | Supply chain - malware in Docker Hub images (v0.69.4-6) | Trivy v0.70.0+ for new pins; v0.69.3 only as rollback |
 | CVE-2026-2664 | Docker Desktop | Medium | gRPC-FUSE kernel module OOB read | Desktop 4.62.0+ |
 | CVE-2025-13743 | Docker Desktop | Low | Expired Hub PATs leaked in diagnostics bundles | Desktop 4.54.0 |
 | CVE-2026-28400 | Model Runner | 7.5 High | Runtime flag injection - arbitrary file overwrite, container escape | Desktop 4.61.0+ |
@@ -330,7 +330,7 @@ For a hardened Dockerfile pattern, see `references/dockerfile-patterns.md` (Lang
 - **Verify at deploy**: `cosign verify --key cosign.pub <image>@<digest>`
 - **Pin CI tool images to SHA256 digests.** Mutable tags are a proven attack vector (Trivy March 2026, tj-actions/reviewdog March 2025).
 - **Use Docker Scout** or Grype for continuous vulnerability monitoring.
-- **Trivy**: safe version is v0.69.3 ONLY. v0.69.4-6 contained credential-stealing malware. If any CI pipeline ran compromised Trivy between March 19-23, 2026, rotate ALL secrets.
+- **Trivy**: use v0.70.0+ from official releases for new pins. v0.69.3 was the March 2026 rollback version. v0.69.4-6 contained credential-stealing malware. If any CI pipeline ran compromised Trivy between March 19-23, 2026, rotate ALL secrets.
 
 ### PCI-DSS 4.0 container requirements (summary)
 
@@ -340,7 +340,7 @@ PCI-DSS 4.0 is the only active version. Key container-specific requirements:
 - **Req 2.2**: Harden containers - non-root, drop caps, read-only rootfs, one process per container
 - **Req 4**: Encrypt transmissions - TLS between CDE containers in Compose (mount certs, use TLS-enabled images, or front with a TLS-terminating reverse proxy)
 - **Req 5.2/5.3**: Immutable images (deploy by digest), Falco for runtime detection
-- **Req 6.3**: Vulnerability scanning on every image before deployment (Docker Scout, Grype, Trivy v0.69.3)
+- **Req 6.3**: Vulnerability scanning on every image before deployment (Docker Scout, Grype, Trivy v0.70.0+)
 - **Req 6.3.2**: SBOM for every production image
 - **Req 8.6.2**: No hardcoded secrets in images, compose files, or env vars
 - **Req 10**: Audit logging - container stdout/stderr to immutable log store
@@ -412,10 +412,10 @@ GPU containers: use `deploy.resources.reservations.devices` with `capabilities: 
 - [ ] runc >= 1.4.0 (CVE-2025-31133/52565/52881 patched)
 - [ ] BuildKit >= 0.28.1 (CVE-2026-33747/33748 patched)
 - [ ] Docker Desktop >= 4.66.1 (CVE-2025-9074/CVE-2026-28400 patched)
-- [ ] Trivy v0.69.3 ONLY (v0.69.4-6 COMPROMISED)
+- [ ] Trivy v0.70.0+ from official releases (v0.69.4-6 COMPROMISED)
 - [ ] Images signed with cosign, verified at deploy
 - [ ] SBOM generated for every production image
-- [ ] Vulnerability scanning in CI (Docker Scout, Grype, or Trivy v0.69.3)
+- [ ] Vulnerability scanning in CI (Docker Scout, Grype, or Trivy v0.70.0+)
 - [ ] No `:latest` tags in production (pin version or SHA256 digest)
 - [ ] CI tools pinned to SHA256 digests (not mutable tags)
 - [ ] Base images rebuilt/updated regularly (weekly minimum)
@@ -474,7 +474,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 5. **Deps before source.** Copy dependency manifests first, install, then copy source. Layer cache depends on it.
 6. **Healthchecks on everything.** Dockerfile `HEALTHCHECK` and Compose `healthcheck:`.
 7. **Pin CI tools to SHA256 digests.** Mutable tags are compromised supply chain vectors (Trivy CVE-2026-33634 March 2026, tj-actions CVE-2025-30066 (upstream: reviewdog CVE-2025-30154) March 2025).
-8. **Trivy v0.69.3 only.** v0.69.4-6 contained credential-stealing malware. If you ran it, rotate secrets.
+8. **Trivy v0.70.0+ for new pins.** v0.69.3 was the March 2026 rollback version; v0.69.4-6 contained credential-stealing malware. If you ran it, rotate secrets.
 9. **Compose: no `version:` field.** It's deprecated and removed. Just delete it.
 10. **Clean apt cache in the same RUN layer.** `apt-get update && apt-get install -y ... && rm -rf /var/lib/apt/lists/*` - all one `RUN`.
 11. **`.dockerignore` is not optional.** `.git`, `node_modules`, `.env`, secrets, test fixtures, docs - all excluded.

--- a/skills/docker/references/security-and-compliance.md
+++ b/skills/docker/references/security-and-compliance.md
@@ -14,7 +14,7 @@ Security hardening, vulnerability management, supply chain integrity, and PCI-DS
 | CVE-2025-31133 | High | runc | Mount manipulation (/dev/null symlink) enables host procfs writes | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
 | CVE-2025-52565 | High | runc | /dev/console race condition grants premature mount access | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
 | CVE-2025-52881 | High | runc | procfs write redirect bypasses LSM relabel, host procfs writes | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
-| CVE-2026-33634 | Critical | Trivy | Supply chain - credential-stealing malware in aquasec/trivy Docker Hub images v0.69.4-6 | Trivy v0.69.3 (safe) |
+| CVE-2026-33634 | Critical | Trivy | Supply chain - credential-stealing malware in aquasec/trivy Docker Hub images v0.69.4-6 | Trivy v0.70.0+ for new pins; v0.69.3 only as rollback |
 | CVE-2026-2664 | Medium | Docker Desktop | gRPC-FUSE kernel module out-of-bounds read | Desktop 4.62.0+ |
 | CVE-2025-13743 | Low | Docker Desktop | Expired Hub PATs leaked in diagnostic bundles via error object serialization | Desktop 4.54.0+ |
 | CVE-2026-28400 | 7.5 High | Model Runner | Runtime flag injection via _configure endpoint - arbitrary file overwrite, container escape | Desktop 4.61.0+ |
@@ -66,7 +66,7 @@ The attackers are a cloud-native threat group active 2025-2026, known for Docker
 1. **Pin images to SHA256 digests**, not tags:
    ```dockerfile
    # BAD: mutable tag
-   FROM aquasec/trivy:0.69.3
+   FROM aquasec/trivy:0.70.0@sha256:<digest>
 
    # GOOD: immutable digest
    FROM aquasec/trivy@sha256:abc123def456...
@@ -94,7 +94,7 @@ The attackers are a cloud-native threat group active 2025-2026, known for Docker
 | Tool | Scans | SBOM | Signs | Free | Notes |
 |------|-------|------|-------|------|-------|
 | **Docker Scout** | Images, SBOM, policies | Generate | No | Free tier | Built into Docker CLI. `docker scout cves`, `docker scout sbom` |
-| **Trivy** (v0.69.3) | Images, IaC, repos, SBOM | Generate | No | Yes | Multi-purpose. PIN TO v0.69.3 |
+| **Trivy** (v0.70.0+) | Images, IaC, repos, SBOM | Generate | No | Yes | Multi-purpose. Pin exact version and digest |
 | **Grype** (Anchore) | Images | No | No | Yes | Fast CVE scanner. Pair with Syft |
 | **Syft** (Anchore) | N/A | Generate | No | Yes | SBOM generator. SPDX + CycloneDX |
 | **Cosign** (Sigstore) | N/A | Attach | Yes | Yes | Keyless OCI signing. Industry standard |
@@ -109,7 +109,7 @@ docker buildx build --provenance=true --sbom=true -t $IMAGE --push .
 
 # 2. Scan (use multiple tools for coverage)
 docker scout cves $IMAGE --exit-code --only-severity critical,high
-trivy image --severity HIGH,CRITICAL --exit-code 1 $IMAGE    # pinned v0.69.3!
+trivy image --severity HIGH,CRITICAL --exit-code 1 $IMAGE    # pinned v0.70.0+ binary or image digest
 
 # 3. Sign (keyless via Sigstore OIDC in CI)
 cosign sign $IMAGE@sha256:$DIGEST
@@ -296,7 +296,7 @@ PCI-DSS 4.0 is the only active version (3.2.1 retired March 2024). All future-da
 | 2.2.4-6 | Remove unnecessary functionality | Distroless/Chainguard base images. No shells, package managers, or dev tools in production. |
 | 5.2/5.3 | Malware protection, FIM | Immutable images (deploy by digest). `read_only: true`. Runtime detection (Falco/Tetragon). |
 | 6.2.1 | Bespoke and custom software developed securely | Images from verified publishers. Signed with cosign. Verified at deployment (admission control). |
-| 6.3.1 | Vulnerability identification | Image scanning in CI (Docker Scout, Grype, Trivy v0.69.3) and before every deployment. |
+| 6.3.1 | Vulnerability identification | Image scanning in CI (Docker Scout, Grype, Trivy v0.70.0+) and before every deployment. |
 | 6.3.2 | Component inventory | SBOM generated for every production image. Stored and queryable. |
 | 6.4.2 | WAF on public-facing apps | Reverse proxy with WAF (ModSecurity, Cloud Armor) in front of CDE containers. |
 | 8.6.2 | No hardcoded secrets | No secrets in Dockerfiles, Compose files, env vars, committed `.env` files. Use Compose secrets or Vault. |

--- a/skills/docker/references/target-versions.md
+++ b/skills/docker/references/target-versions.md
@@ -1,10 +1,11 @@
 # Docker Target Versions
 
-May 2026 snapshot. Verify current releases before pinning.
+May 2026 snapshot. Verified 2026-05-19 against Docker release notes, Docker Desktop appcast,
+and upstream GitHub release APIs. Verify current releases before pinning.
 
-- Docker Engine 29.4.0, Docker Desktop 4.66.1
+- Docker Engine 29.4.3, Docker Desktop 4.73.x (4.73.1 Windows, 4.73.0 macOS/Linux)
 - Docker Compose v5.1.3 (Go SDK, Bake-delegated builds)
-- BuildKit v0.29.0 (bundled with Engine 29.x)
-- containerd 2.2.3 / **2.3 LTS** (recommended for production after checking release notes)
-- Podman 5.8.2, Buildah 1.43.0
-- runc 1.4.1 (latest; CVE-2025-31133/52565/52881 patched since 1.4.0)
+- BuildKit v0.30.0
+- containerd 2.3.0 LTS (recommended for production after checking release notes)
+- Podman 5.8.2, Buildah 1.43.1
+- runc 1.4.2 (CVE-2025-31133/52565/52881 patched since 1.4.0)

--- a/skills/git/references/forge-workflows.md
+++ b/skills/git/references/forge-workflows.md
@@ -146,7 +146,8 @@ host. `glab` picks the right token based on the repo's remote. For repos without
 yet, use `GITLAB_HOST` or `--host`.
 
 **SSH-IP vs hostname mismatch**: if the SSH remote resolves to an IP and the web URL uses
-a hostname, `glab mr list` can fail. Use `glab api` with URL-encoded paths (see `ci-cd/references/gitlab-ci.md`).
+a hostname, `glab mr list` can fail. Use `glab api` with URL-encoded paths (see the
+**ci-cd** skill's `references/gitlab-ci.md`).
 
 ### MR creation with `glab`
 

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -328,7 +328,7 @@ The Trivy supply chain attack (CVE-2026-33634) is the defining security event of
 - **Monitor for force-push events** on action repos you depend on. GitHub's audit log and StepSecurity Harden-Runner can detect this.
 - **Vendor critical CI tools** or use pre-built, verified binaries instead of pulling from upstream on every run.
 - **Rotate secrets** if any CI pipeline ran compromised Trivy (v0.69.4/5/6) between March 19-23, 2026. The infostealer malware exfiltrated SSH keys, cloud creds, Docker configs, and k8s tokens.
-- **Trivy safe version: v0.69.3.** Actions: `trivy-action@v0.35.0`, `setup-trivy@v0.2.6` (verify SHAs against GitHub security advisory GHSA-69fq-xp46-6x23).
+- **Trivy safe version: v0.70.0+ for new pins.** v0.69.3 was the March 2026 rollback version. Actions such as `trivy-action@v0.35.0` and `setup-trivy@v0.2.6` still need verified commit SHAs, not mutable tags.
 
 ### Platform awareness
 

--- a/skills/kubernetes/references/architecture.md
+++ b/skills/kubernetes/references/architecture.md
@@ -223,7 +223,7 @@ The Trivy supply chain attack (CVE-2026-33634) demonstrated that **mutable Git t
 - **Separate CI secrets by environment**: staging pipeline should NOT have access to production credentials.
 - **Monitor action repos for force-push events**: subscribe to security advisories for all actions you use.
 
-**Trivy safe versions (as of 2026-03-24):** binary v0.69.3, `trivy-action@v0.35.0`, `setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6.
+**Trivy safe versions (May 2026):** use binary v0.70.0+ from official releases for new pins. The March 2026 rollback set was binary v0.69.3, `trivy-action@v0.35.0`, and `setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6.
 
 ### Secrets Management
 

--- a/skills/kubernetes/references/compliance.md
+++ b/skills/kubernetes/references/compliance.md
@@ -87,7 +87,7 @@ Cloud provider responsibility for managed K8s (EKS, GKE, AKS). Document the shar
 
 | Sub-req | K8s implementation |
 |---------|-------------------|
-| 11.3.1 (quarterly vuln scans) | **Trivy Operator** (v0.69.3 - see supply chain warning below) continuous in-cluster scanning; registry scanning on schedule. |
+| 11.3.1 (quarterly vuln scans) | **Trivy Operator** pinned to a current verified release (see supply chain warning below) for continuous in-cluster scanning; registry scanning on schedule. |
 | 11.3.1.2 (authenticated internal scans) | **Application-level** scans with credentials (Nessus, Qualys, OpenVAS) from within the cluster network. This is NOT the same as image scanning - PCI requires scanning the running application endpoints with authenticated plugins. Trivy/Grype scan images; Nessus/Qualys scan the live app. You need both. |
 | 11.5/11.5.2 (FIM, change detection) | **Falco** rules for critical file writes; **ArgoCD/Flux** drift detection (Git as source of truth); admission controllers blocking non-compliant changes. |
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -120,7 +120,7 @@ Find known CVEs in dependencies and assess supply chain risk.
 - **Python**: `pip-audit --format json` or `safety check --json`
 - **Go**: `govulncheck ./...`
 - **Rust**: `cargo audit --json` - also check for `unsafe` blocks without `// SAFETY:` comments, `transmute` misuse, unvalidated FFI boundaries
-- **General**: `trivy fs --scanners vuln .` (verify trivy version is 0.69.3 or earlier - 0.69.4-0.69.6 are compromised)
+- **General**: `trivy fs --scanners vuln .` (use Trivy 0.70.0+ from official releases, or 0.69.3 only as a March 2026 incident rollback; never use 0.69.4-0.69.6)
 
 **Flag**: HIGH/CRITICAL CVEs with fixes available, deps unmaintained 2+ years, lockfile out of sync with manifest, non-standard registries.
 

--- a/skills/security-audit/references/report-guide.md
+++ b/skills/security-audit/references/report-guide.md
@@ -85,7 +85,7 @@ X findings: N critical, N high, N medium, N low, N informational.
 - semgrep: `pip install semgrep` or `brew install semgrep`
 - gitleaks: `brew install gitleaks` or `go install github.com/gitleaks/gitleaks/v8@latest`
 - trufflehog: `brew install trufflehog` or `go install github.com/trufflesecurity/trufflehog/v3@latest`
-- trivy: `brew install trivy` or see https://aquasecurity.github.io/trivy (use v0.69.3 - versions 0.69.4-0.69.6 are compromised)
+- trivy: `brew install trivy` or see https://aquasecurity.github.io/trivy (use v0.70.0+ from official releases; v0.69.3 was the March 2026 incident rollback; never use v0.69.4-0.69.6)
 - scorecard: `go install github.com/ossf/scorecard/v5/cmd/scorecard@latest`
 - checkov: `pip install checkov`
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -55,9 +55,11 @@ Before returning any generated or modified skill, verify against this list:
   cross-referencing related skills by **bold** name (e.g., `use **skill-name**`)
 - [ ] **Workflow section with numbered steps**: clear, sequential, actionable
 - [ ] **Rules section at the end**: non-negotiable constraints in imperative form
-- [ ] **Style compliant**: no banned words (per `CLAUDE.md`/`AGENTS.md`), plain ASCII only
-  (no em-dashes, curly quotes, ligatures - use a single `-` where you would reach for an em
-  dash, never `--`). Check both SKILL.md AND reference files - banned words in references count
+- [ ] **Style compliant**: no banned words (per `CLAUDE.md`/`AGENTS.md`), ASCII by default
+  except collection-approved markers such as the public-description `· ` prefix and shared
+  output-contract box glyphs. No em-dashes, curly quotes, ligatures, or `--` dash substitutes.
+  Use a single `-` where you would reach for an em dash. Check both SKILL.md AND reference files
+  - banned words in references count
 - [ ] **Target ~500 lines**: if over 500, extract to `references/` with clear pointers. Hard max 600
 - [ ] **Reference files use `references/` relative paths**: not hardcoded or tool-specific paths
 - [ ] **All references verified**: every tool, CLI flag, IaC resource, config snippet, and
@@ -486,7 +488,9 @@ See `skills/_shared/output-contract.md` for the full contract.
    inventories and verify counts from live public skills.
 6. **No AI slop in skills.** Avoid comment noise, over-abstraction, ALL CAPS theater, and
    "just in case" instructions.
-7. **Plain ASCII only.** No em dashes, curly quotes, ligatures, or `--` dash substitutes.
+7. **ASCII by default.** Keep skill prose ASCII except collection-approved markers such as the
+   public-description `· ` prefix and shared output-contract box glyphs. No em dashes, curly
+   quotes, ligatures, or `--` dash substitutes.
 8. **Run the AI Self-Check.** Every generated or modified skill gets checked before return.
 9. **Branch every run.** In git-backed collections, create or record a run branch before checks.
 10. **Report every run.** Finish with the Run Report format and score before/after or "not scored."

--- a/skills/skill-creator/references/conventions.md
+++ b/skills/skill-creator/references/conventions.md
@@ -241,7 +241,10 @@ Overview.
 ### Text
 
 - **Imperative form**: "Check the config", not "You should check the config"
-- **Plain ASCII**: no em-dashes, no `--` double-dash substitute, no curly quotes, no ligatures. Use a single `-` where you would reach for an em dash.
+- **ASCII by default**: skill prose should stay ASCII except collection-approved markers such
+  as the public-description `· ` prefix and shared output-contract box glyphs. No em-dashes,
+  no `--` double-dash substitute, no curly quotes, no ligatures. Use a single `-` where you
+  would reach for an em dash.
 - **Explain why**: "Pin images to SHA256 digests because mutable tags are a proven attack vector
   (Trivy March 2026, tj-actions March 2025)" beats "Always pin images"
 - **Calm directives**: "Do X" outperforms "YOU MUST ALWAYS DO X" on most modern coding agents. Use ALL CAPS

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -408,7 +408,7 @@ provider "aws" {
 | Tool | Role | Status |
 |------|------|--------|
 | **Checkov** | Static HCL + plan analysis, 750+ checks, PCI/CIS/NIST frameworks | 🟢 Active, recommended |
-| **Trivy** (absorbed tfsec) | IaC + container + repo scanning, single binary | 🟢 Active (v0.69.3 safe, v0.69.4-6 COMPROMISED) |
+| **Trivy** (absorbed tfsec) | IaC + container + repo scanning, single binary | 🟢 Active (use v0.70.0+ for new pins; v0.69.4-6 COMPROMISED) |
 | **TFLint** | Provider-specific linting, catches misconfigs linters miss | 🟢 Active |
 | **OPA / Conftest** | Custom policy-as-code on JSON plan output | 🟢 Active (CNCF) |
 | **Sentinel** | Native TFC/TFE policy engine | 🟢 Active (proprietary) |

--- a/skills/terraform/references/production-checklist.md
+++ b/skills/terraform/references/production-checklist.md
@@ -35,7 +35,7 @@ Pre-deploy verification for Terraform configurations. Run through every section 
 - [ ] Separate IAM roles for plan (read-only) and apply (write)
 - [ ] CDE state files in separate backend with separate IAM role
 - [ ] GitHub Actions pinned to commit SHAs (post tj-actions compromise)
-- [ ] Trivy/Checkov pinned to safe versions (Trivy v0.69.3, NOT v0.69.4-6)
+- [ ] Trivy/Checkov pinned to safe versions (Trivy v0.70.0+ for new pins, NOT v0.69.4-6)
 
 ## Compliance (PCI-DSS 4.0)
 

--- a/skills/terraform/references/state-and-security.md
+++ b/skills/terraform/references/state-and-security.md
@@ -166,7 +166,7 @@ PR merged to main:
 ### Supply chain hardening for CI
 
 - **Pin ALL GitHub Actions to commit SHAs** - `uses: hashicorp/setup-terraform@<sha>`, not `@v3`. The tj-actions/changed-files compromise (March 2025, CVE-2025-30066) stole credentials from ~12 hours of CI runs via upstream reviewdog/action-setup (CVE-2025-30154).
-- **Pin Trivy to v0.69.3** - v0.69.4/5/6 were compromised (CVE-2026-33634). Pin to SHA.
+- **Pin Trivy to v0.70.0+ for new pins** - v0.69.3 was the March 2026 rollback version, and v0.69.4/5/6 were compromised (CVE-2026-33634). Pin to SHA or image digest.
 - **Pin Checkov to a specific version** - `pip install checkov==X.Y.Z` or use the container image with a digest
 - **Use StepSecurity Harden-Runner** to detect unexpected network connections in CI jobs
 - **Separate CI secrets by environment** - staging pipeline should NOT access prod credentials

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -9,7 +9,7 @@ compatibility: "Requires git. Optional: wc (for size audits)"
 metadata:
   source: iuliandita/skills
   date_added: "2026-03-25"
-  effort: low
+  effort: medium
   argument_hint: "[doc-or-path] (e.g., CLAUDE.md, docs/runbook.md)"
 ---
 

--- a/skills/zero-day/references/target-versions.md
+++ b/skills/zero-day/references/target-versions.md
@@ -1,10 +1,11 @@
 # Zero-Day Target Versions
 
-May 2026 snapshot. Verify current releases before pinning.
+May 2026 snapshot. Verified 2026-05-19 against GitHub release APIs and project release notes.
+Verify current releases before pinning.
 
-- CodeQL CLI: v2.25.1
-- Semgrep: v1.157.0
-- Joern: v4.0.x
-- Ghidra: 12.0.4
+- CodeQL CLI: v2.25.4
+- Semgrep: v1.163.0
+- Joern: v4.0.540
+- Ghidra: 12.1
 - AFL++: v4.40c
 - Rizin: v0.8.2


### PR DESCRIPTION
## Summary

- Refresh skill audit fixes and May 2026 target-version guidance.
- Add regression coverage for broken reference links in skill docs.
- Update supply-chain guidance and lint workflow coverage.

## Test Plan

- ./scripts/test-lint-skills.sh
- bash scripts/lint-skills.sh skills
- bash scripts/validate-spec.sh skills
- bash scripts/check-freshness-dates.sh
- bash scripts/check-private-skill-leaks.sh
- ./scripts/check-deep-audit-coverage.sh
- ./scripts/test-install.sh
- shellcheck install.sh scripts/*.sh
- bash -n install.sh scripts/*.sh
- python3 -m py_compile scripts/skill-frontmatter.py
- git diff --check
- gitleaks protect --staged --redact --verbose