### PR TITLE
chore: gitignore disposable .handoff/ docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ __pycache__/
 .pytest_cache/
 .refiner-baseline.json
 test.sh
+
+# Disposable agent handoff docs
+.handoff/


### PR DESCRIPTION
Ignores `.handoff/` — disposable session handoff working docs that shouldn't be tracked.