### PR TITLE
fix(skills): deep-audit remediation - model IDs, version/CVE refresh, contract fixes

### DIFF
--- a/skills/ai-ml/SKILL.md
+++ b/skills/ai-ml/SKILL.md
@@ -441,7 +441,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** AI-ML
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/ai-ml/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/ai-ml/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/ai-ml/SKILL.md
+++ b/skills/ai-ml/SKILL.md
@@ -18,7 +18,7 @@ multi-agent systems with RAG pipelines. The goal is production-grade AI apps tha
 cost-effective, and don't hallucinate their way into an incident.
 
 **Target versions**: May 2026 snapshot. Read `references/target-versions.md` before
-pinning SDKs, runtimes, vector stores, or evaluation tools.
+pinning model IDs (Claude/OpenAI families), SDKs, runtimes, vector stores, or evaluation tools.
 
 ## When to use
 
@@ -143,7 +143,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 with client.messages.stream(
-    model="claude-sonnet-4-6-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     messages=[{"role": "user", "content": prompt}],
 ) as stream:
@@ -251,7 +251,7 @@ def ask(question: str) -> str:
     if not context:
         return "No relevant documents found."
     response = client.messages.create(
-        model="claude-sonnet-4-6-20250514",
+        model="claude-sonnet-4-6",
         max_tokens=1024,
         messages=[{"role": "user", "content": (
             f"Answer based on these documents:\n\n"
@@ -433,7 +433,7 @@ PII detection setup, and content policy implementation.
 - `references/fine-tuning.md` - data prep, PEFT/LoRA, training evaluation, full vs parameter-efficient methods
 - `references/local-inference.md` - quantization, model selection, GPU memory, production serving config
 - `references/safety.md` - prompt injection defense, output validation, PII handling, content filtering, audit logging
-- `references/target-versions.md` - May 2026 version snapshot for AI SDKs, runtimes, vector stores, and eval tools
+- `references/target-versions.md` - May 2026 snapshot: Claude/OpenAI model families, AI SDKs, runtimes, vector stores, and eval tools
 
 ## Output Contract
 

--- a/skills/ai-ml/references/agent-patterns.md
+++ b/skills/ai-ml/references/agent-patterns.md
@@ -52,7 +52,7 @@ def run_agent(user_query: str, tools: list[dict], max_iterations: int = 15) -> s
     while iterations < max_iterations:
         iterations += 1
         response = client.messages.create(
-            model="claude-sonnet-4-6-20250514",
+            model="claude-sonnet-4-6",
             max_tokens=4096,
             tools=tools,
             messages=messages,
@@ -208,7 +208,7 @@ support_agent = Agent(
     name="Support Agent",
     instructions="Help users with technical issues. Use the knowledge base.",
     tools=[search_knowledge_base],
-    model="gpt-4o",
+    model="gpt-5.5",
 )
 
 # Run the agent

--- a/skills/ai-ml/references/evaluation.md
+++ b/skills/ai-ml/references/evaluation.md
@@ -58,7 +58,7 @@ comparison, assertions, and red teaming in a single tool.
 description: "Customer support bot evaluation"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6-20250514
+  - id: anthropic:messages:claude-sonnet-4-6
     config:
       max_tokens: 1024
       temperature: 0
@@ -101,8 +101,8 @@ npx promptfoo eval
 
 # Compare models
 npx promptfoo eval --providers \
-  anthropic:messages:claude-sonnet-4-6-20250514 \
-  openai:chat:gpt-4o
+  anthropic:messages:claude-sonnet-4-6 \
+  openai:chat:gpt-5.5
 
 # View results
 npx promptfoo view
@@ -189,7 +189,7 @@ Supplement manual datasets with LLM-generated test cases:
 ```python
 # Generate test cases from your documentation
 response = client.messages.create(
-    model="claude-sonnet-4-6-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=4096,
     messages=[{
         "role": "user",

--- a/skills/ai-ml/references/llm-patterns.md
+++ b/skills/ai-ml/references/llm-patterns.md
@@ -31,7 +31,7 @@ client = anthropic.Anthropic()
 async_client = anthropic.AsyncAnthropic()
 
 response = client.messages.create(
-    model="claude-sonnet-4-6-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     system="You are a helpful assistant.",
     messages=[{"role": "user", "content": "Hello"}],
@@ -47,7 +47,7 @@ import Anthropic from "@anthropic-ai/sdk";
 const client = new Anthropic(); // reads ANTHROPIC_API_KEY
 
 const response = await client.messages.create({
-  model: "claude-sonnet-4-6-20250514",
+  model: "claude-sonnet-4-6",
   max_tokens: 1024,
   messages: [{ role: "user", content: "Hello" }],
 });
@@ -62,7 +62,7 @@ from openai import OpenAI
 client = OpenAI()  # reads OPENAI_API_KEY
 
 response = client.chat.completions.create(
-    model="gpt-4o",
+    model="gpt-5.5",
     messages=[{"role": "user", "content": "Hello"}],
     max_tokens=1024,
 )
@@ -76,7 +76,7 @@ import { generateText } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
 
 const { text } = await generateText({
-  model: anthropic("claude-sonnet-4-6-20250514"),
+  model: anthropic("claude-sonnet-4-6"),
   prompt: "Hello",
   maxTokens: 1024,
 });
@@ -96,7 +96,7 @@ const { text } = await generateText({
 
 ```python
 with client.messages.stream(
-    model="claude-sonnet-4-6-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=2048,
     messages=[{"role": "user", "content": prompt}],
 ) as stream:
@@ -112,7 +112,7 @@ print(f"\nTokens: {final_message.usage.input_tokens} in, {final_message.usage.ou
 
 ```typescript
 const stream = client.messages.stream({
-  model: "claude-sonnet-4-6-20250514",
+  model: "claude-sonnet-4-6",
   max_tokens: 2048,
   messages: [{ role: "user", content: prompt }],
 });
@@ -130,7 +130,7 @@ const finalMessage = await stream.finalMessage();
 
 ```python
 stream = client.chat.completions.create(
-    model="gpt-4o",
+    model="gpt-5.5",
     messages=[{"role": "user", "content": prompt}],
     stream=True,
 )
@@ -148,7 +148,7 @@ export async function POST(req: Request) {
   const { prompt } = await req.json();
 
   const stream = client.messages.stream({
-    model: "claude-sonnet-4-6-20250514",
+    model: "claude-sonnet-4-6",
     max_tokens: 2048,
     messages: [{ role: "user", content: prompt }],
   });
@@ -169,7 +169,7 @@ Force the model to return structured data by defining a "tool" that captures the
 
 ```python
 response = client.messages.create(
-    model="claude-sonnet-4-6-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     tools=[{
         "name": "extract_info",
@@ -202,7 +202,7 @@ data = tool_block.input  # already parsed dict
 
 ```python
 response = client.chat.completions.create(
-    model="gpt-4o",
+    model="gpt-5.5",
     messages=[{"role": "user", "content": f"Extract info from: {text}"}],
     response_format={
         "type": "json_schema",
@@ -234,7 +234,7 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
 
 const { object } = await generateObject({
-  model: anthropic("claude-sonnet-4-6-20250514"),
+  model: anthropic("claude-sonnet-4-6"),
   schema: z.object({
     name: z.string(),
     age: z.number().int().min(0).max(150).optional(),
@@ -264,7 +264,7 @@ messages = [{"role": "user", "content": user_query}]
 
 while True:
     response = client.messages.create(
-        model="claude-sonnet-4-6-20250514",
+        model="claude-sonnet-4-6",
         max_tokens=4096,
         tools=tools,
         messages=messages,
@@ -320,7 +320,7 @@ class Conversation:
         self._maybe_summarize()
 
         response = client.messages.create(
-            model="claude-sonnet-4-6-20250514",
+            model="claude-sonnet-4-6",
             system=self.system,
             max_tokens=2048,
             messages=self.messages,
@@ -346,7 +346,7 @@ For repeated system prompts or large static contexts, use prompt caching to redu
 
 ```python
 response = client.messages.create(
-    model="claude-sonnet-4-6-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     system=[
         {

--- a/skills/ai-ml/references/target-versions.md
+++ b/skills/ai-ml/references/target-versions.md
@@ -3,6 +3,26 @@
 May 2026 snapshot. Verified 2026-05-19 against PyPI, npm, and upstream GitHub release APIs.
 Verify current releases before pinning.
 
+## Model families
+
+Model IDs move faster than SDK versions and are not covered by routine minor-version bumps.
+Verify against provider docs before pinning. Current as of May 2026:
+
+| Provider | Tier | Model ID | Notes |
+|----------|------|----------|-------|
+| Anthropic | Flagship | `claude-opus-4-8` | Most capable: complex reasoning, long-horizon agentic coding (GA 2026-05-28) |
+| Anthropic | Balanced | `claude-sonnet-4-6` | Default coding model. 4.6+ dropped dated snapshots: the bare ID IS the pinned snapshot |
+| Anthropic | Fast | `claude-haiku-4-5` | Low cost/latency. Dated snapshot: `claude-haiku-4-5-20251001` |
+| OpenAI | Flagship | `gpt-5.5` | Current frontier chat model; recommended replacement for `gpt-4o` |
+| OpenAI | Cost tier | `gpt-5.4-mini`, `gpt-5.4-nano` | Smaller/cheaper tiers |
+
+`gpt-4o` is retired from ChatGPT (2026-04-03) but still API-available; new code should default to
+`gpt-5.5`. Do not append a dated suffix to Claude 4.6+ IDs - the bare ID is the snapshot, and a
+guessed suffix like `claude-sonnet-4-6-20250514` is invalid (that date belonged to the original
+Sonnet 4) and returns a 404.
+
+## SDKs, runtimes, and tooling
+
 | Component | Version | Notes |
 |-----------|---------|-------|
 | Anthropic Python SDK | 0.102.0 | Claude models, streaming, tool use, structured output |

--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -431,7 +431,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** ANSIBLE
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/ansible/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/ansible/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -462,7 +462,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** ANTI-AI-PROSE
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
 - **Deliverable path:** `docs/local/audits/anti-ai-prose/<YYYY-MM-DD>-<slug>.md`
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
 

--- a/skills/anti-slop/SKILL.md
+++ b/skills/anti-slop/SKILL.md
@@ -421,9 +421,9 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** ANTI-SLOP
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
 - **Deliverable path:** `docs/local/audits/anti-slop/<YYYY-MM-DD>-<slug>.md`
-- **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
+- **Severity scale:** reduced subset of the shared scale - `P1 | P2 | P3` with slop-specific meanings (P1 fabricated/ungrounded, P2 maintainability, P3 style; see the Workflow classification). No P0: slop is never a build or security breaker - route those to **code-review** / **security-audit**.
 
 ## Related Skills
 

--- a/skills/arch-btw/SKILL.md
+++ b/skills/arch-btw/SKILL.md
@@ -297,7 +297,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** ARCH-BTW
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/arch-btw/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/arch-btw/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/backend-api/SKILL.md
+++ b/skills/backend-api/SKILL.md
@@ -387,7 +387,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** BACKEND-API
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/backend-api/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/backend-api/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -416,7 +416,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** BROWSE
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/browse/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/browse/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -17,9 +17,9 @@ Every browsing action has a token cost - this skill minimizes it through progres
 smart format selection, and backend-aware strategies.
 
 **Target versions** (May 2026):
-- Lightpanda: 0.2.9
-- @playwright/mcp: 0.0.72
-- agent-browser: 0.26.0
+- Lightpanda: 0.3.1
+- @playwright/mcp: 0.0.75
+- agent-browser: 0.27.0
 
 ## When to use
 
@@ -372,7 +372,7 @@ fastest path to full browsing capability with minimal overhead.
 **Lightpanda MCP setup** (one-time, ~30 seconds):
 ```bash
 # Install the binary (see references/tool-setup.md for other architectures)
-curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.9/lightpanda-x86_64-linux
+curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.3.1/lightpanda-x86_64-linux
 chmod +x lightpanda && mv lightpanda ~/.local/bin/
 ```
 

--- a/skills/browse/references/tool-setup.md
+++ b/skills/browse/references/tool-setup.md
@@ -13,15 +13,15 @@ Headless browser built from scratch in Zig with V8. Single static binary, no dep
 
 ```bash
 # Linux x86_64
-curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.9/lightpanda-x86_64-linux
+curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.3.1/lightpanda-x86_64-linux
 chmod +x lightpanda && sudo mv lightpanda /usr/local/bin/
 
 # Linux aarch64
-curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.9/lightpanda-aarch64-linux
+curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.3.1/lightpanda-aarch64-linux
 chmod +x lightpanda && sudo mv lightpanda /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.2.9/lightpanda-aarch64-macos
+curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.3.1/lightpanda-aarch64-macos
 chmod +x lightpanda && sudo mv lightpanda /usr/local/bin/
 
 # Docker
@@ -125,7 +125,7 @@ or WebKit. Higher token cost than Lightpanda but complete Web API coverage.
 ```bash
 # As Claude Code plugin (if available in your plugin marketplace)
 # Or standalone:
-npx @playwright/mcp@0.0.72
+npx @playwright/mcp@0.0.75
 ```
 
 ### Key Tools
@@ -180,7 +180,7 @@ built-in reasoning.
 ### Installation
 
 ```bash
-npx agent-browser@0.26.0
+npx agent-browser@0.27.0
 # or: npm install -g agent-browser
 ```
 
@@ -207,10 +207,14 @@ agent-browser close                   # Close browser
 ### Batch execution
 
 ```bash
+# JSON via stdin: array of [command, ...args] tuples, requires --json
 echo '[
-  {"action":"open","url":"https://example.com"},
-  {"action":"snapshot","interactive":true}
-]' | agent-browser batch
+  ["open", "https://example.com"],
+  ["snapshot", "-i"]
+]' | agent-browser batch --json
+
+# Or pass quoted commands as arguments (no --json):
+agent-browser batch "open https://example.com" "snapshot -i"
 ```
 
 ### Engine selection

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -441,7 +441,7 @@ the OWASP Top 10 for Agentic Applications, read `references/supply-chain.md`
 
 - `references/github-actions.md` - GitHub Actions patterns, templates, and security hardening
 - `references/forgejo-gitea-actions.md` - Forgejo/Gitea Actions differences, troubleshooting, Woodpecker patterns, and Drone migration guidance
-- `references/gitlab-ci.md` - GitLab CI/CD 18.x patterns, SaaS vs self-managed differences, Catalog, Components, security
+- `references/gitlab-ci.md` - GitLab CI/CD 19.x patterns, SaaS vs self-managed differences, Catalog, Components, security
 - `references/runners.md` - Self-hosted runners (actions-runner, gitlab-runner, forgejo-runner, act_runner, woodpecker-agent) - install, register, executor choice, Linux vs macOS, security hardening
 - `references/best-practices.md` - Dependency updates (Dependabot/Renovate), layered linting, scanning matrix (secrets/SCA/container/IaC/SAST), review gates, merge queues, rollout order
 - `references/supply-chain.md` - supply chain security, incident timeline, SHA pinning, SBOM/SLSA, PCI-DSS compliance, image signing

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -453,7 +453,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** CI-CD
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/ci-cd/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/ci-cd/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/ci-cd/references/best-practices.md
+++ b/skills/ci-cd/references/best-practices.md
@@ -133,7 +133,7 @@ repos:
     hooks:
       - id: actionlint
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.0
+    rev: v8.30.1
     hooks:
       - id: gitleaks
 ```

--- a/skills/ci-cd/references/forgejo-gitea-actions.md
+++ b/skills/ci-cd/references/forgejo-gitea-actions.md
@@ -132,7 +132,7 @@ jobs:
 
 Architecturally different from Actions-based CI: a separate server-plus-agents service
 that Gitea/Forgejo talks to via webhook. Smaller surface, container-native, Raspberry-Pi
-friendly. Written in Go, MIT-licensed. Current stable: 3.13.x (2026).
+friendly. Written in Go, MIT-licensed. Current stable: 3.14.x (2026).
 
 ### Config layout
 

--- a/skills/ci-cd/references/gitlab-ci.md
+++ b/skills/ci-cd/references/gitlab-ci.md
@@ -1,13 +1,13 @@
 # GitLab CI/CD: Patterns & Templates
 
-Production-ready patterns for GitLab CI/CD pipelines. Updated for GitLab 18.10 (March 2026):
+Production-ready patterns for GitLab CI/CD pipelines. Updated for GitLab 19.0 (May 2026):
 CI/CD Catalog GA, Components with typed inputs, rules-based workflows.
 
 ---
 
 ## Current State (2026)
 
-- **GitLab 18.10** (released March 19, 2026). Monthly releases on the third Thursday.
+- **GitLab 19.0** (released May 21, 2026; 19.0.1 current patch). Monthly releases on the third Thursday; majors land each May. 19.0 is a major with breaking changes - notably Redis 6 support removed (migrate to Redis 7.2 / Valkey 7.2), no more Ubuntu 20.04 packages, and Gateway API + Envoy Gateway replaces NGINX Ingress as the Helm chart default. 18.11.x / 18.10.x remain on backports.
 - **CI/CD Catalog** GA since GitLab 17.0 (May 2024). Max 100 components per project (raised in 18.5).
 - **CI Components** are the endorsed path for reusable pipeline logic. `include:` templates still work
   but components have versioning, typed inputs, and discoverability.

--- a/skills/ci-cd/references/runners.md
+++ b/skills/ci-cd/references/runners.md
@@ -148,7 +148,7 @@ check_interval = 0
 |----|---------|
 | Binary (Linux) | Download from `code.forgejo.org/forgejo/runner/releases/latest`, verify with `gpg`, `install -m 755 ... /usr/local/bin/forgejo-runner` |
 | Binary (macOS) | Same, pick `darwin-arm64` or `darwin-amd64` |
-| OCI container | `docker pull data.forgejo.org/forgejo/runner:<major>` (current stable tag is `:11`; check `https://data.forgejo.org/forgejo/-/packages/container/runner/versions` for the latest tag before pinning. Runs as uid 1000.) |
+| OCI container | `docker pull data.forgejo.org/forgejo/runner:<major>` (current stable tag is `:12`, matching runner v12.x; check `https://data.forgejo.org/forgejo/-/packages/container/runner/versions` for the latest tag before pinning. Runs as uid 1000.) |
 | Docker Compose | Reference compose file in upstream docs - pairs with a DinD sidecar |
 | Kubernetes | Community Helm charts exist; no official chart yet |
 

--- a/skills/ci-cd/references/supply-chain.md
+++ b/skills/ci-cd/references/supply-chain.md
@@ -53,6 +53,13 @@ exfiltration mechanism was triggered.
 - Exploited Microsoft/symphony, Google/ai-ml-recipes, Nvidia/nvrc
 - Modified build/deploy scripts via PRs to exfiltrate service principals, API keys, IMDS tokens
 
+### TrapDoor multi-registry campaign - May 2026
+
+- Coordinated malware across npm, PyPI, and crates.io (34+ packages, 384+ artifacts)
+- Steals SSH keys and cloud/crypto credentials; PyPI import-time exec, Rust `build.rs` abuse
+- Hides zero-width-Unicode prompt injection in `.cursorrules` / `CLAUDE.md` to subvert AI coding
+  agents in the pipeline - scan committed agent rule files, not just dependencies
+
 ---
 
 ## SHA Pinning

--- a/skills/ci-cd/references/target-versions.md
+++ b/skills/ci-cd/references/target-versions.md
@@ -4,7 +4,7 @@ May 2026 snapshot. Verified 2026-05-19 against GitLab/Gitea/Forgejo APIs, GitHub
 and supply-chain tool releases. Verify current releases before pinning.
 
 - **GitHub Actions**: ubuntu-24.04 runners (ubuntu-latest), arm64 GA, artifact v4, attestations GA
-- **GitLab CI/CD**: GitLab 18.11.2 current patch line; 18.10.5 for the 18.10 line. CI/CD Catalog GA, CI Components with typed `spec: inputs`
+- **GitLab CI/CD**: GitLab 19.0.1 current (19.0 major released May 21, 2026); 18.11.x / 18.10.x still on backports. CI/CD Catalog GA, CI Components with typed `spec: inputs`
 - **Forgejo Actions**: Forgejo v15.0.2, Runner v12.10.1 (check `data.forgejo.org/forgejo/runner` releases before pinning)
 - **Gitea Actions**: Gitea v1.26.1, act runner v1.0.4 (GA since Gitea 1.21, March 2024)
 - **Woodpecker CI**: v3.14.1 (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)

--- a/skills/cluster-health/SKILL.md
+++ b/skills/cluster-health/SKILL.md
@@ -169,7 +169,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** CLUSTER-HEALTH
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/cluster-health/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/cluster-health/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -466,7 +466,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** CODE-REVIEW
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
 - **Deliverable path:** `docs/local/audits/code-review/<YYYY-MM-DD>-<slug>.md`
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
 

--- a/skills/code-slimming/SKILL.md
+++ b/skills/code-slimming/SKILL.md
@@ -397,9 +397,9 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** CODE-SLIMMING
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
 - **Deliverable path:** `docs/local/audits/code-slimming/<YYYY-MM-DD>-<slug>.md`
-- **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
+- **Severity scale:** not the shared P0-P3 scale. Findings are classified by action - `Do now | Do with tests | Defer | Leave alone` - plus a `Risk: low | medium | high` field per finding (see the Workflow). This skill proposes deletions, not severity-ranked defects.
 
 ## Related Skills
 

--- a/skills/command-prompt/SKILL.md
+++ b/skills/command-prompt/SKILL.md
@@ -356,7 +356,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** COMMAND-PROMPT
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/command-prompt/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/command-prompt/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -309,6 +309,7 @@ Read `references/migration-patterns.md` for cross-engine type mapping, ORM migra
 - [ ] Foreign key columns have indexes
 - [ ] pgAudit installed and configured (if PCI scope)
 - [ ] Patched against CVE-2026-2005 (pgcrypto heap buffer overflow, RCE) - 18.2+ / 17.8+ / 16.12+
+- [ ] On the May 2026 PostgreSQL update (CVE-2026-6473/6475/6477/6637, up to CVSS 8.8: integer-overflow allocations, libpq client stack overwrite, refint stack overflow, MD5 timing leak) - 18.4+ / 17.10+ / 16.14+ / 15.18+ / 14.23+
 
 ### MySQL/MariaDB-Specific
 

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -393,7 +393,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** DATABASES
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/databases/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/databases/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/databases/references/config-templates.md
+++ b/skills/databases/references/config-templates.md
@@ -380,7 +380,7 @@ MSSQL doesn't use a config file like the others. Most settings are applied via T
 -- ============================================================
 
 -- Max memory (leave 4-8GB for OS)
-EXEC sp_configure 'max server memory (MB)', 12288;  - 12GB on a 16GB server
+EXEC sp_configure 'max server memory (MB)', 12288;  -- 12GB on a 16GB server
 RECONFIGURE;
 
 -- MAXDOP (CPU cores per NUMA node, max 8 for OLTP)

--- a/skills/databases/references/migration-patterns.md
+++ b/skills/databases/references/migration-patterns.md
@@ -628,12 +628,12 @@ ON CONFLICT (email) DO UPDATE SET name = EXCLUDED.name;
 ```sql
 -- PostgreSQL: real booleans
 SELECT * FROM users WHERE is_active = TRUE;
-SELECT * FROM users WHERE is_active;  - implicit TRUE check
+SELECT * FROM users WHERE is_active;  -- implicit TRUE check
 SELECT * FROM users WHERE NOT is_active;
 
 -- MySQL: TINYINT(1) pretending to be boolean
 SELECT * FROM users WHERE is_active = 1;
-SELECT * FROM users WHERE is_active;  - works (truthy: non-zero)
+SELECT * FROM users WHERE is_active;  -- works (truthy: non-zero)
 -- TRUE and FALSE keywords exist but are just aliases for 1 and 0.
 
 -- MSSQL: BIT type
@@ -750,9 +750,9 @@ MySQL 8.0+ supports many DDL operations as online (INPLACE or INSTANT algorithm)
 
 ```sql
 -- INSTANT operations (metadata-only, PG 16+ equivalent):
-ALTER TABLE t ADD COLUMN c INT, ALGORITHM=INSTANT;               - 8.0.12+
+ALTER TABLE t ADD COLUMN c INT, ALGORITHM=INSTANT;               -- 8.0.12+
 ALTER TABLE t ALTER COLUMN c SET DEFAULT 42, ALGORITHM=INSTANT;
-ALTER TABLE t RENAME COLUMN old TO new, ALGORITHM=INSTANT;        - 8.0.28+
+ALTER TABLE t RENAME COLUMN old TO new, ALGORITHM=INSTANT;        -- 8.0.28+
 
 -- INPLACE operations (no table copy, allows concurrent DML):
 ALTER TABLE t ADD INDEX idx_col (col), ALGORITHM=INPLACE, LOCK=NONE;

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -322,7 +322,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** DEBIAN-UBUNTU
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/debian-ubuntu/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/debian-ubuntu/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -33,6 +33,7 @@ stale package-version table.
 | Ubuntu HWE lane | verify live | kernel metapackage and hardware-enablement behavior matter more than one exact kernel number |
 | NVIDIA driver branch | verify live | proprietary branch choice affects Wayland, gaming, and DKMS behavior |
 | Mesa stack | verify live | AMD and Intel graphics behavior tracks the shipped Mesa lane |
+| Kernel security | verify live via USN tracker | patch high-severity privesc CVEs promptly; mid-2026 examples to confirm fixed: Copy Fail CVE-2026-31431 (CISA KEV, exploited), Dirty Frag CVE-2026-43284/43500, ptrace CVE-2026-46333 |
 
 ## When to use
 

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -464,7 +464,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** DEEP-AUDIT
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
 - **Deliverable path:** `docs/local/audits/deep-audit/<YYYY-MM-DD>-<slug>.md`
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
 

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -372,7 +372,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** DEV-CYCLE
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/dev-cycle/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/dev-cycle/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Rules

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -449,7 +449,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** DOCKER
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/docker/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/docker/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -276,6 +276,8 @@ Read `references/security-and-compliance.md` for the full PCI-DSS 4.0 container 
 | CVE-2026-2664 | Docker Desktop | Medium | gRPC-FUSE kernel module OOB read | Desktop 4.62.0+ |
 | CVE-2025-13743 | Docker Desktop | Low | Expired Hub PATs leaked in diagnostics bundles | Desktop 4.54.0 |
 | CVE-2026-28400 | Model Runner | 7.5 High | Runtime flag injection - arbitrary file overwrite, container escape | Desktop 4.61.0+ |
+| CVE-2026-5843 | Model Runner (MLX) | 8.8 High | Container-to-host code execution via MLX-LM `model_file` importlib load from untrusted models | Desktop 4.71.0+ |
+| CVE-2026-5817 | Model Runner (vllm-metal) | 8.8 High | Container-to-host RCE via unsandboxed `trust_remote_code` tokenizer load | Desktop 4.68.0+ |
 | CVE-2026-33747 | BuildKit | High | Malicious frontend file escape outside storage root | BuildKit v0.28.1 |
 | CVE-2026-33748 | BuildKit | High | Git URL validation bypass - restricted file access | BuildKit v0.28.1 |
 
@@ -413,7 +415,7 @@ GPU containers: use `deploy.resources.reservations.devices` with `capabilities: 
 
 - [ ] runc >= 1.4.0 (CVE-2025-31133/52565/52881 patched)
 - [ ] BuildKit >= 0.28.1 (CVE-2026-33747/33748 patched)
-- [ ] Docker Desktop >= 4.66.1 (CVE-2025-9074/CVE-2026-28400 patched)
+- [ ] Docker Desktop >= 4.71.0 (adds CVE-2026-5817/5843 Model Runner container-to-host RCE fixes; floor was 4.66.1 for CVE-2025-9074/CVE-2026-28400)
 - [ ] Trivy v0.70.0+ from official releases (v0.69.4-6 COMPROMISED)
 - [ ] Images signed with cosign, verified at deploy
 - [ ] SBOM generated for every production image

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -227,7 +227,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** FIREWALL-APPLIANCE
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/firewall-appliance/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/firewall-appliance/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -17,7 +17,7 @@ Manage, troubleshoot, and harden OPNsense and pfSense firewalls via SSH. Both ar
 pf-powered firewall distributions - most concepts, commands, and patterns apply to both.
 
 **Target versions** (May 2026):
-- OPNsense: 26.4.0 (26.4 series; 26.1.6_2 still supported on the 26.1 stable branch)
+- OPNsense CE: 26.1.7 (current Community Edition stable, "Witty Woodpecker"; CE ships odd quarters .1/.7). Business Edition is 26.4.x (even quarters .4/.10) - do not quote the BE number as the CE version
 - pfSense CE: 2.8.1 / pfSense Plus: 26.03
 - CrowdSec: v1.7.7
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -285,7 +285,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** FRONTEND-DESIGN
 - **Deliverable bucket:** `deliverables`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing UI/UX (e.g., "review my landing page"), emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/deliverables/frontend-design/<YYYY-MM-DD>-<slug>.md`. When invoked to **build a new artifact or generate content** (its primary mode -- producing UI code in chat), respond freely without the contract; build-mode behavior is unchanged.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing UI/UX (e.g., "review my landing page"), emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/deliverables/frontend-design/<YYYY-MM-DD>-<slug>.md`. When invoked to **build a new artifact or generate content** (its primary mode -- producing UI code in chat), respond freely without the contract; build-mode behavior is unchanged.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/full-review/SKILL.md
+++ b/skills/full-review/SKILL.md
@@ -254,7 +254,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** FULL-REVIEW
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
 - **Deliverable path:** `docs/local/audits/full-review/<YYYY-MM-DD>-<slug>.md`
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
 

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -22,7 +22,7 @@ compliance requirements (PCI-DSS 4.0).
 - **git**: 2.53.x (current stable). Git 3.0 expected late 2026 (reftable default, SHA-256 default)
 - **GitHub CLI (`gh`)**: 2.91.0
 - **GitLab CLI (`glab`)**: 1.90.x
-- **Forgejo CLI (`fj`)**: 0.4.1 (March 2026). Rust-written, official community CLI at `codeberg.org/forgejo-contrib/forgejo-cli`. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
+- **Forgejo CLI (`fj`)**: 0.4.0 (latest verified, Jan 2026; the project moves fast - verify the current release at `codeberg.org/forgejo-contrib/forgejo-cli`). Rust-written, official community CLI. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
 - **Forgejo**: v15.0 line current at May 2026 recheck; verify the stable branch before upgrade advice. Critical RCE (CVE-2025-68937) patched in v13.0.2+.
 - **prek**: 0.3.x (Rust, recommended) or **pre-commit**: 4.6.0 (Python, largest ecosystem)
 - **git-filter-repo**: 2.47.x

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -53,10 +53,10 @@ This skill covers five domains depending on context:
 
 ## When NOT to use
 
-- CI/CD pipeline design (use ci-cd) - this skill handles git operations *within* pipelines, not pipeline architecture
-- PR/MR code review (use code-review) - this skill creates PRs, doesn't review code in them
-- Full application security audit (use security-audit) - this skill covers secrets *in git history* and git-specific security, not application-level vulnerability assessment
-- Docker image tagging strategy (use docker) - this skill handles git tags, not container tags
+- CI/CD pipeline design - use **ci-cd**; this skill handles git operations *within* pipelines, not pipeline architecture
+- PR/MR code review - use **code-review**; this skill creates PRs, doesn't review code in them
+- Full application security audit - use **security-audit**; this skill covers secrets *in git history* and git-specific security, not application-level vulnerability assessment
+- Docker image tagging strategy - use **docker**; this skill handles git tags, not container tags
 
 ---
 
@@ -395,7 +395,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** GIT
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/git/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/git/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/git/references/forge-workflows.md
+++ b/skills/git/references/forge-workflows.md
@@ -254,8 +254,9 @@ does not cover yet (e.g. branch protection management).
 | Any with Rust | `cargo install forgejo-cli` or `cargo binstall forgejo-cli` |
 | Binaries | Releases tab on Codeberg (x86_64 Linux/Windows) |
 
-Verify: `fj --version` (prefer 0.5.x or newer as of May 2026 recheck; releases before 0.4.1
-have a PKCE bug that breaks `fj auth login`).
+Verify: `fj --version` and prefer the latest release - the project iterates quickly and some
+early releases had a PKCE bug that broke `fj auth login`. If `fj auth login` fails with a PKCE
+error, upgrade to the current release.
 
 ### `fj` authentication
 
@@ -344,8 +345,8 @@ fj issue search --state open --label bug
 
 ### `fj` releases and tags
 
-`fj` can publish releases (listed as a supported capability in the README), but as of
-v0.4.1 the wiki does not yet document the exact `fj release` subcommand flags. Run
+`fj` can publish releases (listed as a supported capability in the README), but the wiki
+does not yet reliably document the exact `fj release` subcommand flags. Run
 `fj release --help` on the target version to confirm syntax before scripting.
 
 The reliable pattern is git-side tagging + `fj` for the release object:
@@ -433,7 +434,7 @@ curl -s -X POST "https://git.example.com/api/v1/repos/{owner}/{repo}/pulls" \
   on CI for branch protection checks.
 - **Mirror sync delay** - if Forgejo mirrors from GitHub (or vice versa), there's a sync interval.
   Don't expect immediate consistency across forges.
-- **`fj` version** - `fj auth login` fails with PKCE errors on v0.4.0 and earlier. Use 0.4.1+.
+- **`fj` version** - some early releases fail `fj auth login` with PKCE errors. If you hit this, upgrade to the current release.
 - **AGit requires Forgejo 7+** - older self-hosted instances reject `refs/for/<branch>` pushes.
   Fall back to `fj pr create` without `--agit` (push a branch first).
 

--- a/skills/git/references/recovery-and-maintenance.md
+++ b/skills/git/references/recovery-and-maintenance.md
@@ -84,7 +84,7 @@ git bisect run ./scripts/bisect-check.sh
 # Example bisect-check.sh:
 #   #!/usr/bin/env bash
 #   set -euo pipefail
-#   npm ci --silent 2>/dev/null && npm test - --filter="auth" 2>/dev/null
+#   npm ci --silent 2>/dev/null && npm test -- --filter="auth" 2>/dev/null
 #   # Exit code 0 = good commit, non-zero = bad commit
 
 # Bisect with make target

--- a/skills/git/references/security-and-signing.md
+++ b/skills/git/references/security-and-signing.md
@@ -169,7 +169,7 @@ git config --global credential.https://gitlab.example.com.helper libsecret
 
 | Tool | Scope | Speed | False positive rate |
 |------|-------|-------|-------------------|
-| `gitleaks` 9.x | Current + history | Fast | Low |
+| `gitleaks` 8.30.x | Current + history | Fast | Low |
 | `trufflehog` 3.x | Current + history | Medium | Very low (verified) |
 | `detect-secrets` | Current only | Fast | Medium |
 | GitHub secret scanning | Push-time | Real-time | Low (pattern-based) |

--- a/skills/jekyll-hyde/SKILL.md
+++ b/skills/jekyll-hyde/SKILL.md
@@ -240,7 +240,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** JEKYLL-HYDE
 - **Deliverable bucket:** `deliverables`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** an existing artifact (e.g., adversarial review of a strategy doc, design, or PR), emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/deliverables/jekyll-hyde/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (its primary advisor mode -- delivering perspectives in chat), respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** an existing artifact (e.g., adversarial review of a strategy doc, design, or PR), emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/deliverables/jekyll-hyde/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (its primary advisor mode -- delivering perspectives in chat), respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -310,7 +310,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** KALI-LINUX
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/kali-linux/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/kali-linux/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/kali-linux/references/metapackages-and-tool-families.md
+++ b/skills/kali-linux/references/metapackages-and-tool-families.md
@@ -12,7 +12,7 @@ The official metapackage docs and `kali-meta` page are the map.
 | `kali-linux-default` | tools included in normal desktop images | most general-purpose Kali installs |
 | `kali-linux-arm` | ARM-suitable tool mix | SBCs and ARM devices |
 | `kali-linux-nethunter` | NetHunter-related tooling | mobile and Android-adjacent workflows |
-| `kali-linux-large` | older larger desktop bundle | legacy expectations |
+| `kali-linux-large` | extended default tool selection (more than `default`, less than `everything`) | want a broad toolset without going all-in on `everything` |
 | `kali-linux-everything` | every metapackage and tool bundle | only when disk, bandwidth, and patience are cheap |
 | `kali-linux-labs` | intentionally vulnerable practice environments | controlled training only |
 

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Create, review, and architect Kubernetes infrastructure - from raw manifests to Helm charts to multi-cluster strategy. The goal is production-ready, security-hardened, cost-aware infrastructure that a team can maintain.
 
-**Target versions** (May 2026): Kubernetes 1.34-1.36 (1.36.0 "Haru" released April 22, 2026; **1.32 is the active LTS branch with patches through April 2028**), Helm 4.1.4, Helm 3.20.x LTS (security fixes until Nov 2026).
+**Target versions** (May 2026): Kubernetes 1.34-1.36 (1.36.0 "Haru" released April 22, 2026). Upstream Kubernetes has no LTS; community support per minor is ~14 months, so 1.32 reaches upstream EOL ~April 2026. Managed **vendor extended support** (AKS/EKS) carries 1.32 patches roughly 2 more years - attribute it to the platform, not upstream. Helm 4.2.0, Helm 3.21.x (parallel v3 maintenance, security fixes until Nov 2026).
 
 This skill covers four domains depending on context:
 - **Manifests** - raw YAML for Deployments, Services, Gateway API routes, ConfigMaps, Secrets, PVCs
@@ -181,7 +181,7 @@ Read `references/manifest-templates.md` for complete, copy-pasteable YAML templa
 - **Server-side apply (SSA) is the default** for new releases. Better conflict detection when multiple controllers touch the same resources.
 - **OCI digest installation**: `helm install myapp oci://registry/chart@sha256:abc...` - immutable, tamper-proof.
 - **WASM plugin system** - post-renderers must reference plugin names, not raw executables (breaking change).
-- **CLI flag renames**: `--atomic` -> `--rollback-on-failure`, `--force` -> `--force-replace` (old flags still work with deprecation warnings).
+- **CLI flag renames**: `--atomic` -> `--rollback-on-failure`, `--force` -> `--force-replace`. On `helm upgrade` the old flags still work as deprecated aliases, but `helm install --atomic` was removed and now errors - use `--rollback-on-failure`.
 - **`helm registry login` takes domain only** (e.g., `ghcr.io`, not full URL).
 - **OCI registries are the recommended distribution method.** Traditional `index.yaml` repos still work but are no longer the default path.
 

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -444,7 +444,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** KUBERNETES
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/kubernetes/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/kubernetes/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 # Localize: App Internationalization Workflow
 
-**Target versions (May 2026):** react-i18next 15.x, vue-i18n 11.x, next-intl 4.x, i18next 25.x
+**Target versions (May 2026):** react-i18next 17.x, vue-i18n 11.x, next-intl 4.x, i18next 26.x
 
 Systematic approach to internationalizing applications. Covers two scenarios: adding
 multilingual support from scratch and auditing existing i18n for gaps. Built from real
@@ -159,7 +159,7 @@ If no i18n system exists, set one up. If one exists, skip to Step 3.
 | Catalog format | JSON, YAML, TS objects | TS objects give type safety without tooling. JSON works with most libraries |
 | Key structure | flat, nested, dot-notation | Dot-notation (`auth.signIn`) balances readability and grep-ability |
 | Interpolation | positional `{0}`, named `{name}`, ICU | Named for readability. Positional is simpler for machine translation |
-| Pluralization | separate keys, ICU MessageFormat | Separate keys work for 2-form languages (English, German). Use ICU for Slavic and Arabic: Russian has 4 forms (one/few/many/other), Polish has 3, Arabic has 6. Picking "singular/plural" keys up front will force a rewrite later |
+| Pluralization | separate keys, ICU MessageFormat | Separate keys work for 2-form languages (English, German). Use ICU for Slavic and Arabic: Russian and Polish each have 4 CLDR plural categories (one/few/many/other), Arabic has 6. Picking "singular/plural" keys up front will force a rewrite later |
 | Locale detection | browser, URL path, cookie, header | Browser detection for first visit, persisted preference after |
 | Fallback | source locale, then key | Always. Never return empty or crash on missing key |
 | Voice register | formal, informal | Decide per target language upfront. Document the choice |

--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -369,7 +369,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** LOCALIZE
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
 - **Deliverable path:** `docs/local/audits/localize/<YYYY-MM-DD>-<slug>.md`
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
 

--- a/skills/lockpick/SKILL.md
+++ b/skills/lockpick/SKILL.md
@@ -130,7 +130,7 @@ covering:
 3. **SUID/SGID binaries** - find + exploit via GTFOBins
 4. **Linux capabilities** - `getcap`, cap_setuid, cap_dac_read_search
 5. **Cron jobs** - writable scripts, PATH hijacking in cron context
-6. **Kernel exploits** - version-matched CVEs (Dirty Pipe, nf_tables, io_uring, OverlayFS)
+6. **Kernel exploits** - version-matched CVEs (Dirty Pipe, nf_tables, io_uring, OverlayFS; 2026: Copy Fail CVE-2026-31431 [CISA KEV, exploited], Dirty Frag CVE-2026-43284/43500, ptrace CVE-2026-46333)
 7. **PATH hijacking** - SUID binaries calling relative commands
 8. **NFS** - no_root_squash exploitation
 9. **Writable files** - /etc/passwd, /etc/shadow, authorized_keys, systemd units

--- a/skills/lockpick/SKILL.md
+++ b/skills/lockpick/SKILL.md
@@ -365,7 +365,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** LOCKPICK
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/lockpick/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/lockpick/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -112,6 +112,8 @@ import { z } from "zod";
 
 const server = new McpServer({ name: "my-server", version: "1.0.0" });
 
+// Current SDK docs lead with `server.registerTool(name, { description, inputSchema }, handler)`.
+// The `server.tool(name, desc, schema, handler)` shorthand below still works in v1.x.
 server.tool(
   "search_docs",
   "Search documentation by keyword",
@@ -232,8 +234,9 @@ Client Registration (DCR is a fallback, not a requirement).
 - Validate `Origin` header on all requests (DNS rebinding prevention)
 - If using stateful sessions: `MCP-Session-Id` must be cryptographically random (UUID v4+)
 - Client sends `MCP-Protocol-Version` header (e.g., `2025-11-25`)
-- Consider using `createMcpExpressApp()` / `createMcpHonoApp()` from the TS SDK for built-in
-  DNS rebinding protection
+- Consider using `createMcpExpressApp()` / `createMcpHonoApp()` for built-in DNS rebinding
+  protection - these ship from the separate `@modelcontextprotocol/express` and
+  `@modelcontextprotocol/hono` packages, not the core `@modelcontextprotocol/sdk`
 
 ### Step 5: Handle elicitation safely
 
@@ -326,7 +329,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** MCP
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/mcp/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/mcp/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/networking/SKILL.md
+++ b/skills/networking/SKILL.md
@@ -373,7 +373,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** NETWORKING
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/networking/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/networking/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/networking/references/troubleshooting.md
+++ b/skills/networking/references/troubleshooting.md
@@ -377,6 +377,19 @@ Patched in OpenSSL 3.6.1 / 3.5.5 / 3.4.4 / 3.3.6 / 3.0.19 (Jan 2026). **Upgrade 
 
 Check your version: `openssl version` - anything below the patched versions is vulnerable.
 
+### Critical: nginx CVE-2026-42945 "NGINX Rift" (CVSS 9.2)
+
+Heap buffer overflow in `ngx_http_rewrite_module` via a crafted URI - worker DoS and potential
+unauthenticated RCE. Affects nginx OSS 0.6.27-1.30.0 (and Plus R32-R36). Fixed first in
+1.30.1 / 1.31.0; current patched releases are 1.30.2 (stable) / 1.31.1 (mainline). Actively
+exploited in the wild (added to CISA KEV) - patch now.
+
+### Critical: OpenSSH CVE-2026-35414 (cert principal bypass)
+
+A comma in a certificate principal was treated as a list separator, so a CA-signed certificate
+could authenticate as an unintended principal (potentially root). Fixed in OpenSSH 10.3. Upgrade
+and audit `authorized_keys`/CA-signed cert principals.
+
 ### Let's Encrypt with certbot
 
 **45-day certificate rollout timeline:**

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -323,7 +323,7 @@ When a problem looks "flake-only," compare one clean baseline:
 | `nixos-rebuild` evaluation error | `--show-trace`, check option name against the current nixpkgs tag, check `imports` paths |
 | Build fails mid-derivation | `--print-build-logs`, check sandbox violations, check unfree or insecure gates |
 | Boot drops to emergency shell | previous generation from bootloader menu, check `hardware-configuration.nix`, LUKS, kernel modules |
-| Flake input won't update | `nix flake lock --update-input <name>`, check `inputs.<x>.follows`, check registry override |
+| Flake input won't update | `nix flake update <name>` (the `nix flake lock --update-input` form is deprecated on Nix 2.30+), check `inputs.<x>.follows`, check registry override |
 | System is huge, `/nix/store` fills disk | `nix-collect-garbage -d`, `nix-store --optimise`, prune generations, check direnv GC roots |
 | `nix-env -i` installed something that won't stick | user profile vs system config; move to `environment.systemPackages` or `home.packages` |
 | home-manager drift vs NixOS | standalone vs module mode, which one owns the file, `home-manager switch` vs `nixos-rebuild switch` |

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -358,7 +358,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** NIXOS-BTW
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/nixos-btw/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/nixos-btw/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/nixos-btw/references/flakes-and-channels.md
+++ b/skills/nixos-btw/references/flakes-and-channels.md
@@ -145,7 +145,7 @@ Migrating a working channel-based NixOS install to flakes without breaking it:
 ```bash
 nix flake metadata                 # show input URLs and revs from flake.lock
 nix flake update                   # update all inputs and write flake.lock
-nix flake lock --update-input nixpkgs  # update one input
+nix flake update nixpkgs           # update one input (Nix 2.30+; replaces deprecated `nix flake lock --update-input`)
 nix flake check                    # eval all outputs, run checks
 nix flake check --no-build         # eval without building - fast sanity check
 nix flake show                     # show outputs tree

--- a/skills/nixos-btw/references/gotchas-and-special-situations.md
+++ b/skills/nixos-btw/references/gotchas-and-special-situations.md
@@ -26,7 +26,7 @@ Cause: `flake.lock` pins the input at the old rev.
 Fix:
 ```bash
 nix flake update                               # update all inputs
-nix flake lock --update-input nixpkgs          # just one
+nix flake update nixpkgs                        # just one (Nix 2.30+; replaces the deprecated `nix flake lock --update-input nixpkgs`)
 nix flake metadata                             # confirm revs
 ```
 

--- a/skills/prompt-generator/SKILL.md
+++ b/skills/prompt-generator/SKILL.md
@@ -265,7 +265,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** PROMPT-GENERATOR
 - **Deliverable bucket:** `prompts`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content (e.g., review an existing prompt for quality), emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/prompts/prompt-generator/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (its primary mode -- producing a prompt for the user), respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content (e.g., review an existing prompt for quality), emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/prompts/prompt-generator/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (its primary mode -- producing a prompt for the user), respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -335,7 +335,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** RHEL-FEDORA
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/rhel-fedora/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/rhel-fedora/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -26,8 +26,8 @@ ordinary package work, prefer the live distro lane and repo state over a stale p
 
 | Component | Version | Why it matters |
 |-----------|---------|----------------|
-| Fedora stable | 42 | current mainstream Fedora baseline |
-| Fedora next branch | 43 / verify live | useful when a bug is really Fedora-next behavior |
+| Fedora stable | 44 / verify live | current mainstream baseline (Fedora ships ~every 6 months and EOLs ~13 months, faster than this table is bumped - confirm live) |
+| Fedora next branch | 45 / verify live | useful when a bug is really Fedora-next behavior |
 | RHEL enterprise lane | 10.x | current enterprise baseline in the new major lane |
 | RHEL previous major | 9.x | still widely deployed and behaviorally different from 10 |
 | Rocky Linux | verify live major lane | close to RHEL, but current docs and vault state still matter |

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -37,6 +37,7 @@ ordinary package work, prefer the live distro lane and repo state over a stale p
 | SELinux | verify live | policy package and mode matter more than memorized version strings |
 | DNF | verify live | Fedora moves faster than enterprise lanes; DNF 5 vs legacy expectations matter |
 | Podman | verify live | rootless and quadlet behavior depend on the shipped distro lane |
+| Kernel security | verify live via RHSA/FEDORA tracker | patch high-severity privesc CVEs promptly; mid-2026 examples to confirm fixed: Copy Fail CVE-2026-31431 (CISA KEV, exploited), Dirty Frag CVE-2026-43284/43500, ptrace CVE-2026-46333 |
 
 ## When to use
 

--- a/skills/roadmap/SKILL.md
+++ b/skills/roadmap/SKILL.md
@@ -378,7 +378,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** ROADMAP
 - **Deliverable bucket:** `deliverables`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** an existing roadmap (e.g., "review my ROADMAP.md"), emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/deliverables/roadmap/<YYYY-MM-DD>-<slug>.md`. When invoked to **build or update a roadmap** (its primary mode -- writing to the user's working-directory `ROADMAP.md`), respond freely without the contract; build-mode output goes to `ROADMAP.md` in the working directory, not to `docs/local/`.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** an existing roadmap (e.g., "review my ROADMAP.md"), emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/deliverables/roadmap/<YYYY-MM-DD>-<slug>.md`. When invoked to **build or update a roadmap** (its primary mode -- writing to the user's working-directory `ROADMAP.md`), respond freely without the contract; build-mode output goes to `ROADMAP.md` in the working directory, not to `docs/local/`.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/routine-writer/SKILL.md
+++ b/skills/routine-writer/SKILL.md
@@ -239,7 +239,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** ROUTINE-WRITER
 - **Deliverable bucket:** `deliverables`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content (e.g., review an existing routine for quality), emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/deliverables/routine-writer/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (its primary mode -- producing a routine for the user), respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content (e.g., review an existing routine for quality), emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/deliverables/routine-writer/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (its primary mode -- producing a routine for the user), respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -39,6 +39,7 @@ Patterns drawn from real OSS incidents (unauthenticated admin endpoints, credent
 - Style, slop, or maintainability cleanup - use **anti-slop**
 - CI/CD pipeline design, runner architecture, or pipeline hardening strategy - use **ci-cd**
 - Offensive testing, privilege escalation, or post-exploitation work - use **lockpick**
+- Novel vulnerability research, fuzzing, patch diffing, or exploit development - use **zero-day**
 - Network appliance administration or firewall tuning - use **firewall-appliance**
 - Linux networking setup and troubleshooting - use **networking**
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -274,7 +274,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** SECURITY-AUDIT
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
 - **Deliverable path:** `docs/local/audits/security-audit/<YYYY-MM-DD>-<slug>.md`
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -131,6 +131,7 @@ Find known CVEs in dependencies and assess supply chain risk.
 - `colors` 1.4.1+ / `faker` 6.6.6 (2022 maintainer sabotage)
 - `polyfill.io` (2024 domain takeover, malicious CDN injection)
 - `xz-utils` 5.6.0-5.6.1 (2024 backdoor in compression library)
+- TrapDoor (2026-05 multi-registry campaign: 34+ malicious npm/PyPI/crates packages stealing SSH keys and cloud/crypto credentials; notably hides zero-width-Unicode prompt injection in `.cursorrules` / `CLAUDE.md` to subvert AI coding agents - check agent rule files, not just dependencies)
 - `trivy` 0.69.4-0.69.6 / `aquasecurity/trivy` Docker tags 0.69.5-0.69.6 / `aquasecurity/trivy-action` + `aquasecurity/setup-trivy` force-pushed tags (2026-03 TeamPCP supply chain compromise - credential-stealing malware in CI/CD pipelines)
 Any match on package name + version range is P0 severity regardless of `audit` output.
 For active incident triage, use `references/hardening-checklists.md` for repo-wide package,

--- a/skills/security-audit/references/report-guide.md
+++ b/skills/security-audit/references/report-guide.md
@@ -20,14 +20,14 @@ Tag each finding to the correct category.
 |----|----------|------------|
 | A01 | Broken Access Control | Auth bypass, IDOR, privilege escalation, missing function-level auth |
 | A02 | Security Misconfiguration | Default creds, verbose errors, CORS *, unnecessary features enabled, permissive headers |
-| A03 | Supply Chain Failures | Unpinned deps, no lockfile integrity, compromised packages, no SBOM, mutable CI actions |
-| A04 | Injection | SQL, NoSQL, OS command, LDAP, XSS, template injection, header injection |
-| A05 | Insecure Design | Missing rate limiting, no abuse case analysis, client-controlled security state |
-| A06 | Vulnerable Components | Known CVEs in deps, abandoned deps, no update automation |
-| A07 | Auth & Session Failures | Weak passwords, broken session management, missing MFA, credential stuffing exposure |
-| A08 | Data Integrity Failures | Unsigned updates, insecure deserialization, CI/CD pipeline manipulation |
-| A09 | Logging & Monitoring Failures | No audit trail, unmonitored auth failures, sensitive data in logs |
-| A10 | Mishandling Exceptional Conditions | Fail-open behavior, unhandled errors exposing state, silent error swallowing |
+| A03 | Software Supply Chain Failures | Unpinned deps, no lockfile integrity, compromised/known-CVE packages, abandoned deps, no update automation, no SBOM, mutable CI actions |
+| A04 | Cryptographic Failures | Weak/legacy ciphers, hardcoded keys, missing encryption in transit/at rest, weak hashing, predictable randomness |
+| A05 | Injection | SQL, NoSQL, OS command, LDAP, XSS, template injection, header injection |
+| A06 | Insecure Design | Missing rate limiting, no abuse case analysis, client-controlled security state |
+| A07 | Authentication Failures | Weak passwords, broken session management, missing MFA, credential stuffing exposure |
+| A08 | Software or Data Integrity Failures | Unsigned updates, insecure deserialization, CI/CD pipeline manipulation |
+| A09 | Security Logging and Alerting Failures | No audit trail, unmonitored auth failures, no alerting, sensitive data in logs |
+| A10 | Mishandling of Exceptional Conditions | Fail-open behavior, unhandled errors exposing state, silent error swallowing |
 
 ## Report Template
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -492,7 +492,8 @@ See `skills/_shared/output-contract.md` for the full contract.
    "just in case" instructions.
 7. **ASCII by default.** Keep skill prose ASCII except collection-approved markers such as the
    public-description `· ` prefix and shared output-contract box glyphs. No em dashes, curly
-   quotes, ligatures, or `--` dash substitutes.
+   quotes, ligatures, or `--` dash substitutes. Prose only: never rewrite `--` inside code or
+   fenced blocks - there it is real syntax (SQL comments, CLI `--` separators) and must stay.
 8. **Run the AI Self-Check.** Every generated or modified skill gets checked before return.
 9. **Branch every run.** In git-backed collections, create or record a run branch before checks.
 10. **Report every run.** Finish with the Run Report format and score before/after or "not scored."

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -464,7 +464,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** SKILL-CREATOR
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content (e.g., Mode 2 review or Mode 3 audit), emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/skill-creator/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (e.g., Mode 1 create), respond freely without the contract; the existing `## Run Report` guidance applies to that build path.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content (e.g., Mode 2 review or Mode 3 audit), emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/skill-creator/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (e.g., Mode 1 create), respond freely without the contract; the existing `## Run Report` guidance applies to that build path.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/skill-creator/references/conventions.md
+++ b/skills/skill-creator/references/conventions.md
@@ -142,8 +142,8 @@ user confirmation in steps that could run unattended.
 
 | Tier | Token usage | Typical skills | Structure depth |
 |------|-------------|---------------|-----------------|
-| **low** | <5k tokens | update-docs | Minimal workflow, few rules |
-| **medium** | 5-15k tokens | anti-slop, prompt-generator, command-prompt | Moderate workflow, reference files |
+| **low** | <5k tokens | (none in collection; reserved for minimal single-purpose wrappers) | Minimal workflow, few rules |
+| **medium** | 5-15k tokens | anti-slop, prompt-generator, command-prompt, update-docs | Moderate workflow, reference files |
 | **high** | 15k+ tokens | ansible, docker, kubernetes, terraform, etc. (see Skill Inventory) | Full workflow, AI self-check, checklists, multiple references |
 
 ### Upstream skills (for reference)
@@ -244,7 +244,10 @@ Overview.
 - **ASCII by default**: skill prose should stay ASCII except collection-approved markers such
   as the public-description `· ` prefix and shared output-contract box glyphs. No em-dashes,
   no `--` double-dash substitute, no curly quotes, no ligatures. Use a single `-` where you
-  would reach for an em dash.
+  would reach for an em dash. **This is a prose rule only: never rewrite `--` inside code,
+  command examples, or fenced blocks** - `--` is real syntax there (SQL/Lua comments, CLI
+  long-flag separators like `npm test -- --filter`, `git ... --`), and stripping it to `-`
+  produces broken, non-runnable examples.
 - **Explain why**: "Pin images to SHA256 digests because mutable tags are a proven attack vector
   (Trivy March 2026, tj-actions March 2025)" beats "Always pin images"
 - **Calm directives**: "Do X" outperforms "YOU MUST ALWAYS DO X" on most modern coding agents. Use ALL CAPS
@@ -548,7 +551,7 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 | skill-router | medium | 2026-05-01 | Skill routing and trigger conflict analysis |
 | terraform | high | 2026-03-24 | Infrastructure-as-code |
 | testing | high | 2026-04-02 | Test design, debugging, infrastructure |
-| update-docs | low | 2026-03-25 | Documentation sweep |
+| update-docs | medium | 2026-03-25 | Documentation sweep |
 | virtualization | high | 2026-04-02 | Proxmox, libvirt, VM operations |
 | zero-day | high | 2026-04-03 | Vulnerability research and discovery |
 

--- a/skills/skill-refiner/SKILL.md
+++ b/skills/skill-refiner/SKILL.md
@@ -261,7 +261,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** SKILL-REFINER
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content outside the refiner workflow, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/skill-refiner/<YYYY-MM-DD>-<slug>.md`. When invoked to **run the refiner workflow** (its primary mode), use the existing Phase 3 "Final report" format described in the workflow; that build-mode output is unchanged by this contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content outside the refiner workflow, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/skill-refiner/<YYYY-MM-DD>-<slug>.md`. When invoked to **run the refiner workflow** (its primary mode), use the existing Phase 3 "Final report" format described in the workflow; that build-mode output is unchanged by this contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Rules

--- a/skills/skill-router/SKILL.md
+++ b/skills/skill-router/SKILL.md
@@ -99,7 +99,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** SKILL-ROUTER
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content (e.g., a routing-conflict audit across the installed skill set), emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/skill-router/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (its primary routing-decision mode), respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content (e.g., a routing-conflict audit across the installed skill set), emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/skill-router/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content** (its primary routing-decision mode), respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -456,7 +456,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** TERRAFORM
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/terraform/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/terraform/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -328,7 +328,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** TESTING
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/testing/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/testing/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -428,7 +428,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** UPDATE-DOCS
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
 - **Deliverable path:** `docs/local/audits/update-docs/<YYYY-MM-DD>-<slug>.md`
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
 

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -25,7 +25,7 @@ bite you at 3 AM.
 | Proxmox VE | 9.1 | Nov 2025 | Debian 13.2 (trixie), kernel 6.17.2, QEMU 10.1.2 |
 | Proxmox Backup Server | 4.1 | Nov 2025 | Dedup, incremental, prune policies |
 | bpg/proxmox (Terraform) | 0.100.0 | Apr 2026 | Primary Proxmox IaC provider |
-| QEMU | 10.2.2 | Mar 2026 | Stable (11.0-rc2 in progress) |
+| QEMU | 11.0.1 | Apr 2026 | Stable (11.0 series; GA Apr 22, 2026) |
 | libvirt | 12.0.0 | Jan 2026 | Hypervisor abstraction layer |
 | XCP-ng | 8.3 LTS | Oct 2024 | Xen-based, LTS since Jun 2025, EOL Nov 2028 |
 | VMware ESXi | 8.0 U3i | Feb 2026 | Broadcom-owned, licensing upheaval |

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -420,7 +420,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** VIRTUALIZATION
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/virtualization/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/virtualization/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills

--- a/skills/zero-day/SKILL.md
+++ b/skills/zero-day/SKILL.md
@@ -474,7 +474,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 
 - **Skill name:** ZERO-DAY
 - **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract -- boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table -- and write the deliverable to `docs/local/audits/zero-day/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/zero-day/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
 ## Related Skills


### PR DESCRIPTION
Remediation from a full Opus 4.8 deep audit of all 43 skills (read-only audit doc kept locally in `docs/local/audits/skill-creator/`). Three atomic commits, batched by concern.

## `91d77f0` Correctness + version refresh (+ code-dash repair)
- **ai-ml (P0):** replace invalid `claude-sonnet-4-6-20250514` (16 sites; returns 404) with canonical `claude-sonnet-4-6`; add a model-family table anchoring **Opus 4.8** / Sonnet 4.6 / Haiku 4.5 + OpenAI gpt-5.5 tiers; bump `gpt-4o` examples to `gpt-5.5`.
- **security-audit (P1):** fix the OWASP Top 10:2025 table (was missing Cryptographic Failures, had a phantom "Vulnerable Components", used 2021 names).
- **kubernetes (P1/P2):** correct Helm 4 `--atomic` (removed from `helm install`); attribute the 1.32 "LTS" window to vendor (AKS/EKS) extended support, not upstream.
- **Version refresh, re-verified latest-stable 2026-05-29:** GitLab 18.x → **19.0** (incl. breaking-change note); forgejo-runner :11 → :12; Woodpecker 3.13 → 3.14; gitleaks 8.24/"9.x" → 8.30.1; OPNsense CE **26.1.7** (was quoting BE 26.4); Fedora 42 (EOL) → 44; QEMU 11.0.1; Helm 4.2.0/3.21.x; Lightpanda 0.3.1 / agent-browser 0.27.0 / @playwright/mcp 0.0.75; react-i18next 17.x / i18next 26.x.
- **Other:** nixos deprecated `nix flake lock --update-input` → `nix flake update`; kali-linux-large relabel; git `fj` version reconcile; `agent-browser batch --json` example fix; Polish plural count; update-docs effort reconciled to medium.
- **Code repair:** restore real `--` in SQL comments (databases) and npm arg separator (git) that the no-`--`-as-dash prose rule had stripped; add a "prose only, never in code" carve-out.

## `29535ec` Conventions + contracts
- Replace prose ` -- ` em-dash substitute with `-` in every SKILL.md Output Contract (42 files); reconcile anti-slop / code-slimming severity scales to what they actually emit; git "When NOT to use" → `**bold**` convention; mcp package attribution + `registerTool` note.

## `1fabde2` CVE / incident refresh (kernel emphasis)
- **networking:** nginx "NGINX Rift" CVE-2026-42945 (9.2, exploited) + OpenSSH CVE-2026-35414.
- **databases:** PostgreSQL May-2026 batch (CVE-2026-6473/6475/6477/6637).
- **docker:** Model Runner CVE-2026-5817/5843 (8.8 RCE) + checklist floor → 4.71.0.
- **lockpick / debian-ubuntu / rhel-fedora:** 2026 kernel privesc CVEs (Copy Fail CVE-2026-31431 [CISA KEV], Dirty Frag CVE-2026-43284/43500, ptrace CVE-2026-46333).
- **security-audit / ci-cd:** TrapDoor multi-registry supply-chain campaign (incl. its `.cursorrules`/`CLAUDE.md` prompt-injection vector).

Batch D (line-budget trims) de-scoped: 500 is a soft target and nothing breached the 600 hard cap.

## Verification
All local checks green: `lint-skills.sh`, `validate-spec.sh` (42 skills, 0 violations), `check-freshness-dates.sh`, `check-deep-audit-coverage.sh`, leak/overlay checks, `test-install.sh`. Cross-references all resolve; no banned words.