### PR TITLE
chore(skills): mid-June 2026 freshness sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-43 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
+44 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-open_standard-blue.svg)](https://agentskills.io)
@@ -23,7 +23,7 @@ AI coding tools used to mean prompts. Prompts don't compose, don't carry between
 
 Then Karpathy pointed an agent at a 630-line training script overnight. It edited the code, ran a 5-minute training, kept changes that improved the score, discarded the rest. 700 runs, 20 wins, on one GPU. The pattern works on anything you can score.
 
-This repo applies that pattern conservatively to 42 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
+This repo applies that pattern conservatively to 44 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
 
 ## The autoresearch loop
 

--- a/scripts/check-freshness-dates.sh
+++ b/scripts/check-freshness-dates.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-FRESHNESS_LABEL="${SKILLS_FRESHNESS_LABEL:-May 2026}"
+FRESHNESS_LABEL="${SKILLS_FRESHNESS_LABEL:-June 2026}"
 
 mapfile -t files < <(
   git -C "$ROOT" ls-files \

--- a/skills/ai-ml/SKILL.md
+++ b/skills/ai-ml/SKILL.md
@@ -17,7 +17,7 @@ Build, review, and architect applications that use AI models - from single-API c
 multi-agent systems with RAG pipelines. The goal is production-grade AI apps that are reliable,
 cost-effective, and don't hallucinate their way into an incident.
 
-**Target versions**: May 2026 snapshot. Read `references/target-versions.md` before
+**Target versions**: June 2026 snapshot. Read `references/target-versions.md` before
 pinning model IDs (Claude/OpenAI families), SDKs, runtimes, vector stores, or evaluation tools.
 
 ## When to use
@@ -435,7 +435,7 @@ PII detection setup, and content policy implementation.
 - `references/fine-tuning.md` - data prep, PEFT/LoRA, training evaluation, full vs parameter-efficient methods
 - `references/local-inference.md` - quantization, model selection, GPU memory, production serving config
 - `references/safety.md` - prompt injection defense, output validation, PII handling, content filtering, audit logging
-- `references/target-versions.md` - May 2026 snapshot: Claude/OpenAI model families, AI SDKs, runtimes, vector stores, and eval tools
+- `references/target-versions.md` - June 2026 snapshot: Claude/OpenAI model families, AI SDKs, runtimes, vector stores, and eval tools
 
 ## Output Contract
 

--- a/skills/ai-ml/references/target-versions.md
+++ b/skills/ai-ml/references/target-versions.md
@@ -1,22 +1,23 @@
 # AI/ML Target Versions
 
-May 2026 snapshot. Verified 2026-05-19 against PyPI, npm, and upstream GitHub release APIs.
+June 2026 snapshot. Verified 2026-06-14 against PyPI, npm, and upstream GitHub release APIs.
 Verify current releases before pinning.
 
 ## Model families
 
 Model IDs move faster than SDK versions and are not covered by routine minor-version bumps.
-Verify against provider docs before pinning. Current as of May 2026:
+Verify against provider docs before pinning. Current as of June 2026:
 
 | Provider | Tier | Model ID | Notes |
 |----------|------|----------|-------|
+| Anthropic | Frontier | `claude-fable-5` | Most capable public model: SWE, vision, research, autonomy. Blocks high-risk domains, falls back to Opus 4.8 (GA 2026-06-09) |
 | Anthropic | Flagship | `claude-opus-4-8` | Most capable: complex reasoning, long-horizon agentic coding (GA 2026-05-28) |
 | Anthropic | Balanced | `claude-sonnet-4-6` | Default coding model. 4.6+ dropped dated snapshots: the bare ID IS the pinned snapshot |
 | Anthropic | Fast | `claude-haiku-4-5` | Low cost/latency. Dated snapshot: `claude-haiku-4-5-20251001` |
 | OpenAI | Flagship | `gpt-5.5` | Current frontier chat model; recommended replacement for `gpt-4o` |
 | OpenAI | Cost tier | `gpt-5.4-mini`, `gpt-5.4-nano` | Smaller/cheaper tiers |
 
-`gpt-4o` is retired from ChatGPT (2026-04-03) but still API-available; new code should default to
+`gpt-4o` is retired from ChatGPT (2026-02-13) but still API-available; new code should default to
 `gpt-5.5`. Do not append a dated suffix to Claude 4.6+ IDs - the bare ID is the snapshot, and a
 guessed suffix like `claude-sonnet-4-6-20250514` is invalid (that date belonged to the original
 Sonnet 4) and returns a 404.
@@ -25,20 +26,20 @@ Sonnet 4) and returns a 404.
 
 | Component | Version | Notes |
 |-----------|---------|-------|
-| Anthropic Python SDK | 0.102.0 | Claude models, streaming, tool use, structured output |
-| Anthropic TS SDK | 0.96.0 | Same capabilities, TypeScript-first |
-| Claude Agent SDK (TS) | 0.3.143 | Programmatic agent building with Claude Code capabilities |
-| OpenAI Python SDK | 2.37.0 | GPT/o-series models, Responses API |
-| OpenAI Agents SDK | 0.17.2 | Multi-agent orchestration, tracing, sessions |
-| Vercel AI SDK | 6.0.185 | Unified provider interface, ToolLoopAgent, streaming |
-| LangChain | 1.3.1 | Orchestration framework |
-| LangGraph | 1.2.0 | Stateful agent graphs, cycles, persistence |
+| Anthropic Python SDK | 0.109.1 | Claude models, streaming, tool use, structured output |
+| Anthropic TS SDK | 0.104.1 | Same capabilities, TypeScript-first |
+| Claude Agent SDK (TS) | 0.3.177 | Programmatic agent building with Claude Code capabilities |
+| OpenAI Python SDK | 2.41.1 | GPT/o-series models, Responses API |
+| OpenAI Agents SDK | 0.17.5 | Multi-agent orchestration, tracing, sessions |
+| Vercel AI SDK | 6.0.205 | Unified provider interface, ToolLoopAgent, streaming |
+| LangChain | 1.3.9 | Orchestration framework |
+| LangGraph | 1.2.5 | Stateful agent graphs, cycles, persistence |
 | LlamaIndex | 0.14.22 | RAG framework, 300+ integrations |
-| Transformers | 5.8.1 | Model inference, fine-tuning, PyTorch 2.4+ required |
-| vLLM | 0.21.0 | High-throughput serving, continuous batching |
-| Ollama | 0.24.0 | Local inference, MLX backend on Apple Silicon |
+| Transformers | 5.12.0 | Model inference, fine-tuning, PyTorch 2.4+ required |
+| vLLM | 0.23.0 | High-throughput serving, continuous batching |
+| Ollama | 0.30.7 | Local inference, MLX backend on Apple Silicon |
 | pgvector | 0.8.2 | PostgreSQL extension, HNSW + IVFFlat |
-| Qdrant | 1.18.0 | Self-hosted vector DB, hybrid search |
-| Pinecone (Python) | 9.0.0 | Managed vector DB |
+| Qdrant | 1.18.2 | Self-hosted vector DB, hybrid search |
+| Pinecone (Python) | 9.1.0 | Managed vector DB |
 | ChromaDB | 1.5.9 | Lightweight vector DB, local-first |
-| promptfoo | 0.121.11 | LLM eval framework, red teaming |
+| promptfoo | 0.121.15 | LLM eval framework, red teaming |

--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -15,13 +15,13 @@ metadata:
 
 Write, review, and architect Ansible automation - from single playbooks to multi-tier, compliance-hardened infrastructure management. The goal is idempotent, auditable, maintainable automation that works the same locally and in CI/CD.
 
-**Target versions** (May 2026):
-- ansible-core **2.20.x LTS** (Python 3.12+ controller, 3.9+ target, EOL May 2027)
-- ansible (community package) 13.x (depends on ansible-core 2.20)
+**Target versions** (June 2026):
+- ansible-core **2.21.x** (current stable, Python 3.12+ controller, 3.9+ target, EOL Nov 2027); 2.20.x still maintained (2.20.6, EOL May 2027)
+- ansible (community package) 14.x (depends on ansible-core 2.21)
 - molecule 26.x (CalVer), ansible-lint 26.x (CalVer), ansible-navigator 26.x (CalVer)
 - ansible-builder 3.1.x (EE definition v3)
-- AWX 24.6.1 (last formal release Jul 2024; upstream AWX releases paused for a major refactor, devel branch active - track ansible/awx; awx-operator ~2.12.x still ships for K8s deploys). Verify current AWX/AAP release status before recommending a specific version or install path.
-- AAP 2.6 (Oct 2025 - last RPM-installable release; AAP 2.7+ containerized-only)
+- AWX 24.6.1 (last formal release Jul 2024; upstream AWX releases paused for a major refactor, devel branch active - track ansible/awx; awx-operator ~2.19.x still ships for K8s deploys). Verify current AWX/AAP release status before recommending a specific version or install path.
+- AAP 2.7 (GA June 3, 2026 - containerized/Operator only; 2.6 was the last RPM-installable release, still patched)
 
 This skill covers four domains depending on context:
 - **Playbooks** - tasks, handlers, variables, conditions, loops, blocks, templates, Jinja2
@@ -364,7 +364,7 @@ Read `references/compliance.md` for the full PCI-DSS 4.0 requirements mapping to
 
 ## Deprecations and Breaking Changes
 
-### ansible-core 2.20 (current)
+### ansible-core 2.20
 
 **Removals (already removed)**:
 - `smart` transport value - choose `ssh` or `paramiko` explicitly

--- a/skills/arch-btw/SKILL.md
+++ b/skills/arch-btw/SKILL.md
@@ -17,7 +17,7 @@ Administer Arch Linux and Arch-style systems without falling into rolling-releas
 Focus on vanilla Arch first, then layer in CachyOS behavior, `paru` workflow, systemd-native
 service management, boot recovery, kernel handling, and derivative-specific cautions.
 
-**Versions worth pinning** (May 2026):
+**Versions worth pinning** (June 2026):
 
 Only pin versions here when they materially affect compatibility or troubleshooting shape. For
 ordinary rolling packages, prefer the current repo state over stale version tables.

--- a/skills/backend-api/SKILL.md
+++ b/skills/backend-api/SKILL.md
@@ -16,10 +16,10 @@ metadata:
 Design and review HTTP APIs that stay coherent as they grow. Focus on contracts, auth
 boundaries, error models, and framework structure for Python and Node.js services.
 
-**Target versions** (May 2026):
-- FastAPI **0.135.3** (released 2026-04-01)
+**Target versions** (June 2026):
+- FastAPI **0.136.3** (released 2026-05-23)
 - Express **5.2.1** (published 2025-12-01)
-- NestJS **11.1.18** (published 2026-04-03)
+- NestJS **11.1.26** (published 2026-06-08)
 - OpenAPI Specification **3.2.0** (published 2025-09-19)
 - HTTP Semantics: **RFC 9110** (June 2022)
 - Problem Details for HTTP APIs: **RFC 9457** (July 2023)

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -16,9 +16,9 @@ Guide AI agents through web browsing tasks using the cheapest tool that gets the
 Every browsing action has a token cost - this skill minimizes it through progressive disclosure,
 smart format selection, and backend-aware strategies.
 
-**Target versions** (May 2026):
+**Target versions** (June 2026):
 - Lightpanda: 0.3.1
-- @playwright/mcp: 0.0.75
+- @playwright/mcp: 0.0.76
 - agent-browser: 0.27.0
 
 ## When to use

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -24,7 +24,7 @@ Write, review, and architect CI/CD pipelines across GitHub Actions, GitLab CI/CD
 Actions, Gitea Actions, and Woodpecker. The goal is secure, fast, auditable pipelines that
 satisfy both engineering needs and compliance requirements (PCI-DSS 4.0).
 
-**Target versions**: May 2026 snapshot. Read `references/target-versions.md` before
+**Target versions**: June 2026 snapshot. Read `references/target-versions.md` before
 pinning forge, runner, CI, or supply-chain tool versions.
 
 This skill covers workflow design, security, compliance, cross-platform migration,
@@ -444,7 +444,7 @@ the OWASP Top 10 for Agentic Applications, read `references/supply-chain.md`
 - `references/runners.md` - Self-hosted runners (actions-runner, gitlab-runner, forgejo-runner, act_runner, woodpecker-agent) - install, register, executor choice, Linux vs macOS, security hardening
 - `references/best-practices.md` - Dependency updates (Dependabot/Renovate), layered linting, scanning matrix (secrets/SCA/container/IaC/SAST), review gates, merge queues, rollout order
 - `references/supply-chain.md` - supply chain security, incident timeline, SHA pinning, SBOM/SLSA, PCI-DSS compliance, image signing
-- `references/target-versions.md` - May 2026 version snapshot for forges, runners, CI systems, and supply-chain tools
+- `references/target-versions.md` - June 2026 version snapshot for forges, runners, CI systems, and supply-chain tools
 
 ## Output Contract
 

--- a/skills/ci-cd/references/best-practices.md
+++ b/skills/ci-cd/references/best-practices.md
@@ -227,7 +227,7 @@ Both are good. Pick one per pipeline and stick with it.
 
 - **Trivy** - one binary, scans images + filesystems + IaC + secrets + licenses. Good
   default for teams who want fewer tools. After the 2025 TeamPCP incident, pin to a
-  verified version (`v0.70.0+` from official releases; `v0.69.3` was the March 2026
+  verified version (`v0.71.0+` from official releases; `v0.69.3` was the March 2026
   rollback version; avoid `v0.69.4/5/6` which were compromised).
 - **Grype** - vulnerability-matching only, but has **risk scoring** that combines CVSS
   + EPSS (exploit probability) + CISA KEV. Better signal-to-noise on severity gates -

--- a/skills/ci-cd/references/github-actions.md
+++ b/skills/ci-cd/references/github-actions.md
@@ -530,7 +530,7 @@ security:
         sarif_file: trivy.sarif
 ```
 
-**Trivy safe versions (May 2026)**: use binary v0.70.0+ from official releases and pin
+**Trivy safe versions (June 2026)**: use binary v0.71.0+ from official releases and pin
 actions to full commit SHAs. The March 2026 rollback set was binary v0.69.3,
 `trivy-action@v0.35.0`, and `setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6
 (compromised by TeamPCP).

--- a/skills/ci-cd/references/supply-chain.md
+++ b/skills/ci-cd/references/supply-chain.md
@@ -1,7 +1,7 @@
 # CI/CD Supply Chain Security
 
 Cross-platform supply chain hardening patterns, incident timeline, and PCI-DSS 4.0 compliance.
-Updated May 2026 - post-Trivy compromise and the TeamPCP npm/PyPI worm wave.
+Updated June 2026 - post-Trivy compromise and the TeamPCP npm/PyPI worm wave.
 
 ---
 
@@ -38,7 +38,7 @@ they inform every recommendation in this document.
 - **Lesson**: even security tools' own CI is a target. "We trust our scanning tool" is circular reasoning.
 
 **Known safe Trivy versions**:
-- Current new pins (May 2026): binary v0.70.0+ from official releases, pinned by checksum or image digest
+- Current new pins (June 2026): binary v0.71.0+ from official releases, pinned by checksum or image digest
 - March 2026 rollback: binary v0.69.2 or v0.69.3
 - `trivy-action`: **v0.35.0** was the March rollback tag; pin the verified commit SHA, not the tag
 - `setup-trivy`: v0.2.6 was the March rollback tag; pin the verified commit SHA, not the tag

--- a/skills/ci-cd/references/target-versions.md
+++ b/skills/ci-cd/references/target-versions.md
@@ -1,11 +1,11 @@
 # CI/CD Target Versions
 
-May 2026 snapshot. Verified 2026-05-19 against GitLab/Gitea/Forgejo APIs, GitHub releases,
+June 2026 snapshot. Verified 2026-06-14 against GitLab/Gitea/Forgejo APIs, GitHub releases,
 and supply-chain tool releases. Verify current releases before pinning.
 
 - **GitHub Actions**: ubuntu-24.04 runners (ubuntu-latest), arm64 GA, artifact v4, attestations GA
-- **GitLab CI/CD**: GitLab 19.0.1 current (19.0 major released May 21, 2026); 18.11.x / 18.10.x still on backports. CI/CD Catalog GA, CI Components with typed `spec: inputs`
-- **Forgejo Actions**: Forgejo v15.0.2, Runner v12.10.1 (check `data.forgejo.org/forgejo/runner` releases before pinning)
-- **Gitea Actions**: Gitea v1.26.1, act runner v1.0.4 (GA since Gitea 1.21, March 2024)
-- **Woodpecker CI**: v3.14.1 (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)
-- **Supply chain**: cosign v3.0.6 (Sigstore), Syft v1.44.0, Trivy v0.70.0, SLSA v1.1
+- **GitLab CI/CD**: GitLab 19.0.2 current (19.0 major released May 21, 2026; 19.0.2 / 18.11.5 / 18.10.8 patch release June 10, 2026); 18.10.x reaches EOL in June 2026, so move backported instances to 18.11.x. CI/CD Catalog GA, CI Components with typed `spec: inputs`
+- **Forgejo Actions**: Forgejo v15.0.3, Runner v12.10.1 (check `data.forgejo.org/forgejo/runner` releases before pinning)
+- **Gitea Actions**: Gitea v1.26.2, act runner v1.0.4 (GA since Gitea 1.21, March 2024)
+- **Woodpecker CI**: v3.15.0 (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)
+- **Supply chain**: cosign v3.1.1 (Sigstore), Syft v1.45.1, Trivy v0.71.0, SLSA v1.1

--- a/skills/command-prompt/SKILL.md
+++ b/skills/command-prompt/SKILL.md
@@ -16,11 +16,11 @@ metadata:
 Reference skill for writing commands, scripts, and configuration across Unix shells. Detects
 the target shell from context and routes to the appropriate reference.
 
-**Target versions** (May 2026):
+**Target versions** (June 2026):
 - Zsh: 5.10
 - Bash: 5.3
 - Fish: 4.6
-- Nushell: 0.111
+- Nushell: 0.113.1
 - Tcsh: 6.24
 - Dash: 0.5.13
 

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -15,13 +15,13 @@ metadata:
 
 Configure, tune, design schemas, migrate, back up, and review database engines - from single-node dev setups to PCI-compliant production clusters. The goal is correct, performant, durable databases that survive failures, pass audits, and don't wake you up at 3am.
 
-**Target versions** (May 2026):
-- PostgreSQL **18.4** (EOL 2030-11; May 2026 security release), previous: 17.10, 16.14
-- MongoDB **8.0.20** (GA, EOL 2029-10); rapid lane (8.3 latest) is Atlas-only with a short window - verify live before pinning
-- MariaDB **11.8.7** (LTS, EOL 2028-06); 12.x rolling GA is quarterly and EOLs at each successor (12.2 reached EOL 2026-05), with 12.3 the next yearly LTS - verify live
-- MySQL **8.4.8** (LTS); innovation lane (9.x) has a short support window - verify live
-- SQL Server **2025 RTM + CU3** (GA 2025-11-18)
-- PgBouncer **1.25.1**, Pgpool-II **4.7.1**, ProxySQL **3.0.6**
+**Target versions** (June 2026):
+- PostgreSQL **18.4** (EOL 2030-11; May 14, 2026 security release), back-branches: 17.10, 16.14, 15.18, 14.23 (no June stable release; PG 19 in beta)
+- MongoDB **8.0.26** (GA, EOL 2029-10; June 11, 2026 security release fixing CVE-2026-11933); rapid lane (8.2+) is Atlas-only with a short window - verify live before pinning
+- MariaDB **11.8.8** (LTS, EOL 2028-06); 12.x rolling GA is quarterly and EOLs at each successor, with 12.3 the next yearly LTS - verify live
+- MySQL **8.4.9** (LTS); innovation lane (9.6) has a short support window - verify live
+- SQL Server **2025 RTM + CU5** (CU5 KB5084896, 2026-05-20)
+- PgBouncer **1.25.2**, Pgpool-II **4.7.2**, ProxySQL **3.0.8**
 
 This skill covers six domains depending on context:
 - **Configuration** - engine settings, authentication, TLS, tuning parameters
@@ -310,7 +310,7 @@ Read `references/migration-patterns.md` for cross-engine type mapping, ORM migra
 - [ ] Foreign key columns have indexes
 - [ ] pgAudit installed and configured (if PCI scope)
 - [ ] Patched against CVE-2026-2005 (pgcrypto heap buffer overflow, RCE) - 18.2+ / 17.8+ / 16.12+
-- [ ] On the May 2026 PostgreSQL update (CVE-2026-6473/6475/6477/6637, up to CVSS 8.8: integer-overflow allocations, libpq client stack overwrite, refint stack overflow, MD5 timing leak) - 18.4+ / 17.10+ / 16.14+ / 15.18+ / 14.23+
+- [ ] On the May 14, 2026 PostgreSQL update (CVE-2026-6473/6475/6476/6477/6478: integer-wraparound under-sized allocation, intarray/ltree field overflow, pg_createsubscriber SQL injection, libpq lo_*/path traversal, MD5 password timing leak) - 18.4+ / 17.10+ / 16.14+ / 15.18+ / 14.23+
 
 ### MySQL/MariaDB-Specific
 
@@ -330,7 +330,8 @@ Read `references/migration-patterns.md` for cross-engine type mapping, ORM migra
 - [ ] Write concern `w: "majority"` (default in 8.0+)
 - [ ] Schema validation (`$jsonSchema`) on critical collections
 - [ ] Patched against MongoBleed (CVE-2025-14847) - 8.0.17+
-- [ ] Patched against CVE-2026-25611 (pre-auth DoS via compression) - 8.0.18+ / 8.2.4+
+- [ ] Patched against CVE-2026-25611 (pre-auth DoS via compression) - 8.0.18+ / 8.2.4+ / 7.0.29+
+- [ ] On the June 11, 2026 MongoDB security release (CVE-2026-11933) - 8.0.26+
 - [ ] TLS enabled (`net.tls.mode: requireTLS`)
 
 ### MSSQL-Specific
@@ -383,7 +384,7 @@ These are non-negotiable. Violating any of these is a bug.
 10. **Disk-level encryption is insufficient for PCI-DSS 4.0.** Req 3.5.1.2 requires TDE, column-level, or application-layer encryption.
 11. **Patch MongoBleed (CVE-2025-14847).** Self-hosted MongoDB < 8.0.17 / 7.0.28 / 6.0.27 is actively exploitable with no authentication required.
 12. **Patch MongoDB compression DoS (CVE-2026-25611).** Pre-auth DoS via crafted OP_COMPRESSED messages. Default config affected (compression enabled since 3.6). Fixed in 8.0.18+ / 8.2.4+ / 7.0.29+.
-13. **Patch PgBouncer (CVE-2025-12819).** PgBouncer < 1.25.1 can allow unauthenticated SQL execution when `track_extra_parameters` includes `search_path` AND `auth_user` is set (both non-default). Upgrade regardless - the fix is low-risk.
+13. **Patch PgBouncer.** PgBouncer < 1.25.1 (CVE-2025-12819) can allow unauthenticated SQL execution when `track_extra_parameters` includes `search_path` AND `auth_user` is set (both non-default). The May 2026 1.25.2 release adds further fixes (CVE-2026-6664/6665/6666/6667: integer overflow, SCRAM, null-deref, KILL_CLIENT authz). Upgrade to 1.25.2+ - the fixes are low-risk.
 14. **Chunk bulk inserts.** Never build a single `INSERT ... VALUES` with an unbounded row list. Compute batch size from the lowest host-parameter ceiling across supported backends (`floor(limit / columns_per_row)`). Wrap chunks in one transaction when atomicity matters.
 15. **Run the AI self-check.** Every generated migration, schema, or config gets verified against the checklist above before returning.
 

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -19,7 +19,7 @@ security-distro workflow. Focus on Debian stable and Ubuntu LTS first, then laye
 derivative-specific behavior, PPA workflows, snap confinement, Ubuntu HWE, and explicit checks
 for derivatives that diverge on init, packaging defaults, or intended use.
 
-**Versions worth pinning** (verified May 2026):
+**Versions worth pinning** (verified June 2026):
 
 Only pin versions here when they materially affect compatibility or troubleshooting shape. For
 ordinary Debian and Ubuntu package work, prefer the live distro lane and package policy over a

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 Write, review, and architect Dockerfiles, Compose stacks, and container workflows - from single-service dev setups to multi-arch production pipelines with image signing and compliance gates. The goal is minimal, secure, reproducible images that a team can maintain and a QSA can audit.
 
-**Target versions**: May 2026 snapshot. Read `references/target-versions.md` before
+**Target versions**: June 2026 snapshot. Read `references/target-versions.md` before
 pinning Docker, Compose, BuildKit, containerd, Podman, Buildah, or runc.
 
 This skill covers Dockerfiles, Compose, container hardening, supply chain, registry/CI
@@ -418,7 +418,7 @@ See AI Self-Check above for the full build-time checklist (Dockerfile correctnes
 - `references/compose-patterns.md` - Compose patterns and common stack layouts
 - `references/security-and-compliance.md` - container hardening, compliance guidance, and safe public custom image publishing
 - `references/alternative-runtimes.md` - Podman, Buildah, Skopeo, and related runtime patterns
-- `references/target-versions.md` - May 2026 version snapshot for Docker, Compose, BuildKit, containerd, Podman, Buildah, and runc
+- `references/target-versions.md` - June 2026 version snapshot for Docker, Compose, BuildKit, containerd, Podman, Buildah, and runc
 
 ## Output Contract
 

--- a/skills/docker/references/alternative-runtimes.md
+++ b/skills/docker/references/alternative-runtimes.md
@@ -245,7 +245,7 @@ skopeo list-tags docker://ghcr.io/org/myapp
 
 Low-level container runtime. Kubernetes uses it directly. Docker Engine uses it under the hood.
 
-### Key facts (May 2026)
+### Key facts (June 2026)
 
 - **containerd 2.3.0** was released in April 2026 as the first annual LTS release, supported for 2+ years
 - **containerd 2.2.3** remains a supported 2.2 patch release through November 2026

--- a/skills/docker/references/dockerfile-patterns.md
+++ b/skills/docker/references/dockerfile-patterns.md
@@ -117,7 +117,7 @@ Attestations are stored in the registry alongside the image. Requires `--push`.
 
 \* Chainguard dev variants include shell; prod variants don't.
 
-**Choose Chainguard** for: zero-CVE at build time, built-in SBOM + Sigstore, nightly rebuilds, glibc compat, PCI/regulatory compliance. 2000+ images available as of May 2026 recheck.
+**Choose Chainguard** for: zero-CVE at build time, built-in SBOM + Sigstore, nightly rebuilds, glibc compat, PCI/regulatory compliance. 2000+ images available as of June 2026 recheck.
 
 **Choose Alpine** when: you need a shell, all deps work with musl, image size is top priority.
 

--- a/skills/docker/references/target-versions.md
+++ b/skills/docker/references/target-versions.md
@@ -1,11 +1,11 @@
 # Docker Target Versions
 
-May 2026 snapshot. Verified 2026-05-19 against Docker release notes, Docker Desktop appcast,
+June 2026 snapshot. Verified 2026-06-14 against Docker release notes, Docker Desktop appcast,
 and upstream GitHub release APIs. Verify current releases before pinning.
 
-- Docker Engine 29.4.3, Docker Desktop 4.73.x (4.73.1 Windows, 4.73.0 macOS/Linux)
-- Docker Compose v5.1.3 (Go SDK, Bake-delegated builds)
+- Docker Engine 29.5.3, Docker Desktop 4.77.0 (same version across Windows, macOS, Linux)
+- Docker Compose v5.1.4 (Go SDK, Bake-delegated builds)
 - BuildKit v0.30.0
-- containerd 2.3.0 LTS (recommended for production after checking release notes)
-- Podman 5.8.2, Buildah 1.43.1
-- runc 1.4.2 (CVE-2025-31133/52565/52881 patched since 1.4.0)
+- containerd 2.3.1 (2.3.x LTS, recommended for production after checking release notes)
+- Podman 5.8.3, Buildah 1.44.0
+- runc 1.4.3 (CVE-2025-31133/52565/52881 patched since 1.4.0; GHSA-xjvp-4fhw-gc47, a low-severity /dev symlink issue, fixed in 1.4.3/1.3.6)

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -16,10 +16,10 @@ metadata:
 Manage, troubleshoot, and harden OPNsense and pfSense firewalls via SSH. Both are FreeBSD-based,
 pf-powered firewall distributions - most concepts, commands, and patterns apply to both.
 
-**Target versions** (May 2026):
-- OPNsense CE: 26.1.7 (current Community Edition stable, "Witty Woodpecker"; CE ships odd quarters .1/.7). Business Edition is 26.4.x (even quarters .4/.10) - do not quote the BE number as the CE version
+**Target versions** (June 2026):
+- OPNsense CE: 26.1.9 (current Community Edition stable, "Witty Woodpecker"; CE ships odd quarters .1/.7, with 26.7 in beta). Business Edition is 26.4.x (even quarters .4/.10) - do not quote the BE number as the CE version
 - pfSense CE: 2.8.1 / pfSense Plus: 26.03
-- CrowdSec: v1.7.7
+- CrowdSec: v1.7.8
 
 ## When to use
 

--- a/skills/firewall-appliance/references/plugins.md
+++ b/skills/firewall-appliance/references/plugins.md
@@ -6,7 +6,7 @@ inspect via `pkg info <name>` and check `/usr/local/etc/` for their configs.
 ## Security
 
 ### os-crowdsec (CrowdSec)
-Local LAPI + bouncer (verify OPNsense package with `pkg info os-crowdsec`; upstream CrowdSec v1.7.7 as of May 2026 recheck). Parses logs locally, applies local bans + crowd-sourced blocklists.
+Local LAPI + bouncer (verify OPNsense package with `pkg info os-crowdsec`; upstream CrowdSec v1.7.8 as of June 2026 recheck). Parses logs locally, applies local bans + crowd-sourced blocklists.
 
 **Two separate enforcement layers:**
 - **Local decisions** (`crowdsec_blacklists` pf table): IPs your firewall detected and banned

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -17,13 +17,13 @@ A pragmatic, perfectionist UI engineer with strong taste. Treats interfaces as c
 
 This skill replaces the upstream generic `frontend-design` skill in this collection. The persona is the point: bland, accommodating UI advice produces bland UIs.
 
-**Target versions** (May 2026 - pinned so staleness is visible):
+**Target versions** (June 2026 - pinned so staleness is visible):
 
-- Astro 6.2.1 (Astro 5.17 also production-ready)
-- SvelteKit 2.58.0 + Svelte 5.55.5 runes
-- Tailwind CSS v4.2.4
-- Vite 8.0.10
-- React 19.2.5 + Next.js 16.2.4 (heavier option, only when team is React-locked)
+- Astro 6.4.4 (Astro 5.17 also production-ready)
+- SvelteKit 2.58.0 + Svelte 5.56.0 runes
+- Tailwind CSS v4.3.1
+- Vite 8.0.16
+- React 19.2.7 + Next.js 16.2.7 (heavier option, only when team is React-locked)
 - @use-gesture/react 10.3.1 (modern; Hammer.js considered legacy)
 
 ## When to use

--- a/skills/frontend-design/references/frameworks.md
+++ b/skills/frontend-design/references/frameworks.md
@@ -1,6 +1,6 @@
 # Framework Picker
 
-Pinned to May 2026. Update versions when refreshing the skill. Hallucinating "Next.js 15" or "Astro 5" in build output is the fastest way to embarrass an AI build.
+Pinned to June 2026. Update versions when refreshing the skill. Hallucinating "Next.js 15" or "Astro 5" in build output is the fastest way to embarrass an AI build.
 
 The persona's bias: minimalist first. Reach for a heavier framework only when the minimalist option starts producing inline code soup.
 
@@ -9,10 +9,10 @@ The persona's bias: minimalist first. Reach for a heavier framework only when th
 ## Decision tree
 
 1. **No-build, single HTML file demo, codepen-style?** -> Plain HTML + CSS + JS, no framework. State the constraint at the top of the file.
-2. **Static content, marketing site, blog, docs?** -> **Astro 6.2.1** (or **Astro 5.17** if Astro 6 hasn't shipped a feature you need)
-3. **Interactive app, bundle size matters, you want runes?** -> **SvelteKit 2.58.0** + Svelte 5.55.5
-4. **Small app, no SSR needed, want Vite directly?** -> **Vite 8.0.10** + plain TypeScript or a thin layer (Lit, Solid, vanilla)
-5. **Team is React-locked or you genuinely need React's ecosystem?** -> **Next.js 16.2.4** + **React 19.2.5**
+2. **Static content, marketing site, blog, docs?** -> **Astro 6.4.4** (or **Astro 5.17** if Astro 6 hasn't shipped a feature you need)
+3. **Interactive app, bundle size matters, you want runes?** -> **SvelteKit 2.58.0** + Svelte 5.56.0
+4. **Small app, no SSR needed, want Vite directly?** -> **Vite 8.0.16** + plain TypeScript or a thin layer (Lit, Solid, vanilla)
+5. **Team is React-locked or you genuinely need React's ecosystem?** -> **Next.js 16.2.7** + **React 19.2.7**
 
 The persona pushes back on Next.js as a default. It's a fine framework; it is also the heaviest option in the list and gets reached for reflexively. If the answer to "why Next" is "because everyone uses it", that's not a reason.
 
@@ -21,7 +21,7 @@ when they fit.
 
 ---
 
-## Astro 6.2.1 (Cloudflare-owned since January 16, 2026)
+## Astro 6.4.4 (Cloudflare-owned since January 16, 2026)
 
 **When.** Content-heavy: marketing pages, docs, blogs, portfolios, landing sites, hybrid sites with islands of interactivity.
 
@@ -50,7 +50,7 @@ bun create astro@latest
 
 ---
 
-## SvelteKit 2.58.0 + Svelte 5.55.5
+## SvelteKit 2.58.0 + Svelte 5.56.0
 
 **When.** Interactive apps where bundle size and runtime cost matter. Apps where the team wants explicit reactivity.
 
@@ -89,7 +89,7 @@ bun create svelte@latest
 
 ---
 
-## Vite 8.0.10 + plain TS
+## Vite 8.0.16 + plain TS
 
 **When.** Small apps, demos, tools where you want a build but no framework opinions. Single-page tools, internal dashboards with one or two views.
 
@@ -116,7 +116,7 @@ bun create vite@latest
 
 ---
 
-## Next.js 16.2.4 + React 19.2.5
+## Next.js 16.2.7 + React 19.2.7
 
 **When.** Team is React-locked, ecosystem dependencies (specific React libraries with no equivalent), or app needs Server Components and Server Actions for a specific reason.
 
@@ -125,7 +125,7 @@ bun create vite@latest
 **Strengths.**
 
 - Turbopack stable (default bundler in Next 16) - dev startup ~50% faster
-- React Server Components, Server Actions; React 19.2.5 features (View Transitions, useEffectEvent, Activity)
+- React Server Components, Server Actions; React 19.2.7 features (View Transitions, useEffectEvent, Activity)
 - Cache Components with Partial Pre-Rendering and the `"use cache"` directive
 - Largest ecosystem of components, hooks, libraries
 - Vercel-tier hosting integration

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -18,12 +18,12 @@ cut releases, and maintain audit-grade change history across GitHub, GitLab, and
 The goal is clean, signed, traceable history that satisfies both engineering standards and
 compliance requirements (PCI-DSS 4.0).
 
-**Target versions** (May 2026):
-- **git**: 2.53.x (current stable). Git 3.0 expected late 2026 (reftable default, SHA-256 default)
-- **GitHub CLI (`gh`)**: 2.91.0
+**Target versions** (June 2026):
+- **git**: 2.54.x (current stable). Git 3.0 expected late 2026 (reftable default, SHA-256 default)
+- **GitHub CLI (`gh`)**: 2.94.0
 - **GitLab CLI (`glab`)**: 1.90.x
-- **Forgejo CLI (`fj`)**: 0.5.0 (latest verified May 2026, released 2026-04-16; the project moves fast - verify the current release at `codeberg.org/forgejo-contrib/forgejo-cli`). Rust-written, official community CLI. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
-- **Forgejo**: v15.0 line current at May 2026 recheck; verify the stable branch before upgrade advice. Critical RCE (CVE-2025-68937) patched in v13.0.2+.
+- **Forgejo CLI (`fj`)**: 0.5.0 (latest verified June 2026, released 2026-04-16; the project moves fast - verify the current release at `codeberg.org/forgejo-contrib/forgejo-cli`). Rust-written, official community CLI. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
+- **Forgejo**: v15.0 line current at June 2026 recheck; verify the stable branch before upgrade advice. Critical RCE (CVE-2025-68937) patched in v13.0.2+.
 - **prek**: 0.3.x (Rust, recommended) or **pre-commit**: 4.6.0 (Python, largest ecosystem)
 - **git-filter-repo**: 2.47.x
 - **gitleaks**: 8.30.x (secret scanning)

--- a/skills/git/references/forge-workflows.md
+++ b/skills/git/references/forge-workflows.md
@@ -2,7 +2,7 @@
 
 Patterns for GitHub, GitLab, and Forgejo - PRs/MRs, releases, branch protection, CLI usage.
 
-Research date: May 2026.
+Research date: June 2026.
 
 ---
 
@@ -247,7 +247,7 @@ does not cover yet (e.g. branch protection management).
 | Platform | Command |
 |----------|---------|
 | Arch / CachyOS (AUR) | `paru -S forgejo-cli` (or `cargo install forgejo-cli`) |
-| Debian sid / Ubuntu 25.10+ | `sudo apt install forgejo-cli` (not in Debian stable or Ubuntu LTS as of May 2026 recheck) |
+| Debian sid / Ubuntu 25.10+ | `sudo apt install forgejo-cli` (not in Debian stable or Ubuntu LTS as of June 2026 recheck) |
 | Fedora | `sudo dnf copr enable lihaohong/forgejo-cli && sudo dnf install forgejo-cli` |
 | macOS | `brew install forgejo-cli` |
 | Nix | `nix profile install nixpkgs#forgejo-cli` |

--- a/skills/git/references/recovery-and-maintenance.md
+++ b/skills/git/references/recovery-and-maintenance.md
@@ -2,7 +2,7 @@
 
 Reflog, bisect, rerere, filter-repo, stash, worktree, submodules, large repo optimization.
 
-Research date: May 2026.
+Research date: June 2026.
 
 ---
 

--- a/skills/git/references/security-and-signing.md
+++ b/skills/git/references/security-and-signing.md
@@ -2,7 +2,7 @@
 
 Credential management, commit signing setup, secret scanning, CVE reference, and hardening.
 
-Research date: May 2026.
+Research date: June 2026.
 
 ---
 
@@ -254,7 +254,7 @@ git push origin --force --tags
 | CVE-2024-50349 | < 2.48.1 | Medium | Credential leak via terminal escape in URL (Clone2Leak disclosure) |
 | CVE-2024-52006 | < 2.48.1 | Medium | Carriage return smuggling in credential protocol (same Clone2Leak disclosure as CVE-2024-50349) |
 
-**Action**: ensure git >= 2.50.1 (ideally 2.53.x). CVE-2025-48384 is **actively exploited in the
+**Action**: ensure git >= 2.50.1 (ideally 2.54.x). CVE-2025-48384 is **actively exploited in the
 wild** - a weaponized `.gitmodules` file can overwrite hook scripts to achieve RCE on `git clone
 --recursive`. Patched in v2.50.1, v2.49.1, v2.48.2, v2.47.3, and backports. Linux and macOS
 affected; Windows is not.

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -21,7 +21,7 @@ Kali is Debian-shaped, but the places where it goes wrong are usually Kali-speci
 mixing, metapackage sprawl, stale images, persistence mistakes, hardware edge cases, or people
 using the wrong tool family for the job.
 
-**Target versions** (verified May 2026):
+**Target versions** (verified June 2026):
 
 Only pin versions or dated anchors here when they materially affect compatibility or
 troubleshooting shape. For ordinary package work, prefer the live branch and repo state over a
@@ -30,7 +30,7 @@ stale package table.
 | Component | Version or date | Why it matters |
 |-----------|-----------------|----------------|
 | **Current dated Kali image release** | 2026.1 | current image baseline and release notes |
-| Branch docs | May 2026 recheck / verify live | branch behavior and safe lane selection matter more than a single package version |
+| Branch docs | June 2026 recheck / verify live | branch behavior and safe lane selection matter more than a single package version |
 | Metapackage docs | 2025-07 / verify live | tool-family grouping and install scope matter more than memorizing one package list |
 | Kali 2026.1 kernel lane | 6.18 | release-image baseline for hardware and driver expectations |
 

--- a/skills/kali-linux/references/gotchas-and-special-situations.md
+++ b/skills/kali-linux/references/gotchas-and-special-situations.md
@@ -1,6 +1,6 @@
 # Kali Gotchas and Special Situations
 
-Research date: May 2026
+Research date: June 2026
 
 The boring failures win a lot.
 

--- a/skills/kali-linux/references/metapackages-and-tool-families.md
+++ b/skills/kali-linux/references/metapackages-and-tool-families.md
@@ -1,6 +1,6 @@
 # Kali Metapackages and Tool Families
 
-Research date: May 2026
+Research date: June 2026
 
 Kali is easier to manage when you think in bundles and workflows instead of one giant package dump.
 The official metapackage docs and `kali-meta` page are the map.

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Create, review, and architect Kubernetes infrastructure - from raw manifests to Helm charts to multi-cluster strategy. The goal is production-ready, security-hardened, cost-aware infrastructure that a team can maintain.
 
-**Target versions** (May 2026): Kubernetes 1.34-1.36 (1.36.0 "Haru" released April 22, 2026). Upstream Kubernetes has no LTS; community support per minor is ~14 months, so 1.32 reaches upstream EOL ~April 2026. Managed **vendor extended support** (AKS/EKS) carries 1.32 patches roughly 2 more years - attribute it to the platform, not upstream. Helm 4.2.0, Helm 3.21.x (parallel v3 maintenance, security fixes until Nov 2026).
+**Target versions** (June 2026): Kubernetes 1.34-1.36 supported (1.36 "Haru" released April 22, 2026; 1.36.1 / 1.35.5 / 1.34.8 are the current patches). Upstream Kubernetes has no LTS; community support per minor is ~14 months. 1.33 entered maintenance April 28, 2026 and reaches upstream EOL June 28, 2026; 1.32 already hit upstream EOL February 28, 2026. Managed **vendor extended support** (AKS/EKS) carries older minors patches roughly 2 more years - attribute it to the platform, not upstream. Helm 4.2.1, Helm 3.21.x (parallel v3 maintenance, security fixes until Nov 2026).
 
 This skill covers four domains depending on context:
 - **Manifests** - raw YAML for Deployments, Services, Gateway API routes, ConfigMaps, Secrets, PVCs
@@ -173,7 +173,7 @@ Read `references/manifest-templates.md` for complete, copy-pasteable YAML templa
 
 ## Helm Charts
 
-**Helm 4** (released Nov 2025) is current. Helm 3.20.x gets security fixes until Nov 2026.
+**Helm 4** (4.0.0 released Nov 12, 2025; 4.2.1 current) is current. Helm 3.21.x gets security fixes until Nov 2026.
 
 ### What changed in Helm 4
 
@@ -359,7 +359,7 @@ The Trivy supply chain attack (CVE-2026-33634) is the defining security event of
 
 ### Platform awareness
 
-- **cgroup v2 required** on K8s 1.35+. Nodes on cgroup v1 (CentOS 7, RHEL 7, Ubuntu 18.04) will fail.
+- **cgroup v2 required** on K8s 1.36+ (`FailCgroupV1` defaults to true; kubelet won't start on cgroup v1 unless `failCgroupV1: false`). Nodes on cgroup v1 (CentOS 7, RHEL 7, Ubuntu 18.04) will fail.
 - **containerd 2.0 required** on K8s 1.36+. Last release supporting containerd 1.x is 1.35.
 - **K8s 1.36 launches April 22, 2026** - containerd 2.0 required on all nodes. IPVS kube-proxy mode removal not yet committed to a specific version (nftables is the replacement).
 - **AppArmor annotation auto-population stopped** in 1.34; full removal in 1.36. Use `securityContext.appArmorProfile` field.

--- a/skills/kubernetes/references/architecture.md
+++ b/skills/kubernetes/references/architecture.md
@@ -1,6 +1,6 @@
 # Kubernetes Architecture Decision Framework
 
-Deep-dive reference for cluster design, GitOps strategy, security architecture, and operational patterns. Updated for K8s 1.33-1.35+ and Helm 4.
+Deep-dive reference for cluster design, GitOps strategy, security architecture, and operational patterns. Updated for K8s 1.34-1.36 and Helm 4.
 
 ---
 
@@ -109,7 +109,7 @@ spec:
 - Multi-source Applications (mature since ArgoCD 2.6) for separating chart version from env values.
 - `ignoreMissingValueFiles: true` for default/override patterns with ApplicationSets.
 - OCI charts: omit `oci://` prefix in ArgoCD's `repoURL`.
-- Wildcard valueFiles (documented in current Argo CD docs as of May 2026 recheck): `valueFiles: ["values/*.yaml"]`.
+- Wildcard valueFiles (documented in current Argo CD docs as of June 2026 recheck): `valueFiles: ["values/*.yaml"]`.
 - **Anti-pattern**: `randAlphaNum` or other random functions in Helm templates - causes perpetual OutOfSync.
 
 ### Promotion Strategy
@@ -223,7 +223,7 @@ The Trivy supply chain attack (CVE-2026-33634) demonstrated that **mutable Git t
 - **Separate CI secrets by environment**: staging pipeline should NOT have access to production credentials.
 - **Monitor action repos for force-push events**: subscribe to security advisories for all actions you use.
 
-**Trivy safe versions (May 2026):** use binary v0.70.0+ from official releases for new pins. The March 2026 rollback set was binary v0.69.3, `trivy-action@v0.35.0`, and `setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6.
+**Trivy safe versions (June 2026):** use binary v0.70.0+ from official releases for new pins. The March 2026 rollback set was binary v0.69.3, `trivy-action@v0.35.0`, and `setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6.
 
 ### Secrets Management
 
@@ -392,7 +392,7 @@ Keep these in mind when upgrading:
 
 | Requirement | Version | Impact |
 |-------------|---------|--------|
-| **cgroup v2** | 1.35+ | Kubelet fails to start on cgroup v1 nodes. CentOS 7, RHEL 7, Ubuntu 18.04 affected. |
+| **cgroup v2** | 1.36+ | `FailCgroupV1` defaults to true; kubelet fails to start on cgroup v1 nodes unless `failCgroupV1: false`. CentOS 7, RHEL 7, Ubuntu 18.04 affected. |
 | **containerd 2.0+** | 1.36+ | Last release supporting containerd 1.x is 1.35. |
 | **AppArmor via securityContext** | 1.34+ | Annotations removed. Use `securityContext.appArmorProfile` field. |
 | **KMS v2** | Now | KMS v1 disabled by default since 1.29. Migrate to v2. |

--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # Localize: App Internationalization Workflow
 
-**Target versions (May 2026):** react-i18next 17.x, vue-i18n 11.x, next-intl 4.x, i18next 26.x
+**Target versions (June 2026):** react-i18next 17.x, vue-i18n 11.x, next-intl 4.x, i18next 26.x
 
 Systematic approach to internationalizing applications. Covers two scenarios: adding
 multilingual support from scratch and auditing existing i18n for gaps. Built from real

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -17,10 +17,10 @@ Build, review, and debug MCP servers that expose tools, resources, and prompts t
 assistants. The goal is secure, well-structured servers that follow the protocol spec and don't
 become yet another server with preventable injection vulnerabilities.
 
-**Target versions** (May 2026):
-- MCP specification: 2025-11-25 (current stable; 2026-03-15 in draft)
+**Target versions** (June 2026):
+- MCP specification: 2025-11-25 (current stable; 2026-07-28 release candidate in draft)
 - TypeScript SDK: @modelcontextprotocol/sdk 1.29.0 (1.x stable; 2.0.0-alpha in dev)
-- Python SDK: mcp 1.27.0 (v1.26.0+)
+- Python SDK: mcp 1.27.2 (v1.26.0+)
 - Protocol transports: stdio, Streamable HTTP (the standalone HTTP+SSE transport was deprecated in spec 2025-03-26; SSE still streams inside Streamable HTTP)
 
 ## When to use

--- a/skills/networking/SKILL.md
+++ b/skills/networking/SKILL.md
@@ -17,7 +17,7 @@ Configure, troubleshoot, and optimize Linux networking infrastructure. Covers DN
 VPNs, firewalls (nftables), VLANs, subnetting, high availability, dynamic routing, and network
 performance tuning.
 
-**Target versions** (May 2026):
+**Target versions** (June 2026):
 
 | Tool | Version | Notes |
 |------|---------|-------|

--- a/skills/networking/references/troubleshooting.md
+++ b/skills/networking/references/troubleshooting.md
@@ -393,9 +393,8 @@ and audit `authorized_keys`/CA-signed cert principals.
 ### Let's Encrypt with certbot
 
 **45-day certificate rollout timeline:**
-- Now: 90-day certs (default), 6-day short-lived certs available
-- May 2026: opt-in to 45-day certs
-- Feb 2027: default changes to 64-day certs
+- Now: 90-day certs (default), 6-day short-lived certs available; opt-in 45-day `tlsserver` profile live since May 13, 2026
+- Feb 2027: default changes to 64-day certs (10-day authorization reuse)
 - Feb 2028: default changes to 45-day certs
 
 Certbot 5.4.0 supports IP address certificates (`--ip-address`) and ARI (ACME Renewal

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -30,22 +30,23 @@ disposable dev shells, fleet-wide configuration without a separate config-manage
 and a single language for a workstation, a server, a container image, a NixOS VM, and a
 macOS laptop via nix-darwin.
 
-**Versions worth pinning** (verified May 2026):
+**Versions worth pinning** (verified June 2026):
 
 Pin versions only when they shape compatibility or troubleshooting. For ordinary package
 work, trust the live channel or flake lock over a stale table.
 
 | Component | Version or date | Why it matters |
 |-----------|-----------------|----------------|
-| NixOS stable | 25.11 "Xantusia" (Nov 2025) | current stable, maintained until 2026-06-30 |
-| NixOS upcoming | 26.05 "Yarara" (May 2026) | next release; do not target yet for production |
+| NixOS stable | 26.05 "Yarara" (May 2026) | current stable, released 2026-05-30, maintained until 2026-12-31 |
+| NixOS previous stable | 25.11 "Xantusia" (Nov 2025) | EOL 2026-06-30; upgrade off it now |
+| NixOS upcoming | 26.11 (~Nov 2026) | next release; do not target yet for production |
 | Nix (CLI / daemon) | 2.33 (Dec 2025) | stable upstream; 2.32 introduced skip-substitutable-downloads |
-| `nixos-rebuild-ng` | default in 25.11 | Python rewrite of nixos-rebuild, default for new installs |
-| home-manager | release-25.11 (Nov 2025) | matches NixOS 25.11; unstable tracks nixos-unstable |
-| nix-darwin | tracks nixpkgs 25.11 and master | active macOS module system (Intel + Apple Silicon) |
+| `nixos-rebuild-ng` | default in 25.11+ | Python rewrite of nixos-rebuild, default for new installs |
+| home-manager | release-26.05 (May 2026) | matches NixOS 26.05; unstable tracks nixos-unstable |
+| nix-darwin | tracks nixpkgs 26.05 and master | active macOS module system (Intel + Apple Silicon) |
 | Determinate Nix | downstream, flakes-on by default | validated distribution; parallel eval, lazy trees |
 | Lix | fork of Nix | compatibility-focused fork; Meson build, improved errors |
-| Kernel default for 25.11 | Linux 6.12 LTS | default `linuxPackages`; `linuxPackages_latest` tracks mainline (6.17 at 25.11 release, not LTS) |
+| Kernel default for 26.05 | Linux 6.12 LTS | default `linuxPackages`; `linuxPackages_latest` tracks mainline, not LTS |
 
 ## When to use
 
@@ -103,7 +104,7 @@ Before returning NixOS or Nix commands, verify:
 - [ ] **Unfree / insecure gates named explicitly**: set `nixpkgs.config.allowUnfree = true;` or `allowUnfreePredicate`, and list insecure packages under `permittedInsecurePackages`. Do not default to `NIXPKGS_ALLOW_UNFREE=1` as the permanent answer.
 - [ ] **Hardware module present**: for fresh installs, `hardware-configuration.nix` must be regenerated with `nixos-generate-config` and not hand-edited for filesystem UUIDs. For laptops, check nixos-hardware profile.
 - [ ] **Kernel and initrd coherence**: `boot.kernelPackages`, initrd modules, filesystems, and bootloader agree. Do not casually swap kernels on a system with ZFS, NVIDIA, or custom out-of-tree modules.
-- [ ] **Module fields real**: options named in advice exist in the version of nixpkgs the user has. `options` graveyards drift between 23.11, 24.05, 24.11, 25.05, and 25.11 - verify against the `nixpkgs` tag the user pinned.
+- [ ] **Module fields real**: options named in advice exist in the version of nixpkgs the user has. `options` graveyards drift between 24.05, 24.11, 25.05, 25.11, and 26.05 - verify against the `nixpkgs` tag the user pinned.
 - [ ] **Secrets not put in the store**: anything under `./secret.age`, `./sops.yaml`, or similar must be decrypted at activation time by sops-nix or agenix, not embedded directly in a Nix string that ends up world-readable in `/nix/store`.
 - [ ] **disko / impermanence claims match the install**: declarative disk layouts change the recovery story. Confirm partition, filesystem, and subvolume layout before prescribing rollback or wipe steps.
 - [ ] **home-manager mode identified**: standalone, NixOS module, or nix-darwin module. `home-manager switch` vs `nixos-rebuild switch` vs `darwin-rebuild switch` is not interchangeable.
@@ -143,8 +144,8 @@ Before returning NixOS or Nix commands, verify:
 
 | Lane | Default stance | What changes |
 |------|----------------|--------------|
-| **NixOS installed (stable 25.11)** | configuration.nix or flake.nix drives everything | full system is Nix-managed; rollbacks via bootloader |
-| **NixOS unstable / 26.05 pre-release** | treat as rolling-ish | expect breakage; verify options still exist |
+| **NixOS installed (stable 26.05)** | configuration.nix or flake.nix drives everything | full system is Nix-managed; rollbacks via bootloader |
+| **NixOS unstable / 26.11 pre-release** | treat as rolling-ish | expect breakage; verify options still exist |
 | **Nix on non-NixOS Linux** | user-level only | host distro still owns services and boot; no `nixos-rebuild` |
 | **nix-darwin on macOS** | declarative macOS config | `darwin-rebuild switch`; host owns kernel and firmware |
 | **Plain Nix on macOS (no darwin)** | package manager only | `nix profile` or `nix shell` for user tooling |
@@ -390,7 +391,7 @@ See `references/output-contract.md` for the full contract.
 5. **Flakes are intentional.** Enable `nix-command flakes` where the user already uses them; do not push migration during troubleshooting.
 6. **GC roots are real state.** Dev shells, direnv caches, and CI pins hold them. Check before mass deletion.
 7. **Secrets never in the store.** Use sops-nix or agenix with activation-time decryption; anything else ends up world-readable in `/nix/store`.
-8. **Module options must exist in the user's nixpkgs tag.** 23.11/24.05/24.11/25.05/25.11 drift is real; confirm with `nix repl` or the options search before recommending.
+8. **Module options must exist in the user's nixpkgs tag.** 24.05/24.11/25.05/25.11/26.05 drift is real; confirm with `nix repl` or the options search before recommending.
 9. **Overlays compose, not mutate.** `final: prev: { ... }` scope. Do not recommend global profile-level overlays on flake systems.
 10. **Kernel and initrd agree.** Do not flip `boot.kernelPackages` on ZFS, NVIDIA, or custom-module systems without a fallback.
 11. **Do not touch `system.stateVersion` casually.** It controls migration semantics and is not a "version bump" field.

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -19,7 +19,7 @@ fast-moving Fedora lane from the conservative enterprise lane, then account for 
 such as subscription-manager, CentOS Stream drift, Oracle UEK, Amazon's cloud-first defaults,
 and SELinux or firewalld behavior that people love to blame on the wrong layer.
 
-**Versions worth pinning** (verified May 2026):
+**Versions worth pinning** (verified June 2026):
 
 Only pin versions here when they materially affect compatibility or troubleshooting shape. For
 ordinary package work, prefer the live distro lane and repo state over a stale package table.

--- a/skills/routine-writer/SKILL.md
+++ b/skills/routine-writer/SKILL.md
@@ -17,7 +17,7 @@ Turn an unattended, repeatable task into a Claude Code routine: a saved prompt p
 
 **Why routines differ from chat prompts.** A routine runs as a full autonomous Claude Code cloud session. There is no permission-mode picker, no approval prompts, and no human to answer clarifying questions mid-run. A prompt that works fine in a conversation can stall or misfire silently inside a routine because the model has no one to ask. Every routine prompt must be self-contained, state its success criteria, and declare where output goes.
 
-**Research preview context** (May 2026 recheck): routines ship under the beta header `experimental-cc-routine-2026-04-01`. Behavior, limits, and the API surface can change. Pin any beta header references to that value and date so staleness is detectable.
+**Research preview context** (June 2026 recheck): routines ship under the beta header `experimental-cc-routine-2026-04-01`. Behavior, limits, and the API surface can change. Pin any beta header references to that value and date so staleness is detectable.
 
 ## When to use
 

--- a/skills/routine-writer/references/automation.md
+++ b/skills/routine-writer/references/automation.md
@@ -6,7 +6,7 @@ How to emit `/schedule` invocations, `/fire` curl templates, and GitHub Actions 
 
 ## What is automatable, and what is not
 
-The routines API surface, as of May 2026 recheck, is asymmetric:
+The routines API surface, as of June 2026 recheck, is asymmetric:
 
 | Action | Automatable? | How |
 |---|---|---|

--- a/skills/routine-writer/references/trigger-guide.md
+++ b/skills/routine-writer/references/trigger-guide.md
@@ -2,7 +2,7 @@
 
 Per-trigger specifics: cron rules, API fire semantics, GitHub event catalogue, filter fields, and how triggers combine.
 
-All details below reflect the research preview as of May 2026 recheck. The beta header is `experimental-cc-routine-2026-04-01`. Shapes, limits, and behavior can change; pin the beta header date so staleness is detectable.
+All details below reflect the research preview as of June 2026 recheck. The beta header is `experimental-cc-routine-2026-04-01`. Shapes, limits, and behavior can change; pin the beta header date so staleness is detectable.
 
 ---
 
@@ -60,7 +60,7 @@ The `routine_id` in the URL is prefixed `trig_`, not `routine_`. The full URL an
 | Header | Value |
 |---|---|
 | `Authorization` | `Bearer sk-ant-oat01-...` (per-routine token) |
-| `anthropic-beta` | `experimental-cc-routine-2026-04-01` (header dated 2026-04-01; verified May 2026) |
+| `anthropic-beta` | `experimental-cc-routine-2026-04-01` (header dated 2026-04-01; verified June 2026) |
 | `anthropic-version` | `2023-06-01` |
 | `Content-Type` | `application/json` (when body is present) |
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -17,11 +17,11 @@ Structured, multi-pass security audit. Combines automated tooling with manual pa
 
 Patterns drawn from real OSS incidents (unauthenticated admin endpoints, credential exfiltration, zip slip, auth bypass whitelists, Trivy supply chain compromise) and OpenSSF/SLSA/OWASP standards.
 
-**Target versions** (May 2026):
-- Semgrep 1.161.0, Bandit 1.9.4
-- Gitleaks 8.30.1, Betterleaks 1.1.1 (successor by same author), TruffleHog 3.95.2
-- Trivy 0.70.0 (0.69.4-0.69.6 was compromised - see known incidents; 0.70.x is the safe upgrade path)
-- OpenSSF Scorecard 5.1.0 (v6 in proposal stage)
+**Target versions** (June 2026):
+- Semgrep 1.166.0, Bandit 1.9.4
+- Gitleaks 8.30.1, Betterleaks 1.1.1 (successor by same author), TruffleHog 3.95.5
+- Trivy 0.71.0 (0.69.4-0.69.6 was compromised - see known incidents; upgrade past the 0.69.x window)
+- OpenSSF Scorecard 5.5.0 (v6 in proposal stage)
 - OWASP Top 10:2025 (confirmed January 2026), OWASP Agentic Top 10:2026 (released December 2025)
 
 **Scope**: TypeScript/JavaScript (Bun, Node.js, Deno), Python, Go, Rust web applications, CLI tools, Dockerfiles, Compose stacks, CI/CD workflows, Helm charts, Terraform, Proxmox/LXC configs, shell scripts. This skill is SAST + config + supply chain. Not DAST or network pentesting.

--- a/skills/skill-creator/references/conventions.md
+++ b/skills/skill-creator/references/conventions.md
@@ -16,7 +16,7 @@ when creating or reviewing skills to ensure consistency.
 7. AI Self-Check Patterns
 7.5. Diagnostic Skill Pitfalls
 8. Trigger Description Patterns
-9. Skill Inventory (May 2026)
+9. Skill Inventory (June 2026)
 
 ---
 
@@ -506,9 +506,9 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 
 ---
 
-## 9. Skill Inventory (May 2026)
+## 9. Skill Inventory (June 2026)
 
-### Published skills (42)
+### Published skills (44)
 
 | Skill | Effort | Date Added | Domain |
 |-------|--------|-----------|--------|
@@ -527,12 +527,14 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 | databases | high | 2026-03-24 | Database operations |
 | debian-ubuntu | high | 2026-04-22 | Debian / Ubuntu administration |
 | deep-audit | high | 2026-04-14 | Wave-based repo audit orchestrator |
+| deep-grill | high | 2026-06-13 | Plan stress-testing and red-team interrogation |
 | dev-cycle | high | 2026-04-14 | Start-to-finish development workflow |
 | docker | high | 2026-03-24 | Containers |
 | firewall-appliance | high | 2026-03-30 | OPNsense/pfSense firewall management |
 | frontend-design | high | 2026-04-26 | Opinionated UI/UX build and critique |
 | full-review | high | 2026-03-22 | Orchestrator (4 parallel audits) |
 | git | high | 2026-03-24 | Version control, multi-forge |
+| handoff | medium | 2026-06-13 | Session handoff document authoring |
 | jekyll-hyde | medium | 2026-04-28 | Dual-lens decision review |
 | kali-linux | high | 2026-04-22 | Kali Linux administration |
 | kubernetes | high | 2026-03-24 | K8s manifests, Helm, architecture |

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Write, review, and architect Terraform/OpenTofu infrastructure - from individual resources to multi-account, PCI-compliant platform architectures. The goal is reproducible, drift-free, auditable infrastructure that passes both peer review and QSA assessment.
 
-**Target versions** (May 2026): Terraform 1.14.9 (IBM/HashiCorp, BSL; 1.15.0-rc2 in progress), OpenTofu 1.11.6 (Linux Foundation, MPL). Helm provider v3.1+, K8s provider v3.0+, AWS provider v6.x, Azure v4.x, GCP v7.x.
+**Target versions** (June 2026): Terraform 1.15.6 (IBM/HashiCorp, BSL; 1.15.x GA, 1.16.0 in alpha), OpenTofu 1.12.2 (Linux Foundation, MPL; 1.11.9 still maintained). Helm provider v3.1+, K8s provider v3.0+, AWS provider v6.x, Azure v4.x, GCP v7.x.
 
 This skill covers HCL, modules, operations, state, CI/CD, policy-as-code, audit trails,
 PCI-DSS 4.0 controls, drift detection, and CDE isolation.

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -15,10 +15,10 @@ metadata:
 
 Write, structure, and maintain tests across unit, integration, E2E, accessibility, and performance layers. The goal is tests that catch regressions, document behavior, and run fast in CI - not tests that exist to inflate coverage numbers.
 
-**Target versions** (May 2026):
-- Vitest **4.1.2**, Jest **30.3.0**
-- Playwright **1.59.0**, Cypress **15.13.0**
-- pytest **9.0.2**, pytest-cov **7.1.0**
+**Target versions** (June 2026):
+- Vitest **4.1.8**, Jest **30.4.2**
+- Playwright **1.60.0**, Cypress **15.13.0**
+- pytest **9.1.0**, pytest-cov **7.1.0**
 - Go **1.26.1** (testing stdlib, `testing/synctest` GA)
 - Rust **1.94.1** (`cargo test`, cargo-nextest **0.9.132**)
 - Testing Library **16.3.2** (`@testing-library/react`)

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -18,15 +18,15 @@ setups to multi-node clusters with HA, live migration, and GPU passthrough. The 
 production-ready VM infrastructure with correct storage, memory, and CPU config that won't
 bite you at 3 AM.
 
-**Target versions** (verified May 2026):
+**Target versions** (verified June 2026):
 
 | Tool | Version | Release date | Notes |
 |------|---------|-------------|-------|
 | Proxmox VE | 9.1 | Nov 2025 | Debian 13.2 (trixie), kernel 6.17.2, QEMU 10.1.2 |
 | Proxmox Backup Server | 4.1 | Nov 2025 | Dedup, incremental, prune policies |
-| bpg/proxmox (Terraform) | 0.100.0 | Apr 2026 | Primary Proxmox IaC provider |
+| bpg/proxmox (Terraform) | 0.109.0 | Jun 2026 | Primary Proxmox IaC provider |
 | QEMU | 11.0.1 | Apr 2026 | Stable (11.0 series; GA Apr 22, 2026) |
-| libvirt | 12.0.0 | Jan 2026 | Hypervisor abstraction layer |
+| libvirt | 12.4.0 | Jun 2026 | Hypervisor abstraction layer |
 | XCP-ng | 8.3 LTS | Oct 2024 | Xen-based, LTS since Jun 2025, EOL Nov 2028 |
 | VMware ESXi | 8.0 U3i | Feb 2026 | Broadcom-owned, licensing upheaval |
 | VirtualBox | 7.2.6 | Jan 2026 | Dev/testing only |

--- a/skills/zero-day/SKILL.md
+++ b/skills/zero-day/SKILL.md
@@ -21,7 +21,7 @@ This is the *discovery* skill - it finds vulnerabilities nobody has catalogued y
 exploiting known weaknesses on live systems, use **lockpick**. For scanning code against known
 vulnerability patterns, use **security-audit**.
 
-**Target versions**: May 2026 snapshot. Read `references/target-versions.md` before
+**Target versions**: June 2026 snapshot. Read `references/target-versions.md` before
 pinning static analysis, reversing, fuzzing, or debugger tooling.
 
 ## When to use
@@ -465,7 +465,7 @@ and when to reach for each tool during source, binary, or live-system analysis.
 - `references/binary-analysis.md` - binary reverse engineering workflow, patch diffing, fuzzing harness development, dynamic analysis
 - `references/exploit-patterns.md` - proof-of-concept development templates by vulnerability class, with safety guidelines
 - `references/tooling-quick-reference.md` - tool catalog with install paths and best-fit usage notes
-- `references/target-versions.md` - May 2026 version snapshot for static analysis, reversing, fuzzing, and debugger tools
+- `references/target-versions.md` - June 2026 version snapshot for static analysis, reversing, fuzzing, and debugger tools
 
 ## Output Contract
 

--- a/skills/zero-day/references/target-versions.md
+++ b/skills/zero-day/references/target-versions.md
@@ -1,11 +1,11 @@
 # Zero-Day Target Versions
 
-May 2026 snapshot. Verified 2026-05-19 against GitHub release APIs and project release notes.
+June 2026 snapshot. Verified 2026-06-14 against GitHub release APIs and project release notes.
 Verify current releases before pinning.
 
-- CodeQL CLI: v2.25.4
-- Semgrep: v1.163.0
-- Joern: v4.0.540
-- Ghidra: 12.1
-- AFL++: v4.40c
-- Rizin: v0.8.2
+- CodeQL CLI: v2.25.6
+- Semgrep: v1.166.0
+- Joern: v4.0.557
+- Ghidra: 12.1.2
+- AFL++: v5.00c (5.x relicensed to AGPL-3.0; LLVM 23 support - review the license change before bundling)
+- Rizin: v0.8.2 (CVE-2026-22780 / mach0 heap overflow patched in 0.8.2)


### PR DESCRIPTION
Continues the in-progress freshness loop. Brings version/CVE snapshots current as of mid-June 2026 and advances the freshness-gate label from May to June 2026 so all 44 skills share one marker.

## Changes
- **ci-cd**: GitLab 19.0.2 (June 10 patch; 18.10 EOL note), Forgejo 15.0.3, Gitea 1.26.2, Woodpecker 3.15.0, cosign 3.1.1, Syft 1.45.1, Trivy 0.71.0 (pins synced across `supply-chain.md`, `github-actions.md`, `best-practices.md`)
- **security-audit**: Semgrep 1.166.0, TruffleHog 3.95.5, Scorecard 5.5.0, Trivy 0.71.0
- **backend-api**: FastAPI 0.136.3, NestJS 11.1.26
- **command-prompt**: Nushell 0.113.1 · **firewall-appliance**: OPNsense CE 26.1.9, CrowdSec 1.7.8 · **virtualization**: libvirt 12.4.0, bpg/proxmox 0.109.0
- **zero-day**: CodeQL 2.25.6, Joern 4.0.557, Ghidra 12.1.2, AFL++ 5.00c (now AGPL-3.0), Rizin 0.8.2 CVE note
- Fixed SKILL.md snapshot pointers (ai-ml, docker, ci-cd, zero-day) that lagged their already-June reference files
- README count 43/42 → 44; skill-creator inventory 42 → 44 (added **deep-grill**, **handoff**); inventory dated June 2026
- Offensive skills (zero-day) verified in-loop, not via web-research subagents

## Verification
- `validate-spec.sh`: 44 skills, 0 violations
- `lint-skills.sh`: 44 skills, 0 errors
- `check-freshness-dates.sh`: June 2026
- `check-contract-sync.sh`: OK · `check-deep-audit-coverage.sh`: 44/44 · no private leaks

Pre-existing warnings (kubernetes 503 lines, deep-audit 282-char description) left out of scope.