### PR TITLE
fix(skills): refresh stale version pins (databases, ansible, git)

### DIFF
--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -20,7 +20,7 @@ Write, review, and architect Ansible automation - from single playbooks to multi
 - ansible (community package) 13.x (depends on ansible-core 2.20)
 - molecule 26.x (CalVer), ansible-lint 26.x (CalVer), ansible-navigator 26.x (CalVer)
 - ansible-builder 3.1.x (EE definition v3)
-- AWX 24.6.1 (stale since Jul 2024 - verify current status before recommending)
+- AWX 24.6.1 (last formal release Jul 2024; upstream AWX releases paused for a major refactor, devel branch active - track ansible/awx; awx-operator ~2.12.x still ships for K8s deploys)
 - AAP 2.6 (Oct 2025 - last RPM-installable release; AAP 2.7+ containerized-only)
 
 This skill covers four domains depending on context:

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -17,9 +17,9 @@ Configure, tune, design schemas, migrate, back up, and review database engines -
 
 **Target versions** (May 2026):
 - PostgreSQL **18.3** (EOL 2030-11), previous: 17.9, 16.13
-- MongoDB **8.0.20** (GA), 8.2.6 (rapid release, EOL 2026-07)
-- MariaDB **11.8.6** (LTS, EOL 2028-06), 12.2.2 (rolling GA, EOL 2026-05)
-- MySQL **8.4.8** (LTS), 9.6.0 (innovation)
+- MongoDB **8.0.20** (GA, EOL 2029-10); rapid lane (8.3 latest) is Atlas-only with a short window - verify live before pinning
+- MariaDB **11.8.7** (LTS, EOL 2028-06); 12.x rolling GA is quarterly and EOLs at each successor (12.2 reached EOL 2026-05), with 12.3 the next yearly LTS - verify live
+- MySQL **8.4.8** (LTS); innovation lane (9.x) has a short support window - verify live
 - SQL Server **2025 RTM + CU3** (GA 2025-11-18)
 - PgBouncer **1.25.1**, Pgpool-II **4.7.1**, ProxySQL **3.0.6**
 

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -22,7 +22,7 @@ compliance requirements (PCI-DSS 4.0).
 - **git**: 2.53.x (current stable). Git 3.0 expected late 2026 (reftable default, SHA-256 default)
 - **GitHub CLI (`gh`)**: 2.91.0
 - **GitLab CLI (`glab`)**: 1.90.x
-- **Forgejo CLI (`fj`)**: 0.4.0 (latest verified, Jan 2026; the project moves fast - verify the current release at `codeberg.org/forgejo-contrib/forgejo-cli`). Rust-written, official community CLI. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
+- **Forgejo CLI (`fj`)**: 0.5.0 (latest verified May 2026, released 2026-04-16; the project moves fast - verify the current release at `codeberg.org/forgejo-contrib/forgejo-cli`). Rust-written, official community CLI. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
 - **Forgejo**: v15.0 line current at May 2026 recheck; verify the stable branch before upgrade advice. Critical RCE (CVE-2025-68937) patched in v13.0.2+.
 - **prek**: 0.3.x (Rust, recommended) or **pre-commit**: 4.6.0 (Python, largest ecosystem)
 - **git-filter-repo**: 2.47.x


### PR DESCRIPTION
## What

A full skill-creator Mode 3 audit of all 42 skills found the collection in excellent health (every structural gate, cross-reference, trigger boundary, and the historically-missed freshness categories all clean). It surfaced three low-severity freshness watch-items in `Target versions` blocks, all verified live on 2026-05-29 and fixed here.

## Changes

- **databases**: MariaDB 12.2 reached EOL 2026-05-13 while still pinned as a current option. Rather than re-pin brittle quarterly versions, the fast-lanes are reframed by behavior so they can't read as expired:
  - MariaDB LTS `11.8.6` -> `11.8.7`; rolling 12.x described as quarterly/EOL-at-successor with 12.3 as the next yearly LTS.
  - MongoDB rapid `8.2.6 (EOL 2026-07)` -> "rapid lane (8.3 latest) Atlas-only, short window, verify live"; added 8.0 GA EOL 2029-10.
  - MySQL innovation `9.6.0` -> "9.x short window, verify live". LTS/GA pins kept specific.
- **ansible**: AWX's last formal release is `24.6.1` (Jul 2024) and upstream releases are **paused** for a major refactor. Reworded to state the pause and point at `ansible/awx` + `awx-operator ~2.12.x` instead of implying the pin is merely stale.
- **git**: Forgejo CLI `fj` `0.4.0` (Jan 2026) -> `0.5.0` (released 2026-04-16).

## Verification

- `scripts/lint-skills.sh skills` -> 42 checked, 0 errors, 0 warnings
- `scripts/validate-spec.sh skills` -> 42 validated, 0 violations, 0 warnings
- `scripts/check-freshness-dates.sh` -> clean (May 2026)

No structural or contract changes; content-only refresh of three Target-versions blocks.