### PR TITLE
chore: gitignore disposable improve-skill audit plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ test.sh
 
 # Disposable agent handoff docs
 .handoff/
+
+# Disposable improve-skill audit plans
+plans/


### PR DESCRIPTION
Adds `plans/` to .gitignore so the improve-skill's local audit plans stay out of git, mirroring the existing `.handoff/` ignore. No code or behavior change.