### PR TITLE
fix(skills): make output contract self-contained per skill

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Check deep-audit skill coverage
         run: ./scripts/check-deep-audit-coverage.sh
 
+      - name: Check output-contract sync
+        run: ./scripts/check-contract-sync.sh
+
       - name: Lint skill collection
         run: ./scripts/lint-skills.sh
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,13 @@ repos:
         pass_filenames: false
         stages: [pre-commit, pre-push]
 
+      - id: contract-sync-check
+        name: skills carry in-sync output-contract, no runtime _shared refs
+        entry: ./scripts/check-contract-sync.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit, pre-push]
+
       - id: skill-collection-lint
         name: lint skill collection
         entry: ./scripts/lint-skills.sh

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Installer support means the repo knows where to copy or symlink the skills. It i
 
 Issues and PRs welcome. Skills must pass `./scripts/lint-skills.sh` and follow the [Agent Skills specification](https://agentskills.io/specification).
 
+Skills are self-contained: each one references only files inside its own directory, so it works when installed individually. The shared output contract lives at `skills/_shared/output-contract.md` as a build input and is copied into every skill's `references/output-contract.md` by `./scripts/gen-contract-refs.sh`. Edit the contract there, re-run the generator, and commit the result; `./scripts/check-contract-sync.sh` (wired into CI and pre-commit) fails on drift or any runtime `skills/_shared/` reference.
+
 ## License
 
 [MIT](LICENSE)

--- a/scripts/check-contract-sync.sh
+++ b/scripts/check-contract-sync.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Guard the self-contained output contract:
+#   1. Every public skill ships references/output-contract.md identical to the
+#      source of truth (skills/_shared/output-contract.md). No drift.
+#   2. No SKILL.md or references/*.md carries a runtime skills/_shared/ link
+#      (it would be a dead reference on standalone installs).
+#
+# Fix drift with: scripts/gen-contract-refs.sh
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=./scripts/contract-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/contract-lib.sh"
+TARGET_NAME="output-contract.md"
+
+fail=0
+
+if [[ ! -f "$CONTRACT_SRC" ]]; then
+  printf '[!] Source contract missing: %s\n' "$CONTRACT_SRC" >&2
+  exit 1
+fi
+
+# Expected shipped contract (portable portion of the source).
+expected="$(render_shipped_contract)"
+
+# ── 1. Drift check ─────────────────────────────────────────────────────
+for dir in "$ROOT"/skills/*/; do
+  name="$(basename "$dir")"
+  [[ "$name" == _* ]] && continue
+  [[ -f "$dir/SKILL.md" ]] || continue
+  copy="$dir/references/$TARGET_NAME"
+  if [[ ! -f "$copy" ]]; then
+    printf '[!] %s: missing references/%s (run scripts/gen-contract-refs.sh)\n' "$name" "$TARGET_NAME" >&2
+    fail=1
+    continue
+  fi
+  if ! printf '%s\n' "$expected" | cmp -s - "$copy"; then
+    printf '[!] %s: references/%s drifted from source (run scripts/gen-contract-refs.sh)\n' "$name" "$TARGET_NAME" >&2
+    fail=1
+  fi
+done
+
+# ── 2. Ban runtime _shared references ──────────────────────────────────
+# A skill must not point at skills/_shared/ at runtime - it does not ship.
+# The generated output-contract.md copies are exempt: their content is the
+# source contract itself, governed by the drift check above, not authored
+# per skill.
+shared_refs="$(grep -rn 'skills/_shared/' "$ROOT"/skills/*/SKILL.md "$ROOT"/skills/*/references/*.md 2>/dev/null \
+  | grep -v '/references/output-contract\.md:' || true)"
+if [[ -n "$shared_refs" ]]; then
+  printf '[!] runtime reference to skills/_shared/ (use local references/%s instead):\n' "$TARGET_NAME" >&2
+  printf '%s\n' "$shared_refs" >&2
+  fail=1
+fi
+
+if (( fail )); then
+  printf '\nContract sync check failed.\n' >&2
+  exit 1
+fi
+
+printf 'Contract sync OK: all skills carry an in-sync references/%s, no runtime _shared refs.\n' "$TARGET_NAME"

--- a/scripts/contract-lib.sh
+++ b/scripts/contract-lib.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Shared helpers for the per-skill output contract.
+#
+# The source of truth is skills/_shared/output-contract.md. Everything above the
+# `maintainer-notes:not-shipped` marker is the portable contract that ships into
+# each skill's references/output-contract.md; the marker and everything below it
+# are maintainer/build notes that must never reach an installed skill.
+
+CONTRACT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRACT_ROOT="$(cd "$CONTRACT_LIB_DIR/.." && pwd)"
+CONTRACT_SRC="$CONTRACT_ROOT/skills/_shared/output-contract.md"
+CONTRACT_MARKER='<!-- maintainer-notes:not-shipped'
+
+# Emit the portable contract: every line before the marker, with trailing blank
+# lines trimmed so the shipped copy ends in exactly one newline.
+render_shipped_contract() {
+  awk -v marker="$CONTRACT_MARKER" '
+    index($0, marker) == 1 { exit }
+    { lines[n++] = $0 }
+    END {
+      while (n > 0 && lines[n-1] == "") n--
+      for (i = 0; i < n; i++) print lines[i]
+    }
+  ' "$CONTRACT_SRC"
+}

--- a/scripts/gen-contract-refs.sh
+++ b/scripts/gen-contract-refs.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate each skill's local copy of the shared output contract.
+#
+# Skills are installed individually (npx skills add, install.sh), so a skill may
+# not be co-located with skills/_shared/ at runtime. To stay self-contained,
+# every skill ships its own references/output-contract.md, generated from the
+# single source of truth at skills/_shared/output-contract.md.
+#
+# Run this after editing the source contract. CI enforces no drift via
+# scripts/check-contract-sync.sh.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=./scripts/contract-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/contract-lib.sh"
+TARGET_NAME="output-contract.md"
+
+if [[ ! -f "$CONTRACT_SRC" ]]; then
+  printf 'Source contract not found: %s\n' "$CONTRACT_SRC" >&2
+  exit 1
+fi
+
+# Render once: the portable contract is everything above the maintainer marker.
+shipped="$(render_shipped_contract)"
+
+count=0
+for dir in "$ROOT"/skills/*/; do
+  name="$(basename "$dir")"
+  [[ "$name" == _* ]] && continue          # skip _shared and other build inputs
+  [[ -f "$dir/SKILL.md" ]] || continue
+  mkdir -p "$dir/references"
+  printf '%s\n' "$shipped" > "$dir/references/$TARGET_NAME"
+  count=$((count + 1))
+done
+
+printf 'Generated %s/%s into %d skill(s).\n' "references" "$TARGET_NAME" "$count"

--- a/skills/_shared/output-contract.md
+++ b/skills/_shared/output-contract.md
@@ -1,8 +1,6 @@
-# Output Contract — Single Source of Truth
+# Output Contract
 
-This file is the canonical output contract for every public skill in iuliandita/skills. Each `skills/<name>/SKILL.md` references this file from a `## Output Contract` section and declares its mode (always-on or conditional) and deliverable bucket.
-
-This directory has no `SKILL.md`, so `install.sh`, `scripts/lint-skills.sh`, and `scripts/validate-spec.sh` skip it. Do not add a `SKILL.md` here.
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
 
 ## Two surfaces
 
@@ -218,3 +216,13 @@ After:
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
 Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+
+<!-- maintainer-notes:not-shipped
+Everything above this marker is the portable output contract. It is the single source
+of truth and is copied verbatim into each skill's own references/output-contract.md by
+scripts/gen-contract-refs.sh (drift-guarded by scripts/check-contract-sync.sh). This
+marker and everything below it are stripped before copying, so installed skills never
+see repo-internal build notes. _shared/ has no SKILL.md, so install.sh,
+scripts/lint-skills.sh, and scripts/validate-spec.sh skip it; do not add one. Edit the
+contract above, then re-run the generator.
+-->

--- a/skills/ai-ml/SKILL.md
+++ b/skills/ai-ml/SKILL.md
@@ -439,7 +439,7 @@ PII detection setup, and content policy implementation.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** AI-ML
 - **Deliverable bucket:** `audits`

--- a/skills/ai-ml/references/output-contract.md
+++ b/skills/ai-ml/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -428,7 +428,7 @@ All Ansible DevTools projects (molecule, ansible-lint, ansible-navigator, tox-an
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** ANSIBLE
 - **Deliverable bucket:** `audits`

--- a/skills/ansible/references/output-contract.md
+++ b/skills/ansible/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -458,7 +458,7 @@ Report:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** ANTI-AI-PROSE
 - **Deliverable bucket:** `audits`

--- a/skills/anti-ai-prose/references/output-contract.md
+++ b/skills/anti-ai-prose/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/anti-slop/SKILL.md
+++ b/skills/anti-slop/SKILL.md
@@ -417,7 +417,7 @@ These look like slop but aren't:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** ANTI-SLOP
 - **Deliverable bucket:** `audits`

--- a/skills/anti-slop/references/output-contract.md
+++ b/skills/anti-slop/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/arch-btw/SKILL.md
+++ b/skills/arch-btw/SKILL.md
@@ -289,7 +289,7 @@ When a bug looks "desktop-only," compare one clean baseline:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** ARCH-BTW
 - **Deliverable bucket:** `audits`

--- a/skills/arch-btw/references/output-contract.md
+++ b/skills/arch-btw/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/backend-api/SKILL.md
+++ b/skills/backend-api/SKILL.md
@@ -384,7 +384,7 @@ Rolling deploys send SIGTERM to old instances while new ones come up. Handle it 
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** BACKEND-API
 - **Deliverable bucket:** `audits`

--- a/skills/backend-api/references/output-contract.md
+++ b/skills/backend-api/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -437,7 +437,7 @@ account-specific pages.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** BROWSE
 - **Deliverable bucket:** `audits`

--- a/skills/browse/references/output-contract.md
+++ b/skills/browse/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -448,7 +448,7 @@ the OWASP Top 10 for Agentic Applications, read `references/supply-chain.md`
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** CI-CD
 - **Deliverable bucket:** `audits`

--- a/skills/ci-cd/references/output-contract.md
+++ b/skills/ci-cd/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/cluster-health/SKILL.md
+++ b/skills/cluster-health/SKILL.md
@@ -169,7 +169,7 @@ Return a concise report:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** CLUSTER-HEALTH
 - **Deliverable bucket:** `audits`

--- a/skills/cluster-health/references/output-contract.md
+++ b/skills/cluster-health/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -462,7 +462,7 @@ Keep it tight. Show the bug, show the fix, move on. Long explanations only when 
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** CODE-REVIEW
 - **Deliverable bucket:** `audits`

--- a/skills/code-review/references/output-contract.md
+++ b/skills/code-review/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/code-slimming/SKILL.md
+++ b/skills/code-slimming/SKILL.md
@@ -387,7 +387,7 @@ bundle weight, cache misses, or indirect calls. In hot paths, require measuremen
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** CODE-SLIMMING
 - **Deliverable bucket:** `audits`

--- a/skills/code-slimming/references/output-contract.md
+++ b/skills/code-slimming/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/command-prompt/SKILL.md
+++ b/skills/command-prompt/SKILL.md
@@ -352,7 +352,7 @@ Before returning any shell script, check:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** COMMAND-PROMPT
 - **Deliverable bucket:** `audits`

--- a/skills/command-prompt/references/output-contract.md
+++ b/skills/command-prompt/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -391,7 +391,7 @@ These are non-negotiable. Violating any of these is a bug.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** DATABASES
 - **Deliverable bucket:** `audits`

--- a/skills/databases/references/output-contract.md
+++ b/skills/databases/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -319,7 +319,7 @@ When a bug looks desktop-only, compare one clean baseline:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** DEBIAN-UBUNTU
 - **Deliverable bucket:** `audits`

--- a/skills/debian-ubuntu/references/output-contract.md
+++ b/skills/debian-ubuntu/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -460,7 +460,7 @@ but preserves the wave ordering.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** DEEP-AUDIT
 - **Deliverable bucket:** `audits`

--- a/skills/deep-audit/references/output-contract.md
+++ b/skills/deep-audit/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/deep-grill/SKILL.md
+++ b/skills/deep-grill/SKILL.md
@@ -182,7 +182,7 @@ The mechanics are not optional - they are what separates a real grill from a cha
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** DEEP-GRILL
 - **Deliverable bucket:** `deliverables`

--- a/skills/deep-grill/references/decision-record.md
+++ b/skills/deep-grill/references/decision-record.md
@@ -77,7 +77,7 @@ when it must be answered.
 
 - **Decisions and risks use checkboxes** so the implementer can flip `- [ ]` to `- [x]` as each is
   built or each mitigation lands - the same convention as audit deliverables in
-  `skills/_shared/output-contract.md`.
+  `references/output-contract.md`.
 - **Numbering is monotonic** within each section (D1, D2...; R1, R2...; Q1, Q2...).
 - **Risk priorities** use the shared `P0 | P1 | P2 | P3` scale.
 - **Keep alternatives brief.** One line on what was rejected is enough; the record captures the

--- a/skills/deep-grill/references/output-contract.md
+++ b/skills/deep-grill/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -367,7 +367,7 @@ GitLab substitutes `glab mr create`, `glab ci status --live`, `glab mr merge --s
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** DEV-CYCLE
 - **Deliverable bucket:** `audits`

--- a/skills/dev-cycle/references/output-contract.md
+++ b/skills/dev-cycle/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -422,7 +422,7 @@ See AI Self-Check above for the full build-time checklist (Dockerfile correctnes
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** DOCKER
 - **Deliverable bucket:** `audits`

--- a/skills/docker/references/output-contract.md
+++ b/skills/docker/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -225,7 +225,7 @@ config system, REST API, IPv6 gotchas, SOPs, and recovery procedures.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** FIREWALL-APPLIANCE
 - **Deliverable bucket:** `audits`

--- a/skills/firewall-appliance/references/output-contract.md
+++ b/skills/firewall-appliance/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -283,7 +283,7 @@ Run through the AI Self-Check above.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** FRONTEND-DESIGN
 - **Deliverable bucket:** `deliverables`

--- a/skills/frontend-design/references/output-contract.md
+++ b/skills/frontend-design/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/full-review/SKILL.md
+++ b/skills/full-review/SKILL.md
@@ -255,7 +255,7 @@ If a skill is not available, perform a manual review in the same `general-purpos
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** FULL-REVIEW
 - **Deliverable bucket:** `audits`

--- a/skills/full-review/references/output-contract.md
+++ b/skills/full-review/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -395,7 +395,7 @@ Source code management requirements that map to git practices.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** GIT
 - **Deliverable bucket:** `audits`

--- a/skills/git/references/output-contract.md
+++ b/skills/git/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -245,7 +245,7 @@ deleted; a committed one stays in the repo as a record of the PR it shipped with
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** HANDOFF
 - **Deliverable bucket:** `deliverables`

--- a/skills/handoff/references/output-contract.md
+++ b/skills/handoff/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/jekyll-hyde/SKILL.md
+++ b/skills/jekyll-hyde/SKILL.md
@@ -237,7 +237,7 @@ Every response should pass these checks:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** JEKYLL-HYDE
 - **Deliverable bucket:** `deliverables`

--- a/skills/jekyll-hyde/references/output-contract.md
+++ b/skills/jekyll-hyde/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -306,7 +306,7 @@ When the problem smells like "Kali is broken," check the boring causes first:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** KALI-LINUX
 - **Deliverable bucket:** `audits`

--- a/skills/kali-linux/references/output-contract.md
+++ b/skills/kali-linux/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -466,7 +466,7 @@ PCI-DSS 4.0 is the only active version (3.2.1 retired March 2024). 51 future-dat
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** KUBERNETES
 - **Deliverable bucket:** `audits`

--- a/skills/kubernetes/references/output-contract.md
+++ b/skills/kubernetes/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -366,7 +366,7 @@ Once i18n is set up, the workflow for new features is:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** LOCALIZE
 - **Deliverable bucket:** `audits`

--- a/skills/localize/references/output-contract.md
+++ b/skills/localize/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/lockpick/SKILL.md
+++ b/skills/lockpick/SKILL.md
@@ -359,7 +359,7 @@ Capture `script -q /tmp/session.log` at the start of each engagement to get a fu
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** LOCKPICK
 - **Deliverable bucket:** `audits`

--- a/skills/lockpick/references/output-contract.md
+++ b/skills/lockpick/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -328,7 +328,7 @@ AI models consistently make these errors when generating MCP server code:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** MCP
 - **Deliverable bucket:** `audits`

--- a/skills/mcp/references/output-contract.md
+++ b/skills/mcp/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/networking/SKILL.md
+++ b/skills/networking/SKILL.md
@@ -370,7 +370,7 @@ Network configuration touches several PCI-DSS requirements:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** NETWORKING
 - **Deliverable bucket:** `audits`

--- a/skills/networking/references/output-contract.md
+++ b/skills/networking/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -355,7 +355,7 @@ When a problem looks "flake-only," compare one clean baseline:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** NIXOS-BTW
 - **Deliverable bucket:** `audits`

--- a/skills/nixos-btw/references/output-contract.md
+++ b/skills/nixos-btw/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/prompt-generator/SKILL.md
+++ b/skills/prompt-generator/SKILL.md
@@ -261,7 +261,7 @@ Note: simple task, so plain prose - no XML sections, no numbered steps, no bloat
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** PROMPT-GENERATOR
 - **Deliverable bucket:** `prompts`

--- a/skills/prompt-generator/references/output-contract.md
+++ b/skills/prompt-generator/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -332,7 +332,7 @@ When a bug looks desktop-only, compare one clean baseline:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** RHEL-FEDORA
 - **Deliverable bucket:** `audits`

--- a/skills/rhel-fedora/references/output-contract.md
+++ b/skills/rhel-fedora/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/roadmap/SKILL.md
+++ b/skills/roadmap/SKILL.md
@@ -374,7 +374,7 @@ silently - move to **Parked** with a reason, or confirm deletion explicitly.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** ROADMAP
 - **Deliverable bucket:** `deliverables`

--- a/skills/roadmap/references/output-contract.md
+++ b/skills/roadmap/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/routine-writer/SKILL.md
+++ b/skills/routine-writer/SKILL.md
@@ -235,7 +235,7 @@ API-only and GitHub-only routines skip artifact #2 and emit a web-UI walkthrough
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** ROUTINE-WRITER
 - **Deliverable bucket:** `deliverables`

--- a/skills/routine-writer/references/output-contract.md
+++ b/skills/routine-writer/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -273,7 +273,7 @@ These look like security issues but aren't (or are acceptable):
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** SECURITY-AUDIT
 - **Deliverable bucket:** `audits`

--- a/skills/security-audit/references/output-contract.md
+++ b/skills/security-audit/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -460,7 +460,7 @@ instead of inventing a composite.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** SKILL-CREATOR
 - **Deliverable bucket:** `audits`

--- a/skills/skill-creator/references/output-contract.md
+++ b/skills/skill-creator/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/skill-refiner/SKILL.md
+++ b/skills/skill-refiner/SKILL.md
@@ -269,7 +269,7 @@ Before committing any skill modification, verify:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** SKILL-REFINER
 - **Deliverable bucket:** `audits`

--- a/skills/skill-refiner/references/output-contract.md
+++ b/skills/skill-refiner/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/skill-router/SKILL.md
+++ b/skills/skill-router/SKILL.md
@@ -97,7 +97,7 @@ For examples, see `references/routing-patterns.md`.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** SKILL-ROUTER
 - **Deliverable bucket:** `audits`

--- a/skills/skill-router/references/output-contract.md
+++ b/skills/skill-router/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -454,7 +454,7 @@ Read `references/production-checklist.md` for the full pre-deploy checklist cove
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** TERRAFORM
 - **Deliverable bucket:** `audits`

--- a/skills/terraform/references/output-contract.md
+++ b/skills/terraform/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -326,7 +326,7 @@ Enforce via `vitest --coverage --coverage.thresholds.lines=80`, `pytest --cov --
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** TESTING
 - **Deliverable bucket:** `audits`

--- a/skills/testing/references/output-contract.md
+++ b/skills/testing/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -424,7 +424,7 @@ When a feature, service, or API is deprecated during a session:
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** UPDATE-DOCS
 - **Deliverable bucket:** `audits`

--- a/skills/update-docs/references/output-contract.md
+++ b/skills/update-docs/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -417,7 +417,7 @@ but non-trivial for large estates.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** VIRTUALIZATION
 - **Deliverable bucket:** `audits`

--- a/skills/virtualization/references/output-contract.md
+++ b/skills/virtualization/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/zero-day/SKILL.md
+++ b/skills/zero-day/SKILL.md
@@ -469,7 +469,7 @@ and when to reach for each tool during source, binary, or live-system analysis.
 
 ## Output Contract
 
-See `skills/_shared/output-contract.md` for the full contract.
+See `references/output-contract.md` for the full contract.
 
 - **Skill name:** ZERO-DAY
 - **Deliverable bucket:** `audits`

--- a/skills/zero-day/references/output-contract.md
+++ b/skills/zero-day/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.


### PR DESCRIPTION
## Problem

All 44 skills referenced `skills/_shared/output-contract.md`, but `_shared/` has no `SKILL.md`, so it is **never installed** — `install.sh` (`discover_skills` requires a `SKILL.md`) and `npx skills add` both skip it. The path only resolves inside the source repo, so every standalone install shipped a **dead reference** in 100% of skills. Verified: `npx skills add iuliandita/skills` ships each skill's `references/` dir but no `_shared/`.

This is a separation/self-containment defect — skills are installed individually, so a skill must not depend on anything outside its own directory.

## Fix

- Vendor the contract into each skill's `references/output-contract.md`, generated from `skills/_shared/output-contract.md` (now a documented **build input**, not a runtime dependency).
- Rewrite all 44 `SKILL.md` links (plus `deep-grill/references/decision-record.md`) from `skills/_shared/output-contract.md` to the local `references/output-contract.md`.
- Add `scripts/gen-contract-refs.sh` (generator) and `scripts/check-contract-sync.sh` (fails on drift between source and copies, and bans any runtime `skills/_shared/` reference).
- Wire the sync check into pre-commit and the CI `collection` job.
- Document the workflow in README Contributing.

## Verification

- `scripts/check-contract-sync.sh`: clean; negative tests confirm it catches drift and banned `_shared` refs.
- `lint-skills.sh`, `validate-spec.sh`, `test-install.sh`, `test-lint-skills.sh`: all pass (only the pre-existing kubernetes 503-line warning).
- Standalone install of a single skill (`install.sh ... git`) ships `references/output-contract.md`, the SKILL.md link resolves locally, and no `_shared` references remain.