### PR TITLE
fix(skills): refresh CVE/advisory references with recent 2026 incidents

### DIFF
--- a/skills/ansible/references/compliance.md
+++ b/skills/ansible/references/compliance.md
@@ -157,6 +157,8 @@ roles:
 
 # SSHv2 is the only protocol; SSHv1 and the `Protocol` directive were removed in OpenSSH 7.6.
 # Do not set `Protocol` on modern sshd - it triggers a deprecation/parse warning.
+# Keep OpenSSH patched: CVE-2026-35414 (Apr 2026, fixed in 10.3) let a comma in a trusted-CA
+# certificate principal bypass authorized_keys principal matching and authenticate as root.
 
 # Authentication
 PermitRootLogin no

--- a/skills/ci-cd/references/supply-chain.md
+++ b/skills/ci-cd/references/supply-chain.md
@@ -1,7 +1,7 @@
 # CI/CD Supply Chain Security
 
 Cross-platform supply chain hardening patterns, incident timeline, and PCI-DSS 4.0 compliance.
-Updated March 2026 - post-Trivy compromise.
+Updated May 2026 - post-Trivy compromise and the TeamPCP npm/PyPI worm wave.
 
 ---
 
@@ -46,6 +46,13 @@ they inform every recommendation in this document.
 
 **IOC**: check for a repo named `tpcp-docs` in your org - its presence indicates the fallback
 exfiltration mechanism was triggered.
+
+### TeamPCP npm/PyPI wave - "Mini Shai-Hulud" (April-May 2026)
+
+- TeamPCP's follow-up to the Trivy compromise: a self-propagating worm across npm and PyPI.
+- April 29: four official SAP `@sap/*` npm packages poisoned (09:55-12:14 UTC). April 30: PyTorch `lightning` PyPI 2.6.2/2.6.3. May 11: 84 malicious versions across 42 `@tanstack/*` packages (19:20-19:26 UTC). Mistral AI, UiPath, OpenSearch also hit.
+- Harvests GitHub/npm tokens, CI/CD secrets, cloud creds, and API keys; ~1,800 developers across npm + PyPI (and PHP).
+- **Lesson**: a single compromised maintainer namespace fans out to a whole package family within minutes. Pin by digest, enable npm trusted publishing / provenance, and scope CI tokens narrowly.
 
 ### HackerBot-Claw (February 2026)
 

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 Configure, tune, design schemas, migrate, back up, and review database engines - from single-node dev setups to PCI-compliant production clusters. The goal is correct, performant, durable databases that survive failures, pass audits, and don't wake you up at 3am.
 
 **Target versions** (May 2026):
-- PostgreSQL **18.3** (EOL 2030-11), previous: 17.9, 16.13
+- PostgreSQL **18.4** (EOL 2030-11; May 2026 security release), previous: 17.10, 16.14
 - MongoDB **8.0.20** (GA, EOL 2029-10); rapid lane (8.3 latest) is Atlas-only with a short window - verify live before pinning
 - MariaDB **11.8.7** (LTS, EOL 2028-06); 12.x rolling GA is quarterly and EOLs at each successor (12.2 reached EOL 2026-05), with 12.3 the next yearly LTS - verify live
 - MySQL **8.4.8** (LTS); innovation lane (9.x) has a short support window - verify live

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -33,7 +33,7 @@ stale package-version table.
 | Ubuntu HWE lane | verify live | kernel metapackage and hardware-enablement behavior matter more than one exact kernel number |
 | NVIDIA driver branch | verify live | proprietary branch choice affects Wayland, gaming, and DKMS behavior |
 | Mesa stack | verify live | AMD and Intel graphics behavior tracks the shipped Mesa lane |
-| Kernel security | verify live via USN tracker | patch high-severity privesc CVEs promptly; mid-2026 examples to confirm fixed: Copy Fail CVE-2026-31431 (CISA KEV, exploited), Dirty Frag CVE-2026-43284/43500, ptrace CVE-2026-46333 |
+| Kernel security | verify live via USN tracker | patch high-severity privesc CVEs promptly; mid-2026 examples to confirm fixed: Copy Fail CVE-2026-31431 (CISA KEV, exploited), Dirty Frag CVE-2026-43284/43500, Fragnesia CVE-2026-46300 (ESP-in-TCP, exploited), ptrace CVE-2026-46333 |
 
 ## When to use
 

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -152,7 +152,7 @@ Read `references/manifest-templates.md` for complete, copy-pasteable YAML templa
 - `app.kubernetes.io/part-of` - parent system
 
 **External access** (new clusters must use Gateway API, not legacy Ingress):
-- **Gateway API** `HTTPRoute` (GA v1.5): role-oriented, expressive routing, no annotation hell. Ingress-NGINX retired March 2026.
+- **Gateway API** `HTTPRoute` (GA v1.5): role-oriented, expressive routing, no annotation hell. Ingress-NGINX retired March 2026 (its Feb 2026 RCE set CVE-2026-24512/24513/24514, CVSS 8.8, is a further reason to migrate off; fixed in ingress-nginx 1.13.7 / 1.14.3 if you must stay).
 - **ClusterIP** (default): internal-only
 - **LoadBalancer**: cloud LB without HTTP routing
 - **Headless** (`clusterIP: None`): StatefulSet pod discovery

--- a/skills/lockpick/SKILL.md
+++ b/skills/lockpick/SKILL.md
@@ -130,7 +130,7 @@ covering:
 3. **SUID/SGID binaries** - find + exploit via GTFOBins
 4. **Linux capabilities** - `getcap`, cap_setuid, cap_dac_read_search
 5. **Cron jobs** - writable scripts, PATH hijacking in cron context
-6. **Kernel exploits** - version-matched CVEs (Dirty Pipe, nf_tables, io_uring, OverlayFS; 2026: Copy Fail CVE-2026-31431 [CISA KEV, exploited], Dirty Frag CVE-2026-43284/43500, ptrace CVE-2026-46333)
+6. **Kernel exploits** - version-matched CVEs (Dirty Pipe, nf_tables, io_uring, OverlayFS; 2026: Copy Fail CVE-2026-31431 [CISA KEV, exploited], Dirty Frag CVE-2026-43284/43500, Fragnesia CVE-2026-46300 [ESP-in-TCP, exploited], ptrace CVE-2026-46333)
 7. **PATH hijacking** - SUID binaries calling relative commands
 8. **NFS** - no_root_squash exploitation
 9. **Writable files** - /etc/passwd, /etc/shadow, authorized_keys, systemd units

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -37,7 +37,7 @@ ordinary package work, prefer the live distro lane and repo state over a stale p
 | SELinux | verify live | policy package and mode matter more than memorized version strings |
 | DNF | verify live | Fedora moves faster than enterprise lanes; DNF 5 vs legacy expectations matter |
 | Podman | verify live | rootless and quadlet behavior depend on the shipped distro lane |
-| Kernel security | verify live via RHSA/FEDORA tracker | patch high-severity privesc CVEs promptly; mid-2026 examples to confirm fixed: Copy Fail CVE-2026-31431 (CISA KEV, exploited), Dirty Frag CVE-2026-43284/43500, ptrace CVE-2026-46333 |
+| Kernel security | verify live via RHSA/FEDORA tracker | patch high-severity privesc CVEs promptly; mid-2026 examples to confirm fixed: Copy Fail CVE-2026-31431 (CISA KEV, exploited), Dirty Frag CVE-2026-43284/43500, Fragnesia CVE-2026-46300 (ESP-in-TCP, exploited), ptrace CVE-2026-46333 |
 
 ## When to use
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -133,6 +133,7 @@ Find known CVEs in dependencies and assess supply chain risk.
 - `xz-utils` 5.6.0-5.6.1 (2024 backdoor in compression library)
 - TrapDoor (2026-05 multi-registry campaign: 34+ malicious npm/PyPI/crates packages stealing SSH keys and cloud/crypto credentials; notably hides zero-width-Unicode prompt injection in `.cursorrules` / `CLAUDE.md` to subvert AI coding agents - check agent rule files, not just dependencies)
 - `trivy` 0.69.4-0.69.6 / `aquasecurity/trivy` Docker tags 0.69.5-0.69.6 / `aquasecurity/trivy-action` + `aquasecurity/setup-trivy` force-pushed tags (2026-03 TeamPCP supply chain compromise - credential-stealing malware in CI/CD pipelines)
+- Mini Shai-Hulud worm (2026-04/05 TeamPCP npm/PyPI follow-up: SAP `@sap/*` npm Apr 29, PyTorch `lightning` PyPI 2.6.2/2.6.3 Apr 30, 84 malicious versions across 42 `@tanstack/*` May 11 - self-propagating, steals GitHub/npm tokens, CI/CD secrets, and cloud creds; ~1,800 developers across npm + PyPI)
 Any match on package name + version range is P0 severity regardless of `audit` output.
 For active incident triage, use `references/hardening-checklists.md` for repo-wide package,
 IOC, local-runtime, and remote-repo checks.


### PR DESCRIPTION
## What

Freshness pass on CVE/advisory references after a sweep showed several skills' "current threat" framing leaned on 2025 incidents. The collection was already fairly current (Trivy 2026-03, TrapDoor 2026-05, runc Nov 2025, PostgreSQL May-2026 CVE set), so this fills the **genuinely-recent gaps**. Every CVE/incident below was **web-verified against primary advisories** before adding.

## Linux kernel (answers "any missing kernel CVEs?")

- **Fragnesia CVE-2026-46300** added next to the existing Copy Fail / Dirty Frag / ptrace refs in `lockpick`, `debian-ubuntu`, `rhel-fedora`. xfrm ESP-in-TCP page-cache LPE -> root, CVSS 7.8, patched 2026-05-13, **exploited in attacks** (Qualys ThreatPROTECT). Distinct from Dirty Frag (CVE-2026-43284/43500), which was already present.

## Supply chain

- **TeamPCP npm/PyPI "Mini Shai-Hulud" worm wave** (2026-04/05) added to `security-audit`'s known-incidents list and `ci-cd`'s incident timeline: SAP `@sap/*` npm (Apr 29), PyTorch `lightning` PyPI 2.6.2/2.6.3 (Apr 30), 84 malicious versions across 42 `@tanstack/*` (May 11); ~1,800 developers across npm + PyPI. Notable because TeamPCP is the same actor behind the already-documented Trivy compromise. `supply-chain.md` "Updated" bumped to May 2026.

## Other current advisories

- **databases**: PostgreSQL pin `18.3 -> 18.4` (17.10 / 16.14) to match the May 14 2026 security release already referenced in the CVE checklist.
- **ansible**: note **OpenSSH CVE-2026-35414** (Apr 2026, fixed in 10.3; comma in a CA cert principal -> `authorized_keys` bypass -> root) in the sshd hardening template.
- **kubernetes**: note the Feb 2026 **ingress-nginx RCE set CVE-2026-24512/24513/24514** (CVSS 8.8) reinforcing migration off the retired controller.

## Verification

- `scripts/lint-skills.sh skills` -> 42 checked, 0 errors, 0 warnings
- `scripts/validate-spec.sh skills` -> 42 validated, 0 violations, 0 warnings
- `scripts/check-freshness-dates.sh` -> clean (May 2026)

8 files. Additive content; no structural/contract changes.