### PR TITLE
fix(skills): sharpen full-review vs deep-audit routing separation

### DIFF
--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deep-audit
 description: >
-  · Run 5-wave repo audits, persist findings, and generate phased tasks. Triggers: 'deep audit', 'full audit', 'comprehensive review', 'audit report', 'mega review', 'deep review'. Not for quick sweeps (use full-review).
+  · Run an exhaustive 5-wave repo audit (every applicable lens, up to 29 agents), persist findings, generate phased tasks. Triggers: 'deep audit', 'comprehensive audit', 'full audit', 'mega review', 'deep review', 'audit report'. Not for a quick fixed 4-skill sweep (use full-review).
 license: MIT
 compatibility: "Requires iuliandita/skills collection installed. Subagent support strongly recommended. Optional: a brainstorming or ideation skill in the host harness (matched by name pattern) for large-audit planning handoff."
 metadata:

--- a/skills/full-review/SKILL.md
+++ b/skills/full-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: full-review
 description: >
-  · Run combined code-review, anti-slop, security-audit, and update-docs pass. Triggers: 'full review', 'review everything', 'audit this repo', 'full check', 'run all checks'. Not for single-dimension audits.
+  · Run 4 fixed audits in parallel (code-review, anti-slop, security-audit, update-docs) as a quick quality gate. Triggers: 'full review', 'run all checks', 'full check', 'quad audit', 'review before merge'. Not for exhaustive/wave audits (use deep-audit) or single-dimension checks.
 license: MIT
 compatibility: "Requires code-review, anti-slop, security-audit, update-docs skills installed"
 metadata:


### PR DESCRIPTION
## What

Make the two audit orchestrators' triggers disjoint so they stop both firing on the same request. This is the deferred "open question" from the 2026-06-14 deep-grill on collection separation (PR #85 fixed the `_shared` self-containment half).

## Why

The boundary was asymmetric:
- `deep-audit`'s description already said "Not for quick sweeps (use full-review)".
- `full-review` only said "Not for single-dimension audits" — no pointer to deep-audit, and two of its triggers (`'audit this repo'`, `'review everything'`) semantically lean *exhaustive*, i.e. deep-audit territory. That overlap is what made both fire.

## Changes (frontmatter descriptions only)

- **full-review**: drops `'audit this repo'` / `'review everything'`; triggers now `'full review'`, `'run all checks'`, `'full check'`, `'quad audit'`, `'review before merge'`; adds "use deep-audit" pointer. Identity = fixed-4, parallel, quick gate.
- **deep-audit**: `'comprehensive review'` -> `'comprehensive audit'` so the trigger set is anchored on the depth axis (deep / comprehensive / mega / exhaustive), not the word "review".

The discriminating axis (fixed-4-quick vs exhaustive-wave-persisted) now lives in the trigger words themselves. No body/workflow changes; the `When NOT to use` and `Related Skills` cross-references between the two were already correct.

`code-slimming` / `anti-slop` were also reviewed and left unchanged — already cleanly separated (routing table + mutual `When NOT to use`).

## Verification

- `scripts/lint-skills.sh` — 44 skills, 0 errors
- `scripts/check-contract-sync.sh` — OK, no `_shared` runtime refs
- `scripts/validate-spec.sh` — 44 validated, 0 violations
- `git diff --no-ext-diff --check` — clean