### PR TITLE
fix(skills): correct technical errors found in full content review

### DIFF
--- a/skills/ansible/references/compliance.md
+++ b/skills/ansible/references/compliance.md
@@ -155,9 +155,8 @@ roles:
 # Managed by Ansible - do not edit manually
 # PCI-DSS 4.0: Req 2.2.7 (encrypted non-console admin), Req 8 (authentication)
 
-# Protocol 2 is the only option since OpenSSH 7.6+ (directive removed).
-# Kept for: compliance scanners that grep for it, and older SSH versions.
-Protocol 2
+# SSHv2 is the only protocol; SSHv1 and the `Protocol` directive were removed in OpenSSH 7.6.
+# Do not set `Protocol` on modern sshd - it triggers a deprecation/parse warning.
 
 # Authentication
 PermitRootLogin no

--- a/skills/anti-slop/references/rust.md
+++ b/skills/anti-slop/references/rust.md
@@ -105,7 +105,7 @@ if let Some(v) = maybe_value {
 ## Supply Chain Risk (Lies)
 
 **High-risk crates** (active CVEs, March 2026):
-- `tar`, `async-tar`, `tokio-tar` - CVE-2026-33056 (symlink-following RCE during `cargo build`). Pin `tar >= 0.4.45`. Fix shipped in Rust 1.94.0 (released March 5, 2026). Affects uv, testcontainers, wasmCloud.
+- `tar`, `async-tar`, `tokio-tar` - CVE-2026-33056 (symlink-following RCE during `cargo build`). Pin `tar >= 0.4.45` (the actionable mitigation). Fix also shipped in the Cargo bundled with Rust 1.94.x. Affects uv, testcontainers, wasmCloud.
 - Rust supply chain attacks up 130% in 2025. Crates.io deploying TUF (The Update Framework) in 2026.
 
 **Detect:**

--- a/skills/code-review/references/java.md
+++ b/skills/code-review/references/java.md
@@ -177,8 +177,8 @@ return configs.collect(Collectors.toList()); // exception thrown HERE, uncaught
 ### Virtual Threads (Project Loom)
 
 **Detect:**
-- `synchronized` blocks in code called from virtual threads - pins the carrier thread, defeating scalability (use `ReentrantLock` instead)
-- `ThreadLocal` with virtual threads - 1M virtual threads = 1M ThreadLocal instances (use `ScopedValue` in Java 25+)
+- `synchronized` blocks called from virtual threads on Java 21-23 - pins the carrier thread, defeating scalability (use `ReentrantLock`). Java 24+ fixes this via JEP 491, so do not flag `synchronized` as a pinning bug on 24+
+- `ThreadLocal` with virtual threads - 1M virtual threads = 1M ThreadLocal instances (use `ScopedValue`; preview in Java 21-24, stable in 25)
 - Assuming virtual threads increase DB throughput (HikariCP has 10 connections regardless - 9,990 virtual threads just block waiting)
 - `StructuredTaskScope` without try-with-resources (thread leak on exception)
 

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -70,7 +70,7 @@ AI tools consistently produce the same database mistakes. **Before returning any
 - [ ] No `DROP TABLE` or `DROP DATABASE` without explicit user confirmation
 - [ ] Migration is idempotent - can be run twice without error
 - [ ] Rollback/down migration exists and is tested
-- [ ] PG enum changes use `ALTER TYPE ... ADD VALUE` outside a transaction (cannot run inside BEGIN/COMMIT, fails silently in some ORMs)
+- [ ] PG enum changes use `ALTER TYPE ... ADD VALUE` outside a transaction (PG 12+ allows it inside a transaction, but the new value cannot be used until that transaction commits - run it standalone to use the value immediately)
 
 ### Schema
 
@@ -179,7 +179,7 @@ Follow the domain-specific section below. Always apply the production checklist 
 1. Determine backend budget: `max_connections` minus superuser_reserved minus replication slots = available.
 2. PgBouncer `default_pool_size` per user/db pair: start at `available / number_of_app_instances`, round down.
 3. Set `max_client_conn` to the total connections your app fleet will open (all instances combined).
-4. Use `transaction` pool mode for web apps (stateless requests). Use `session` mode only if the app uses prepared statements without PgBouncer 1.21+ `max_prepared_statements`, temp tables, or `SET` commands.
+4. Use `transaction` pool mode for stateless web apps. Switch to `session` mode (which supports all PostgreSQL features) when the app needs session-level state: temp tables, advisory locks, `SET`, or prepared statements on PgBouncer older than 1.21 (1.21+ supports prepared statements in transaction mode via `max_prepared_statements`).
 5. Validate: `psql -h pgbouncer-host -p 6432 pgbouncer -c "SHOW POOLS;"` - watch `sv_active` vs `sv_idle` under load.
 
 **Migration safety check** (before running any DDL in production):
@@ -299,7 +299,7 @@ Read `references/migration-patterns.md` for cross-engine type mapping, ORM migra
 
 - [ ] `pg_hba.conf`: `hostssl` only, `scram-sha-256` only, CIDR-restricted
 - [ ] `shared_buffers` = 25% RAM, `effective_cache_size` = 75% RAM
-- [ ] `work_mem` sized for concurrency (default 64MB is high for OLTP with many connections - per-sort, not per-connection)
+- [ ] `work_mem` sized for concurrency (PG default is 4MB; allocated per sort/hash operation, not per connection - multiply by concurrent queries x operations to estimate peak memory)
 - [ ] `random_page_cost = 1.1` for SSD storage
 - [ ] `statement_timeout` set per-role (not globally - migrations need longer)
 - [ ] `idle_in_transaction_session_timeout` set (60s default)

--- a/skills/databases/references/migration-patterns.md
+++ b/skills/databases/references/migration-patterns.md
@@ -659,7 +659,7 @@ SELECT * FROM t WHERE col IS NOT DISTINCT FROM NULL;
 -- MSSQL-specific: ISNULL() vs COALESCE() - ISNULL is faster but only takes 2 args.
 
 -- String concatenation with NULL:
--- MySQL CONCAT('a', NULL, 'b') = 'ab' (NULL is skipped)
+-- MySQL CONCAT('a', NULL, 'b') = NULL (NULL propagates; use CONCAT_WS() to skip NULLs)
 -- PostgreSQL 'a' || NULL || 'b' = NULL (NULL propagates)
 -- MSSQL 'a' + NULL + 'b' = NULL (NULL propagates, unless SET CONCAT_NULL_YIELDS_NULL OFF)
 

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -79,7 +79,7 @@ Before declaring finish-mode complete:
 - [ ] Release convention detected via 2+ independent signals before attempting a release
 - [ ] `code-review` ran on the diff against base, not against HEAD alone
 - [ ] PR/MR body includes summary + test plan; no AI attribution trailers
-- [ ] CI watched to completion with forge-appropriate verification (e.g., `gh pr view --json statusCheckRollup`, `glab ci status --output json`, manual confirmation for Bitbucket/bare) - not merged on "probably fine"
+- [ ] CI watched to completion with forge-appropriate verification (e.g., `gh pr view --json statusCheckRollup`, `glab ci status`, manual confirmation for Bitbucket/bare) - not merged on "probably fine"
 - [ ] For releases: tag matches the bumped version; CHANGELOG has a new section dated today; release-workflow watch used forge-appropriate exit-status flag (`gh run watch --exit-status` etc.)
 - [ ] No `--no-verify`, no `--force-push`, no destructive reset - if blocked, fix the root cause
 - [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them

--- a/skills/docker/references/alternative-runtimes.md
+++ b/skills/docker/references/alternative-runtimes.md
@@ -172,7 +172,7 @@ set -euo pipefail
 ctr=$(buildah from node:22-slim)
 
 # Run commands in the container
-buildah run $ctr - npm ci --omit=dev
+buildah run $ctr -- npm ci --omit=dev
 buildah copy $ctr ./dist /app/dist
 
 # Configure the image

--- a/skills/docker/references/dockerfile-patterns.md
+++ b/skills/docker/references/dockerfile-patterns.md
@@ -232,7 +232,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 CMD ["gunicorn", "app:app", "--bind", "0.0.0.0:8000"]
 ```
 
-Always use a venv in the container (Python 3.12+ externally managed). `--no-cache-dir` avoids storing wheels.
+Always use a venv in the container (Python 3.12+ externally managed). Use either a `--mount=type=cache` pip cache OR `--no-cache-dir`, never both.
 
 ### Rust
 

--- a/skills/docker/references/security-and-compliance.md
+++ b/skills/docker/references/security-and-compliance.md
@@ -66,7 +66,7 @@ The attackers are a cloud-native threat group active 2025-2026, known for Docker
 1. **Pin images to SHA256 digests**, not tags:
    ```dockerfile
    # BAD: mutable tag
-   FROM aquasec/trivy:0.70.0@sha256:<digest>
+   FROM aquasec/trivy:0.70.0
 
    # GOOD: immutable digest
    FROM aquasec/trivy@sha256:abc123def456...

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -159,7 +159,7 @@ After every change, confirm the firewall is healthy:
    - OPNsense CLI: `configctl template reload OPNsense/Filter` (after editing alias via API or XML). To verify the alias was created: `configctl template list | grep Alias`, then confirm with `pfctl -t WebServer -T show`.
    - pfSense: `easyrule` doesn't support aliases - use GUI or edit `/cf/conf/config.xml` directly
 5. Add a pass rule on the **VLAN interface** (not WAN - pf evaluates rules on the interface where traffic enters): source = alias, destination = server alias, port = 443
-6. Place the allow rule above any block-all rule for that interface (rule ordering matters - pf evaluates last match, not first match, so a later block overrides an earlier pass)
+6. Place the allow rule above any block-all rule for that interface (OPNsense/pfSense interface rules use `quick` by default, so the FIRST matching rule wins - put the specific allow above the broad block)
 7. Test: `pfctl -n -f /tmp/rules.debug` (OPNsense) to dry-run before applying
 8. Apply: `configctl filter reload` (OPNsense) or `pfSsh.php playback svc restart filter` (pfSense)
 9. Verify: `pfctl -sr | grep <alias>` to confirm the rule is active
@@ -172,7 +172,7 @@ Block IoT devices from reaching internal networks while allowing internet access
 2. Create an alias for RFC1918 ranges: name `RFC1918`, type `Network`, content `10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`
 3. Add a **block** rule on the IoT interface: source = IoT subnet, destination = `RFC1918` alias, action = block. This prevents IoT from reaching any internal network.
 4. Add a **pass** rule below it: source = IoT subnet, destination = any, ports = 53 (DNS), 443 (HTTPS). This allows internet access for the permitted services.
-5. Rule order matters: the block rule for RFC1918 must come before the pass rule for any, since pf uses last-match semantics - the block must not be overridden by a later pass.
+5. Rule order matters: with `quick` (the OPNsense/pfSense default) the FIRST matching rule wins, so the RFC1918 block must come before the broad pass rule - otherwise the pass matches first and lets the traffic through.
 6. Test and apply as above: `pfctl -n -f /tmp/rules.debug`, then `configctl filter reload`
 
 ### Troubleshooting connectivity after VLAN changes

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -267,7 +267,7 @@ Quick reference:
 - **Revert a pushed commit**: `git revert <sha>` (creates a new commit, safe for shared branches)
 - **Find lost commits**: `git reflog` - shows every HEAD movement for 90 days
 - **Find which commit broke something**: `git bisect start && git bisect bad && git bisect good <sha>`
-- **Automated bisect with test script**: `git bisect start HEAD v1.0.0 && git bisect run bun test - src/auth.test.ts` - runs the test at each bisect step automatically. Any command that exits 0 (good) or 1-124/128-255 (bad) works. Exit 125 means "skip this commit". Ideal for CI integration: `git bisect run ./scripts/ci-check.sh`
+- **Automated bisect with test script**: `git bisect start HEAD v1.0.0 && git bisect run bun test - src/auth.test.ts` - runs the test at each bisect step automatically. Exit codes: 0 = good, 1-127 except 125 = bad, 125 = skip this commit, 128-255 = abort the bisect immediately. Ideal for CI integration: `git bisect run ./scripts/ci-check.sh`
 - **Squash last N commits (no interactive rebase)**: `git reset --soft HEAD~N && git commit -m "feat: combined change"` - resets N commits but keeps all changes staged, then commits them as one. Safer than `git rebase -i` in automated contexts.
 - **Recover deleted branch**: `git reflog`, find the SHA, `git checkout -b branch-name <sha>`
 - **Scrub secrets from history**: `git filter-repo --replace-text <(echo 'SECRET==>REDACTED')` - then force-push ALL branches and tags. Coordinate with team. See references.

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -181,7 +181,7 @@ Read `references/manifest-templates.md` for complete, copy-pasteable YAML templa
 - **Server-side apply (SSA) is the default** for new releases. Better conflict detection when multiple controllers touch the same resources.
 - **OCI digest installation**: `helm install myapp oci://registry/chart@sha256:abc...` - immutable, tamper-proof.
 - **WASM plugin system** - post-renderers must reference plugin names, not raw executables (breaking change).
-- **CLI flag renames**: `--atomic` -> `--rollback-on-failure`, `--force` -> `--force-replace`. On `helm upgrade` the old flags still work as deprecated aliases, but `helm install --atomic` was removed and now errors - use `--rollback-on-failure`.
+- **CLI flag renames**: `--atomic` -> `--rollback-on-failure`, `--force` -> `--force-replace`. The old flags still work as deprecated aliases on both install and upgrade (a brief Helm 4.0 regression that broke `helm install --atomic` was fixed in v4.1.3); prefer `--rollback-on-failure` for new scripts.
 - **`helm registry login` takes domain only** (e.g., `ghcr.io`, not full URL).
 - **OCI registries are the recommended distribution method.** Traditional `index.yaml` repos still work but are no longer the default path.
 

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -21,7 +21,7 @@ become yet another server with preventable injection vulnerabilities.
 - MCP specification: 2025-11-25 (current stable; 2026-03-15 in draft)
 - TypeScript SDK: @modelcontextprotocol/sdk 1.29.0 (1.x stable; 2.0.0-alpha in dev)
 - Python SDK: mcp 1.27.0 (v1.26.0+)
-- Protocol transports: stdio, streamable HTTP (SSE deprecated in spec 2025-03-26)
+- Protocol transports: stdio, Streamable HTTP (the standalone HTTP+SSE transport was deprecated in spec 2025-03-26; SSE still streams inside Streamable HTTP)
 
 ## When to use
 
@@ -112,12 +112,15 @@ import { z } from "zod";
 
 const server = new McpServer({ name: "my-server", version: "1.0.0" });
 
-// Current SDK docs lead with `server.registerTool(name, { description, inputSchema }, handler)`.
-// The `server.tool(name, desc, schema, handler)` shorthand below still works in v1.x.
-server.tool(
+// Current SDK API: `server.registerTool(name, { title, description, inputSchema }, handler)`.
+// The older `server.tool(name, desc, schema, handler)` shorthand still works in v1.x.
+server.registerTool(
   "search_docs",
-  "Search documentation by keyword",
-  { query: z.string().max(200).describe("Search query"), limit: z.number().int().min(1).max(100).default(10) },
+  {
+    title: "Search docs",
+    description: "Search documentation by keyword",
+    inputSchema: { query: z.string().max(200).describe("Search query"), limit: z.number().int().min(1).max(100).default(10) },
+  },
   async ({ query, limit }) => {
     // If this tool reads files, apply path validation from Step 3 before any fs access.
     const sanitized = query.replace(/[^\w\s-]/g, "");
@@ -224,7 +227,7 @@ server.tool("read_file", "Read a project file",
 | **stdio** | Local tools, CLI integration | No | Runs as user's process. Most secure. |
 | **Streamable HTTP** | Remote/multi-client servers | Recommended | Single endpoint, POST for messages, optional SSE streaming. |
 
-SSE transport was deprecated in spec 2025-03-26. Use streamable HTTP for all remote servers.
+The standalone HTTP+SSE transport (spec 2024-11-05) was deprecated in spec 2025-03-26; use Streamable HTTP for all remote servers (it still uses SSE internally for optional response streaming).
 Auth is optional per spec but strongly recommended for servers handling user data. When
 implementing auth, use OAuth 2.1 with PKCE. Prefer Client ID Metadata Documents over Dynamic
 Client Registration (DCR is a fallback, not a requirement).

--- a/skills/nixos-btw/references/hardware-desktop-and-kernel.md
+++ b/skills/nixos-btw/references/hardware-desktop-and-kernel.md
@@ -172,8 +172,8 @@ NixOS carries both. Pick by session type and compositor.
 ```nix
 {
   services.xserver.enable = true;
-  services.xserver.displayManager.gdm.enable = true;
-  services.xserver.desktopManager.gnome.enable = true;
+  services.displayManager.gdm.enable = true;
+  services.desktopManager.gnome.enable = true;
 }
 ```
 

--- a/skills/nixos-btw/references/rebuild-generations-and-rollback.md
+++ b/skills/nixos-btw/references/rebuild-generations-and-rollback.md
@@ -31,7 +31,7 @@ sudo nixos-rebuild switch --flake .#box --build-host builder.lan
 ### nixos-rebuild-ng
 
 NixOS 25.11 made **`nixos-rebuild-ng`** the default. It is a Python rewrite of
-`nixos-rebuild` with the same verbs and flags. Older guides reference the Perl version; the
+`nixos-rebuild` with the same verbs and flags. Older guides reference the Bash version; the
 behavior is the same for 95% of workflows, but internal tracing and some edge flags differ.
 
 ## Useful flags

--- a/skills/routine-writer/references/trigger-guide.md
+++ b/skills/routine-writer/references/trigger-guide.md
@@ -133,28 +133,16 @@ GitHub triggers require the **Claude GitHub App** installed on the target reposi
 
 ### Supported events
 
+The research preview currently supports only **two** GitHub trigger events (pull request and
+release). More are expected as the feature matures - verify the current list in the web UI
+before relying on any other event.
+
 | Event | Triggers when |
 |---|---|
 | Pull request | A PR is opened, closed, assigned, labeled, synchronized, or otherwise updated |
-| Pull request review | A PR review is submitted, edited, or dismissed |
-| Pull request review comment | A comment on a PR diff is created, edited, or deleted |
-| Push | Commits are pushed to a branch |
 | Release | A release is created, published, edited, or deleted |
-| Issues | An issue is opened, edited, closed, labeled, or otherwise updated |
-| Issue comment | A comment on an issue or PR is created, edited, or deleted |
-| Sub issues | A sub-issue or parent issue is added or removed |
-| Commit comment | A commit or diff is commented on |
-| Discussion | A discussion is created, edited, answered, or otherwise updated |
-| Discussion comment | A discussion comment is created, edited, or deleted |
-| Check run | A check run is created, requested, rerequested, or completed |
-| Check suite | A check suite completes or is requested |
-| Merge queue entry | A PR enters or leaves the merge queue |
-| Workflow run | A GitHub Actions workflow run starts or completes |
-| Workflow job | A GitHub Actions job is queued or completes |
-| Workflow dispatch | A workflow is manually triggered |
-| Repository dispatch | A custom `repository_dispatch` event is sent |
 
-Each category can be filtered to a single action (e.g., `pull_request.opened`) or left to match all actions.
+Each can be filtered to a single action (e.g., `pull_request.opened`) or left to match all actions.
 
 ### Pull request filters
 

--- a/skills/skill-refiner/references/harness-detection.md
+++ b/skills/skill-refiner/references/harness-detection.md
@@ -12,7 +12,7 @@ How skill-refiner detects and validates AI CLI harnesses for cross-model peer re
 | Codex | `codex` | `~/.codex/config.toml` | `OPENAI_API_KEY` | `codex exec "respond with PONG"` |
 | Gemini CLI | `gemini` | `~/.gemini/settings.json` | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | `gemini -p "respond with PONG"` |
 | OpenCode | `opencode` | project-level `.opencode/` (verify) | varies by provider | check `opencode --help` |
-| Aider | `aider` | `~/.aider.conf.yml` | `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` | `aider --message "respond with PONG" --no-git --yes` |
+| Aider | `aider` | `~/.aider.conf.yml` | `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` | `aider --message "respond with PONG" --no-git --yes-always` |
 | Goose | `goose` | `~/.config/goose/config.yaml` | varies by provider | check `goose --help` |
 
 **Important:** Smoke test commands are approximate. Verify against current CLI versions

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -234,7 +234,7 @@ import {
 }
 ```
 
-**Moved blocks** (TF 1.8+): declarative intra-state refactoring. Rename resources or move into/out of modules within the same state file. Reviewed in PRs, applied automatically on `terraform apply`. Does NOT work across state files.
+**Moved blocks** (TF 1.1+): declarative intra-state refactoring. Rename resources or move into/out of modules within the same state file. Reviewed in PRs, applied automatically on `terraform apply`. Does NOT work across state files.
 
 ```hcl
 moved {
@@ -332,7 +332,7 @@ Read `references/state-and-security.md` for state backends, locking, encryption,
 
 See `references/state-and-security.md` for full backend config examples, OIDC federation patterns, CI/CD pipeline flows, and cross-state migration workflows.
 
-**S3 + native locking** (TF 1.10+): DynamoDB-based locking is deprecated. Use `use_lockfile = true`. Encrypt with KMS. Enable versioning and CloudTrail data events on the bucket.
+**S3 + native locking** (TF 1.10+): native `use_lockfile = true` replaces DynamoDB locking (DynamoDB still works and is slated for deprecation in a future release). Encrypt with KMS. Enable versioning and CloudTrail data events on the bucket.
 
 **OpenTofu**: add client-side state encryption on top (AES-GCM, AWS KMS, GCP KMS, or OpenBao) - encrypts before upload, even a compromised backend can't read state.
 


### PR DESCRIPTION
## What

Full per-skill **content-correctness** review of all 42 skills (the deeper pass after the structural/freshness audit). Subagents reviewed the actual domain instructions; every finding was **web-verified before fixing**. Several subagent findings turned out to be false positives from stale training and were deliberately **left unchanged** (real 2026 CVEs `CVE-2026-31431`/`-46333`, k8s native-sidecar GA in 1.33, OWASP A03:2025 = Software Supply Chain Failures, real `@modelcontextprotocol/express`/`hono` packages).

## Fixes (all web-verified)

| Skill | Fix |
|---|---|
| git | bisect exit codes: 128-255 **aborts** the bisect (was labeled "bad"); bad = 1-127 except 125 |
| databases | PG enum ALTER TYPE rationale (PG12+); `work_mem` default is **4MB** not 64MB; PgBouncer mode framing; MySQL `CONCAT` **propagates** NULL |
| mcp | lead with `server.registerTool` (current SDK); SSE wording (standalone HTTP+SSE deprecated, SSE still inside Streamable HTTP) |
| terraform | `moved` block is **TF 1.1+** (not 1.8); DynamoDB locking *slated* for deprecation, not already deprecated |
| kubernetes | `helm install --atomic` not removed (4.0 regression fixed in **v4.1.3**) |
| firewall-appliance | OPNsense/pfSense interface rules use `quick` = **first-match wins**, not last-match |
| nixos-btw | GNOME `gdm`/`gnome` options moved to `services.displayManager`/`services.desktopManager`; legacy `nixos-rebuild` was **Bash** not Perl |
| docker | `buildah run` needs `--`; Python `--no-cache-dir` vs cache-mount contradiction; "BAD mutable tag" example was actually digest-pinned |
| code-review | `synchronized` pinning fixed in **Java 24 (JEP 491)** - gate the advice; `ScopedValue` preview since 21 |
| anti-slop | tar CVE fix attribution softened to Rust 1.94.x |
| routine-writer | GitHub trigger events trimmed to the **two** supported in the research preview (pull request, release) |
| skill-refiner | aider flag is `--yes-always` |
| ansible | drop removed sshd `Protocol` directive (gone in OpenSSH 7.6) |
| dev-cycle | `glab ci status` takes no `--output json` |

## Verification

- `scripts/lint-skills.sh skills` -> 42 checked, 0 errors, 0 warnings
- `scripts/validate-spec.sh skills` -> 42 validated, 0 violations, 0 warnings
- `scripts/check-freshness-dates.sh` -> clean

18 files across 14 skills. Content-only; no structural/contract changes.