### PR TITLE
feat(skills): add deep-grill plan interrogator skill

### DIFF
--- a/.refiner-runs.json
+++ b/.refiner-runs.json
@@ -2193,5 +2193,61 @@
       "c102c7b",
       "cda2b57"
     ]
+  },
+  {
+    "run_id": "2026-06-13-deep-grill",
+    "branch": "feat/deep-grill",
+    "date": "2026-06-13",
+    "primary": {
+      "harness": "claude-code",
+      "model": "claude-opus-4-8",
+      "context": "1M"
+    },
+    "secondary": {
+      "harness": "codex",
+      "model": "codex-cli (cross-model review)",
+      "weight": "5%"
+    },
+    "config": {
+      "iterations_max": null,
+      "iterations_used": 6,
+      "threshold": 85,
+      "mode": "circuit-breaker",
+      "note": "targeted single-skill run, min 5 iterations, no ceiling"
+    },
+    "pool": [
+      "deep-grill"
+    ],
+    "termination": "plateau - all forward-test findings resolved, cross-model NO_FLAGS",
+    "scoring_method": "targeted manual rubric (gate/AI-self-check/behavioral/cross-model), not full automated sweep",
+    "score_changes": {
+      "deep-grill": {
+        "before": 96.5,
+        "after": 99.5,
+        "delta": 3.0,
+        "G": "pass",
+        "A": "94>100",
+        "B": "98>99",
+        "X": "NO_FLAGS"
+      }
+    },
+    "real_bugs_fixed": [
+      "description 245>240 -> 'stress-test it'->'attack it' (spec-compliant, matches Phase 2 vocab)",
+      "AI Self-Check headless carve-out moved onto checklist items as (interactive only) tags - removes literal contradiction",
+      "decision-record template: added optional headless-note slot + Notes convention",
+      "Step 2: headless records a flagged assumption instead of 'then ask' (no-codebase + no-user case)",
+      "Output Contract: clarified slug-per-subject vs shared -N suffix",
+      "Step 1: headless trigger names 'any invoking context that tells you no user is there'"
+    ],
+    "forward_tests": [
+      "baseline: infra+decision lens (CI hosted-runner cutover) - correct lens, no false route-out, correct path",
+      "post-change: fiction lens (lighthouse radio story) - used new headless template slot near-verbatim; confirmed headless guidance now consistent"
+    ],
+    "reverted": [],
+    "contested": [],
+    "phase2": "NOT run - targeted single-skill run; meta-improvement out of scope and requires explicit human approval",
+    "commits": [
+      "squashed into PR #79"
+    ]
   }
 ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-42 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
+43 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-open_standard-blue.svg)](https://agentskills.io)
@@ -105,7 +105,7 @@ That's it. For specific skills, alternative tools, the bundled installer, or sym
 
 ## What's in here
 
-42 skills covering infra (Kubernetes, Terraform, Docker, Ansible), cluster health diagnostics, distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review, code slimming, and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, and meta-tooling (the skill creator, refiner, router, and full-review orchestrator).
+43 skills covering infra (Kubernetes, Terraform, Docker, Ansible), cluster health diagnostics, distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review, code slimming, and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, plan interrogation (deep-grill, inspired by Matt Pocock's grill-me), and meta-tooling (the skill creator, refiner, router, and full-review orchestrator).
 
 Browse [`skills/`](skills/) for the full list, or query it:
 

--- a/scripts/check-deep-audit-coverage.sh
+++ b/scripts/check-deep-audit-coverage.sh
@@ -45,6 +45,7 @@ excluded_skills=(
   browse
   cluster-health
   deep-audit
+  deep-grill
   dev-cycle
   full-review
   jekyll-hyde

--- a/skills/deep-audit/references/exclusions.md
+++ b/skills/deep-audit/references/exclusions.md
@@ -14,6 +14,7 @@ so future contributors do not re-add them by reflex.
 | **skill-refiner** | Batch-improves skill collections via eval loops. Same domain as skill-creator. |
 | **skill-router** | Meta routing helper for choosing skills. Deep-audit already owns dispatch routing. |
 | **jekyll-hyde** | Strategic decision review. Useful after audit results exist, but not a file-pattern audit lens. |
+| **deep-grill** | Interrogates a plan before it becomes code. Operates pre-implementation on a design, not on repo files. |
 | **lockpick** | Offensive security / CTF / privesc. Different threat model from defensive audit; security-audit + zero-day cover the defensive side. |
 | **kali-linux** | Live-system administration of Kali. Kali is Debian-based, so repo-side packaging concerns are caught by debian-ubuntu in Wave 3. The skill itself is for running Kali, not auditing repos. |
 | **full-review** | Alternate orchestrator (the smaller 4-skill version). Mutually exclusive with deep-audit by design. |

--- a/skills/deep-grill/SKILL.md
+++ b/skills/deep-grill/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: deep-grill
+description: >
+  · Grill a plan before building: clarify the decision tree, then attack it. Triggers: 'grill me', 'deep grill', 'stress-test this plan', 'poke holes', 'what did I miss'. Not for existing code (code-review) or decision red-team (jekyll-hyde).
+license: MIT
+compatibility: "None - works on any plan or design. Optional: a codebase to explore for code/infra domains."
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-06-13"
+  effort: high
+  argument_hint: "<plan-or-design>"
+---
+
+# Deep Grill: Two-Phase Plan Interrogator
+
+Most build failures are not the model failing to write code - they are requirements that were
+never specified. Deep-grill kills that failure before anything exists, in two phases:
+
+1. **Clarify** - walk the decision tree, resolve every upstream choice before its downstream
+   ones, until no unspecified requirement would change what gets built.
+2. **Adversary** - once the plan is resolved, attack it: assumptions, failure modes, weak
+   premises, unstated risks. Break it on paper before reality breaks it for real.
+
+It is domain-adaptive: it detects whether you are grilling a feature plan, an infrastructure
+change, a fiction draft, or a strategic decision, and grills on what actually matters for that
+domain. It ends by writing a single decision record - the design, the spec, and the surviving
+risks in one file.
+
+## When to use
+
+- Before building a feature or system from a rough plan or design
+- Before a risky infrastructure change (migration, cutover, schema change, rollout)
+- Before committing to an architecture or design decision that is expensive to undo
+- Pressure-testing a fiction outline, plot, or draft direction before drafting pages
+- When the user says "grill me", "deep grill", "stress-test this plan", "poke holes",
+  "pressure-test this", "interrogate my design", or "what did I miss"
+
+## When NOT to use
+
+- Reviewing existing code for bugs, edge cases, or regressions - use **code-review**
+- AI-generated code quality, over-abstraction, or test theater - use **anti-slop**
+- Security vulnerabilities, auth flaws, secrets, or OWASP issues - use **security-audit**
+- A full repository audit or merge gate over code that exists - use **deep-audit** or **full-review**
+- A standalone adversarial decision review or dark-pattern lens, with no plan to resolve - use **jekyll-hyde**
+- Capturing or prioritizing ideas in a backlog - use **roadmap**
+- Turning notes into a reusable LLM prompt - use **prompt-generator**
+- Writing the plan or implementation plan *for* the user. Deep-grill interrogates a plan; it
+  does not author one. If the harness has a brainstorming or planning skill, brainstorm to
+  produce the plan, then deep-grill to interrogate it.
+
+---
+
+## AI Self-Check
+
+This skill runs a multi-turn interview and writes a structured decision-record file. Before and
+during a grill, verify. Two items are tagged **(interactive only)**: in headless / non-interactive
+mode (see Step 1) they do not apply, because there is no conversation - emit the tree in one pass
+and fold both phases into the record. Everything else still holds.
+
+- [ ] **One question at a time** *(interactive only)*: never batch questions into a single message.
+- [ ] **Recommended answer every time**: each question carries your own recommended answer and a one-line why.
+- [ ] **Explored before asking**: anything answerable from the codebase, files, or docs was looked up, not asked.
+- [ ] **Tree walked top-down**: upstream decisions resolved before the downstream ones that depend on them.
+- [ ] **Phase switch announced** *(interactive only)*: Phase 2 starts only after the tree is resolved, and the switch is stated out loud.
+- [ ] **Phase 2 attacks, not restates**: adversarial questions hit assumptions, failure modes, and premises - they do not re-ask Phase 1.
+- [ ] **Vague answers forced concrete**: "we'll handle it later" is pushed to a real decision or logged as an explicit open question.
+- [ ] **Decision record written**: resolved decisions, surviving risks, open questions, and a next step land in the deliverable file.
+- [ ] **Domain detected and routed**: correct lens applied; if the real task is code review, security, or a repo audit, routed to the right skill instead.
+- [ ] **Hidden state identified**: existing code, config, prior decisions, and constraints are surfaced before grilling, not assumed.
+- [ ] **Routing overlap checked**: overlap with jekyll-hyde and code-review handled per "When NOT to use" before proceeding.
+
+---
+
+## Workflow
+
+### Step 1: Detect the target and domain
+
+Identify what is being grilled and pick the lens. Ask at most one classifying question if it is
+genuinely ambiguous; otherwise state your read and proceed.
+
+| Domain | Lens grills on |
+|---|---|
+| **Code / design** | data flow, interfaces, state, concurrency, edge cases, error handling, rollback, test strategy |
+| **Infra change** | blast radius, idempotency, rollback path, secret handling as a chain, drift, verification gate before apply |
+| **Fiction draft** | voice contract, POV consistency, stakes, character differentiation, genre conventions, sensory grounding |
+| **Decision / strategy** | options and reversibility, second-order effects, who decides, success metric, what would change your mind |
+| **Generic** | fallback decision-tree walk when none of the above fit |
+
+**Lenses are not exclusive.** Many plans straddle two - caching, queues, rate limiters, and
+migrations are both code and infra. When two fire, pick the lens of the dominant *risk* (usually
+infra when there is a blast radius, a rollback path, or a live-data consistency concern) and pull
+the relevant question groups from the second lens too.
+
+Read `references/domains.md` for the full per-domain question banks once the domain is known.
+
+If the request is actually about code that already exists ("is this function correct", "is this
+exploitable", "audit this repo"), route out per "When NOT to use" instead of grilling.
+
+**Headless / non-interactive mode**: if no interactive user is available (a `--bare` or `exec`
+run, or any invoking context that tells you no user is there to answer), do not block on
+one-at-a-time prompting. Emit the full decision tree with your
+recommended answer for every node in one pass, flag the assumptions you made, run the adversarial
+pass against those assumptions, and still write the decision record.
+
+### Step 2: Phase 1 - Clarify (resolve the decision tree)
+
+Run the core grill mechanics. They are the load-bearing part, and apply in every domain:
+
+- Build the decision tree for the plan. **Resolve upstream choices before downstream ones** -
+  a downstream answer is worthless if its parent decision flips.
+- Ask **one question at a time**.
+- For **every** question, provide your own recommended answer and a one-line reason. You are a
+  collaborator with opinions, not a form.
+- If a question can be answered by **exploring the codebase, files, or docs, go look** instead of
+  asking the user. If the plan was handed to you inline with no codebase to explore, say what you
+  would normally have checked, then ask - or, in headless mode where no one can answer, record it
+  as a flagged assumption instead of asking.
+- Pull domain-specific questions from `references/domains.md`.
+- Force vague answers into concrete ones. "We'll figure out caching later" becomes a decision now
+  or an explicit logged open question - never a silent gap.
+
+End Phase 1 when no unresolved upstream decision remains and no unspecified requirement would
+change what gets built.
+
+### Step 3: Phase 2 - Adversary (stress-test the resolved plan)
+
+Announce the switch plainly, e.g. "Plan's resolved. Switching to adversarial mode now." The user
+should feel the gloves change. (In headless one-pass mode there is no conversation to announce
+in - just fold the adversarial pass into the record as its own section.)
+
+Attack the *finished* plan:
+
+- Name the load-bearing assumptions. Which one, if wrong, collapses the plan?
+- Hunt failure modes: where does this break under load, at the edges, under concurrency, on the unhappy path?
+- Find the weakest premise and pull on it.
+- Surface unstated risks - operational, security-shaped, reputational, maintenance debt.
+- Run a pre-mortem: "It is three months later and this failed. What was the cause?"
+- Ask what you are *not* building that bites later, and what second-order effects the plan triggers.
+
+For each surfaced risk, resolve it one of three ways: **accept** it (and record why), **mitigate**
+it (and record how), or recognize it **reopens a Phase 1 decision** - in which case go back,
+re-resolve that branch, and return.
+
+Timebox it. Stop when new attacks stop changing the plan. Do not grind out risks that no longer
+move the decision.
+
+### Step 4: Write the decision record
+
+Write one file to `docs/local/deliverables/deep-grill/<YYYY-MM-DD>-<slug>.md` using the template in
+`references/decision-record.md`. It contains:
+
+- **Context** - what is being built and why.
+- **Resolved decisions** - the design and the spec: what to build, with the reasoning for each choice.
+- **Surviving risks** - what Phase 2 surfaced and you accepted, each with its mitigation or acceptance rationale.
+- **Open questions** - anything deferred, stated explicitly so it cannot hide.
+- **Recommended next step** - the concrete first action.
+
+This file is the deliverable. It is both the design (resolved choices) and the spec (what to
+build and what to watch).
+
+---
+
+## Interrogation rules
+
+The mechanics are not optional - they are what separates a real grill from a chat:
+
+- **One question at a time.** Batching collapses the decision tree into a survey and loses the dependency order.
+- **Recommend an answer to everything.** Your recommendation gives the user something to push against; silence makes them do all the work.
+- **Explore, do not ask, when the answer is in the repo.** Asking what you could have checked wastes the user and erodes trust.
+- **Upstream before downstream.** Always.
+- **Phase discipline.** Clarify fully, then attack. Announce the transition.
+- **Opinions, not "it depends."** If it depends, say on what, then give your default.
+- **No vague survivors.** Every hand-wave becomes a decision or a logged open question.
+- **Timebox the adversary.** Diminishing returns are real; stop when the plan stops moving.
+
+---
+
+## Reference Files
+
+- `references/domains.md` - per-domain question banks (code, infra, fiction, decision, generic) and a short guide to adding your own lens.
+- `references/decision-record.md` - the decision-record artifact template.
+
+## Output Contract
+
+See `skills/_shared/output-contract.md` for the full contract.
+
+- **Skill name:** DEEP-GRILL
+- **Deliverable bucket:** `deliverables`
+- **Deliverable path:** `docs/local/deliverables/deep-grill/<YYYY-MM-DD>-<slug>.md`. The `<slug>`
+  is short kebab-case derived from the plan's subject (e.g. `redis-read-through-cache`), so two
+  different plans on the same day get two different slugs - the shared contract's `-N` suffix is
+  only for re-grilling the same subject twice.
+- **Mode:** conditional. The primary path is the two-phase grill of a forming plan: respond
+  conversationally during the interview (no boxed contract mid-interview), and at the end always
+  write the decision record to the deliverable path using `references/decision-record.md`.
+  Headless / non-interactive runs follow this same primary path - the one-pass decision record at
+  the deliverable path, no boxed contract. When
+  invoked instead to **stress-test an existing artifact** as a pure audit (Phase 2 only, surfacing
+  a findings list against a spec or design doc that already exists), emit the full boxed contract -
+  inline header, per-finding detail in the deliverable, boxed conclusion, conclusion table.
+- **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; used only in the audit path).
+
+## Related Skills
+
+- **jekyll-hyde** - red-teams a decision and surfaces dark patterns standalone. Deep-grill resolves
+  a plan into a buildable spec first, *then* red-teams it, and writes the record. Use jekyll-hyde
+  for a one-shot decision review; use deep-grill to take a vague plan all the way to buildable.
+- **code-review** - finds bugs in code that exists. Deep-grill interrogates a plan that does not exist yet.
+- **deep-audit** - wave-based audit of an existing repo. Deep-grill operates before code, on the plan.
+- **security-audit** - reviews exploitable vulnerabilities in code. Deep-grill may flag security-shaped
+  risk during Phase 2 but does not replace a security audit.
+- **roadmap** - captures and prioritizes ideas. Deep-grill interrogates one idea before you build it.
+- **prompt-generator** - formats notes into a reusable prompt. Deep-grill produces a decision record, not a prompt.
+
+## Rules
+
+1. One question at a time. Never batch. Exception: headless / non-interactive mode emits the whole tree in one pass (Step 1).
+2. Every question carries your recommended answer and a one-line reason.
+3. Explore the codebase, files, and docs for anything answerable there; do not ask what you can check.
+4. Resolve upstream decisions before the downstream ones that depend on them.
+5. Do not start Phase 2 until the tree is resolved, and announce the switch.
+6. Phase 2 attacks the plan; it does not restate Phase 1.
+7. Force vague answers into a concrete decision or a logged open question before moving on.
+8. Always write the decision record. It is the design and the spec.
+9. Timebox the adversarial phase; stop when attacks stop changing the plan.
+10. Route out if the real task is code review, security, or a repo audit.

--- a/skills/deep-grill/references/decision-record.md
+++ b/skills/deep-grill/references/decision-record.md
@@ -1,0 +1,90 @@
+# Decision Record Template
+
+The deliverable deep-grill writes at the end of a grill. One file per session at
+`docs/local/deliverables/deep-grill/<YYYY-MM-DD>-<slug>.md`. Pure markdown - renders in GitHub,
+GitLab, VS Code, and Obsidian.
+
+It is both the design (the resolved choices) and the spec (what to build and what to watch). Keep
+it tight: a record someone can act on, not a transcript of the interview.
+
+---
+
+## Template
+
+```markdown
+# Deep-Grill: <topic> - <YYYY-MM-DD>
+
+- **Domain:** <code | infra | fiction | decision | generic>
+- **Plan grilled:** <one line on what was interrogated>
+- **Decisions:** <N resolved>  ·  **Surviving risks:** <N>  ·  **Open questions:** <N>
+
+> _Headless one-pass grill (omit this line when interactive):_ no user answered in real time.
+> The tree below was emitted in one pass with a recommended answer per node; items that could
+> not be verified from the codebase or files are flagged inline as **assumptions**, not facts.
+
+---
+
+## Context
+
+<2-4 sentences: what is being built or decided, and why now. The problem, not the solution.>
+
+## Resolved decisions
+
+The design and the spec. Each decision is a choice that is now settled, with its reasoning.
+
+- [ ] **D1 <decision title>**
+  - **Chosen:** <what was decided>
+  - **Why:** <the reasoning that settled it>
+  - **Alternatives rejected:** <what was considered and dropped, briefly>
+
+- [ ] **D2 <decision title>**
+  - **Chosen:** <...>
+  - **Why:** <...>
+  - **Alternatives rejected:** <...>
+
+## Surviving risks
+
+What Phase 2 surfaced and the plan now carries. Each risk is accepted or mitigated, not ignored.
+
+- [ ] **R1 <risk title>** (P0 | P1 | P2 | P3)
+  - **Risk:** <the failure mode and its trigger>
+  - **Who pays:** <who bears the cost if it fires>
+  - **Disposition:** accepted | mitigated
+  - **Mitigation / rationale:** <how it is mitigated, or why it is acceptable to carry>
+
+- [ ] **R2 <risk title>** (P1)
+  - **Risk:** <...>
+  - **Who pays:** <...>
+  - **Disposition:** <...>
+  - **Mitigation / rationale:** <...>
+
+## Open questions
+
+Anything deferred. Stated explicitly so it cannot hide. Each needs an owner or a trigger for
+when it must be answered.
+
+- [ ] **Q1 <question>** - answer needed by <when / what triggers it>
+- [ ] **Q2 <question>** - <...>
+
+## Recommended next step
+
+<The single concrete first action. What to do Monday morning.>
+```
+
+---
+
+## Notes
+
+- **Decisions and risks use checkboxes** so the implementer can flip `- [ ]` to `- [x]` as each is
+  built or each mitigation lands - the same convention as audit deliverables in
+  `skills/_shared/output-contract.md`.
+- **Numbering is monotonic** within each section (D1, D2...; R1, R2...; Q1, Q2...).
+- **Risk priorities** use the shared `P0 | P1 | P2 | P3` scale.
+- **Keep alternatives brief.** One line on what was rejected is enough; the record captures the
+  decision, not the full debate.
+- **Open questions are not failures.** A grill that ends with three honest open questions and an
+  owner for each beats one that pretends everything is resolved.
+- **If a Phase 2 risk reopened a decision**, the record shows the *final* resolved decision, not
+  the intermediate one that was overturned.
+- **Headless one-pass grills** keep the blockquote note under the header and tag each unverified
+  node as an assumption. Interactive grills delete the note - every node was answered live.

--- a/skills/deep-grill/references/domains.md
+++ b/skills/deep-grill/references/domains.md
@@ -1,0 +1,131 @@
+# Deep-Grill Domain Lenses
+
+Per-domain question banks. Each lens lists Phase 1 clarify questions (ordered upstream to
+downstream - resolve the top groups before the lower ones) and Phase 2 adversarial angles.
+
+These are prompts for *your* questioning, not a script to read aloud. Skip what the plan already
+answers, explore the codebase for anything checkable, and always offer a recommended answer.
+
+---
+
+## Code / design
+
+**Phase 1 - clarify (upstream to downstream):**
+
+- **Problem and scope**: what user-visible behavior must exist when done? What is explicitly out of scope?
+- **Boundaries and interfaces**: what are the inputs, outputs, and contracts? Who calls this, and what do they expect?
+- **Data and state**: what is the source of truth? Where does state live, and who owns mutation? What is the shape of the core data model?
+- **Control flow**: synchronous or async? Sequential, concurrent, or event-driven? What ordering guarantees matter?
+- **Edge cases**: empty, huge, malformed, duplicate, and concurrent inputs - what is the defined behavior for each?
+- **Error handling**: what fails, how does it surface, and who recovers? Retry, fail loud, or degrade?
+- **Persistence and migration**: schema changes? Backward compatibility? Data backfill?
+- **Testing**: what proves it works? Unit, integration, or end-to-end? What is the one test that would catch the scariest regression?
+- **Rollout and rollback**: feature flag, gradual rollout, kill switch? How is it reverted if wrong?
+
+**Phase 2 - attack:**
+
+- Which assumption about the input data, the caller, or the runtime is load-bearing and unverified?
+- Where is the race condition you have not named? What happens under retries or duplicate delivery?
+- What breaks at 100x the expected volume? What breaks at zero?
+- What is the blast radius of a bug here - one request, one user, or the whole system?
+- What did you decide not to test, and why is that the thing that will break?
+
+---
+
+## Infra change
+
+**Phase 1 - clarify (upstream to downstream):**
+
+- **Goal and trigger**: what outcome forces this change now? What breaks if it is not done?
+- **Consistency contract**: for caching, replication, async, or CDC changes, what staleness or
+  correctness guarantee must the data keep - read-your-writes, bounded staleness, or eventual?
+  This is load-bearing: it decides whether the chosen pattern (cache-aside, TTL, write-invalidate)
+  is even valid, and every downstream knob hangs off it. Resolve it before TTLs or invalidation.
+- **Blast radius**: exactly which systems, services, and users are in scope? What is explicitly untouched?
+- **Current state and drift**: does live state match the declared config? Is there drift to reconcile first?
+- **Idempotency**: can the change be applied twice safely? Is it declarative, or a one-shot imperative step?
+- **Secrets and access**: if secrets or access controls move, what is the chain from source of truth through delivery into the runtime? Is the change additive and contract-preserving?
+- **Dependencies and ordering**: what must change first? What depends on this completing?
+- **Verification gate**: what dry-run, diff, or plan proves the change is bounded before apply? What is the expected diff, and what diff would be a red flag?
+- **Rollback**: what is the exact revert path? How long does it take, and what state is lost?
+
+**Phase 2 - attack:**
+
+- What does the plan assume is already true about the environment that nobody verified?
+- What is the unexpected destroy or replace hiding in the diff?
+- If the apply fails halfway, what state are you left in, and is it recoverable?
+- Who is paged when this breaks at 3am, and do they have the runbook?
+- What downstream consumer breaks on a change you think is internal?
+
+---
+
+## Fiction draft
+
+**Phase 1 - clarify (upstream to downstream):**
+
+- **Contract**: what genre, length, and audience? What promise does the opening make to the reader?
+- **Voice**: whose voice carries this, and what makes it distinct? First or third, tense, distance from the POV character?
+- **POV discipline**: single or multiple POV? What are the rules, and where might they slip?
+- **Stakes**: what does the protagonist want, what stands in the way, and what is the cost of failure?
+- **Structure**: what is the shape - the turn, the escalation, the ending the opening pays off?
+- **Character differentiation**: how do the main characters differ in want, voice, and behavior under pressure?
+- **Grounding**: where is the sensory and concrete detail anchored, versus abstract summary?
+
+**Phase 2 - attack:**
+
+- Where does the voice flatten into generic competent prose with no fingerprint?
+- Which character could be swapped for another with no change to their lines?
+- Where is the stakes claim told rather than felt on the page?
+- What does the ending promise that the opening never set up, or vice versa?
+- Where does the draft explain an emotion the scene should have made the reader feel?
+
+---
+
+## Decision / strategy
+
+**Phase 1 - clarify (upstream to downstream):**
+
+- **Decision**: what is the actual choice, stated as options, not a vague direction?
+- **Owner and timing**: who decides, by when, and what forces the timing?
+- **Reversibility**: is this a one-way or two-way door? What becomes hard to undo?
+- **Success metric**: what observable outcome means this was the right call? When is it measured?
+- **Constraints**: budget, time, compliance, team skill, dependency, reputation - which bind hardest?
+- **Stakeholders and cost bearers**: who benefits, who pays, who is not in the room?
+- **Evidence**: what is known from data versus assumed? What is the strongest piece of disconfirming evidence?
+
+**Phase 2 - attack:**
+
+- What would have to be true for this to be the wrong call, and how likely is that?
+- What is the second-order effect nobody is pricing in?
+- Who is harmed by this decision, and is that acceptable or just out of sight?
+- What is the cheapest experiment that would change your mind before you commit?
+- If this is irreversible, what reversible version gets you 80 percent of the value?
+
+---
+
+## Generic
+
+When no specialized lens fits, walk the universal decision tree:
+
+**Phase 1**: goal -> constraints -> options -> the load-bearing choice -> its dependents ->
+success criteria -> what is out of scope.
+
+**Phase 2**: the riskiest assumption -> the failure mode -> who pays -> the pre-mortem cause ->
+the cheapest way to de-risk before committing.
+
+---
+
+## Adding a domain lens
+
+To extend deep-grill for your own field (legal, data pipeline, game design, hardware, etc.):
+
+1. Add a section here with the same two-part shape: **Phase 1 - clarify** (question groups ordered
+   upstream to downstream) and **Phase 2 - attack** (adversarial angles).
+2. Order Phase 1 groups so each group's answers constrain the next. The first group should be the
+   decision that, if it flips, invalidates everything below it.
+3. Phase 2 angles should target what is *specific* to the domain - the failure modes a generic
+   review would miss. If an angle applies to every domain, it belongs in Generic, not here.
+4. Add a one-row entry to the lens table in `SKILL.md` Step 1 so the new domain is detectable.
+
+Keep each lens to question prompts, not prose. The skill supplies the method; the lens supplies
+the domain-specific targets.

--- a/skills/jekyll-hyde/SKILL.md
+++ b/skills/jekyll-hyde/SKILL.md
@@ -39,6 +39,7 @@ measure, or cut.
 - Capturing ideas into a project backlog - use **roadmap**
 - Turning notes into an LLM prompt - use **prompt-generator**
 - Running a full repository audit or merge gate - use **full-review** or **deep-audit**
+- Resolving a vague plan into a buildable spec before red-teaming it - use **deep-grill**
 
 ---
 
@@ -254,6 +255,7 @@ See `skills/_shared/output-contract.md` for the full contract.
 - **deep-audit** - runs a comprehensive repo audit. This skill stays at the advisor layer.
 - **roadmap** - records and prioritizes ideas. This skill advises on which decision path is healthier.
 - **prompt-generator** - turns notes into prompts. This skill is itself an advisor, not a prompt formatter.
+- **deep-grill** - interrogates a plan into a resolved spec, then red-teams it and writes a decision record. This skill red-teams a decision standalone; deep-grill clarifies first, then attacks.
 
 ## Rules
 


### PR DESCRIPTION
Two-phase, domain-adaptive plan interrogator. Phase 1 clarifies the decision tree (one question at a time, recommended answer per node, explores the codebase before asking). Phase 2 adversarially stress-tests the resolved plan. Ends by writing a decision record.

Domain lenses: code/design, infra change, fiction draft, decision/strategy, generic fallback. Inspired by Matt Pocock's three-line grill-me, credited in the README.

- Adds reciprocal cross-references in jekyll-hyde and deep-audit exclusions
- Bumps README skill count to 43

Verification: lint + spec gates pass (0 errors); forward-tested headless against a Redis cache plan (correct lens, headless one-pass path, contract-shaped decision record). Headless-mode consistency across Step 1 / Rules / Self-Check / Output Contract was reconciled and `<slug>` defined.