### PR TITLE
feat(observability): add observability/SRE skill as deep-audit Wave 3 lens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-44 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
+45 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-open_standard-blue.svg)](https://agentskills.io)
@@ -23,7 +23,7 @@ AI coding tools used to mean prompts. Prompts don't compose, don't carry between
 
 Then Karpathy pointed an agent at a 630-line training script overnight. It edited the code, ran a 5-minute training, kept changes that improved the score, discarded the rest. 700 runs, 20 wins, on one GPU. The pattern works on anything you can score.
 
-This repo applies that pattern conservatively to 44 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
+This repo applies that pattern conservatively to 45 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
 
 ## The autoresearch loop
 
@@ -133,4 +133,4 @@ Skills are self-contained: each one references only files inside its own directo
 
 ---
 
-`kubernetes` `terraform` `docker` `ansible` `archlinux` `cachyos` `pacman` `paru` `aur` `systemd` `nixos` `nix` `flakes` `home-manager` `nix-darwin` `helm` `argocd` `ci-cd` `github-actions` `gitlab-ci` `postgresql` `mongodb` `mysql` `networking` `dns` `wireguard` `tailscale` `vpn` `nftables` `opnsense` `pfsense` `mcp` `model-context-protocol` `security-audit` `owasp` `pentesting` `code-slimming` `privilege-escalation` `ctf` `code-review` `git` `shell` `zsh` `bash` `prompt-engineering` `pci-dss` `compliance` `devops` `infrastructure-as-code` `iac` `containers` `podman` `buildah` `sealed-secrets` `haproxy` `caddy` `traefik` `nginx` `autoresearch` `self-improving` `llm` `rag` `embedding` `vector-store` `langchain` `langgraph` `openai-sdk` `anthropic-sdk` `agents` `fine-tuning` `ollama` `vllm` `promptfoo` `vitest` `jest` `playwright` `pytest` `tdd` `e2e` `accessibility` `axe-core` `load-testing` `k6` `proxmox` `qemu` `kvm` `libvirt` `packer` `cloud-init` `gpu-passthrough` `virtualization` `hypervisor`
+`kubernetes` `terraform` `docker` `ansible` `archlinux` `cachyos` `pacman` `paru` `aur` `systemd` `nixos` `nix` `flakes` `home-manager` `nix-darwin` `helm` `argocd` `ci-cd` `github-actions` `gitlab-ci` `postgresql` `mongodb` `mysql` `networking` `dns` `wireguard` `tailscale` `vpn` `nftables` `opnsense` `pfsense` `mcp` `model-context-protocol` `security-audit` `owasp` `pentesting` `code-slimming` `privilege-escalation` `ctf` `code-review` `git` `shell` `zsh` `bash` `prompt-engineering` `pci-dss` `compliance` `devops` `infrastructure-as-code` `iac` `containers` `podman` `buildah` `sealed-secrets` `haproxy` `caddy` `traefik` `nginx` `autoresearch` `self-improving` `llm` `rag` `embedding` `vector-store` `langchain` `langgraph` `openai-sdk` `anthropic-sdk` `agents` `fine-tuning` `ollama` `vllm` `promptfoo` `vitest` `jest` `playwright` `pytest` `tdd` `e2e` `accessibility` `axe-core` `load-testing` `k6` `proxmox` `qemu` `kvm` `libvirt` `packer` `cloud-init` `gpu-passthrough` `virtualization` `hypervisor` `observability` `prometheus` `opentelemetry` `grafana` `metrics` `tracing` `slo`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ That's it. For specific skills, alternative tools, the bundled installer, or sym
 
 ## What's in here
 
-44 skills covering infra (Kubernetes, Terraform, Docker, Ansible), cluster health diagnostics, distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review, code slimming, and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, plan interrogation and session handoff (deep-grill and handoff, inspired by Matt Pocock's grill-me and handoff skills), and meta-tooling (the skill creator, refiner, router, and full-review orchestrator).
+45 skills covering infra (Kubernetes, Terraform, Docker, Ansible), cluster health diagnostics, observability and SRE signal pipelines, distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review, code slimming, and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, plan interrogation and session handoff (deep-grill and handoff, inspired by Matt Pocock's grill-me and handoff skills), and meta-tooling (the skill creator, refiner, router, and full-review orchestrator).
 
 Browse [`skills/`](skills/) for the full list, or query it:
 

--- a/scripts/check-deep-audit-coverage.sh
+++ b/scripts/check-deep-audit-coverage.sh
@@ -31,6 +31,7 @@ wave_skills=(
   mcp
   networking
   nixos-btw
+  observability
   rhel-fedora
   roadmap
   security-audit

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deep-audit
 description: >
-  · Run an exhaustive 5-wave repo audit (every applicable lens, up to 29 agents), persist findings, generate phased tasks. Triggers: 'deep audit', 'comprehensive audit', 'full audit', 'mega review', 'deep review', 'audit report'. Not for a quick fixed 4-skill sweep (use full-review).
+  · Run an exhaustive 5-wave repo audit (every applicable lens, up to 30 agents), persist findings, generate phased tasks. Triggers: 'deep audit', 'comprehensive audit', 'full audit', 'mega review', 'deep review', 'audit report'. Not for a quick fixed 4-skill sweep (use full-review).
 license: MIT
 compatibility: "Requires iuliandita/skills collection installed. Subagent support strongly recommended. Optional: a brainstorming or ideation skill in the host harness (matched by name pattern) for large-audit planning handoff."
 metadata:
@@ -13,7 +13,7 @@ metadata:
 
 # Deep Audit: Wave-Based Repo Orchestrator
 
-Run up to 29 audit agents against a repo in 5 sequential waves. This is the broadest application-repo dispatch plan (4 Wave 2 + up to 20 conditional Wave 3 lenses + 2 Wave 4 + 3 Wave 5), not the total skill count. Wave 1 detects the tech stack, Waves 2-5 dispatch only matching audit skills, and each wave reports before the next begins.
+Run up to 30 audit agents against a repo in 5 sequential waves. This is the broadest application-repo dispatch plan (4 Wave 2 + up to 21 conditional Wave 3 lenses + 2 Wave 4 + 3 Wave 5), not the total skill count. Wave 1 detects the tech stack, Waves 2-5 dispatch only matching audit skills, and each wave reports before the next begins.
 
 The five waves are: Reconnaissance; Code Quality (code-review, anti-slop, anti-ai-prose,
 code-slimming); Domain-Specific (detected skills only); Security (security-audit then zero-day); and Docs & Hygiene (update-docs, roadmap, git).
@@ -107,7 +107,7 @@ If the user specified a scope, pass it as the script's first argument to filter 
 to that subtree (`git ls-files -- path/to/scope` instead of the full repo).
 
 After detection, present the recon summary before proceeding. Compute
-`{unmatched_skills}` as the 20 Wave 3 candidates minus the matched set.
+`{unmatched_skills}` as the 21 Wave 3 candidates minus the matched set.
 Compute `{count}` by summing: 4 (Wave 2) + matched Wave 3 skills + 2 (Wave 4) +
 3 (Wave 5). Example: if 6 Wave 3 skills match, count = 4 + 6 + 2 + 3 = 15. If the matched Wave 3 set is too broad for the user's goal, recommend a scoped deep-audit or **full-review** instead of pretending every lens is equally valuable.
 
@@ -141,7 +141,7 @@ Skills that will run:
 Total agents: {count}
 ```
 
-Concrete example for a Node+Postgres+Docker+K8s repo with i18n, frontend code, and GitHub Actions (9 Wave 3 skills matched out of 20):
+Concrete example for a Node+Postgres+Docker+K8s repo with i18n, frontend code, and GitHub Actions (9 Wave 3 skills matched out of 21):
 
 ```
 Repo: myorg/api @ a3f91c2 (main)  |  Files: 412  |  Scope: full codebase
@@ -149,7 +149,7 @@ Languages: TypeScript, SQL, YAML
 
 Wave 2 (always): code-review, anti-slop, anti-ai-prose, code-slimming
 Wave 3 (detected): testing, command-prompt, databases, backend-api, frontend-design, localize, docker, kubernetes, ci-cd
-Wave 3 (skipped): terraform, ansible, networking, ai-ml, mcp, arch-btw, debian-ubuntu, rhel-fedora, nixos-btw, firewall-appliance, virtualization
+Wave 3 (skipped): terraform, ansible, networking, observability, ai-ml, mcp, arch-btw, debian-ubuntu, rhel-fedora, nixos-btw, firewall-appliance, virtualization
 Wave 4 (always): security-audit, zero-day
 Wave 5 (always): update-docs, roadmap, git
 
@@ -231,13 +231,14 @@ Scope: {scope}. Return the complete report.
 | `frontend-design` | Audit frontend UI/UX implementation, visual hierarchy, accessibility, responsive behavior, framework drift, and AI design tells. Do not redesign or edit - report only. |
 | `localize` | Audit i18n completeness. Find hardcoded user-facing strings, validate locale catalogs, check for missing translations. |
 | `ci-cd` | Audit pipeline config for security (SHA pinning, secret exposure), efficiency, and correctness. |
+| `observability` | Audit signal coverage: uninstrumented services, missing SLOs/error budgets, alert anti-patterns, metric cardinality risk, broken trace/log correlation. Do not add instrumentation - report only. |
 
 All other skills use the generic prompt.
 
 Present results:
 
 ```markdown
-## Wave 3: Domain-Specific [{N} of 20 skills matched]
+## Wave 3: Domain-Specific [{N} of 21 skills matched]
 
 ### {Skill Display Name}
 {report verbatim}

--- a/skills/deep-audit/references/detection-patterns.md
+++ b/skills/deep-audit/references/detection-patterns.md
@@ -27,6 +27,7 @@ its domain isn't actually present.
 | ansible | `ansible.cfg`, `galaxy.yml`, `galaxy.yaml`, `roles/*/tasks/main.yml` | Also: `playbooks/*.yml` containing `hosts:`, or `requirements.yml` containing `roles:` or `collections:` |
 | ci-cd | `.github/workflows/*.yml`, `.github/workflows/*.yaml`, `.gitlab-ci.yml`, `.forgejo/workflows/`, `Jenkinsfile`, `.circleci/config.yml` | - |
 | networking | `nginx.conf`, `Caddyfile`, `haproxy.cfg`, `traefik.yml`, `traefik.yaml`, `traefik.toml`, `*.zone`, `named.conf`, `dnsmasq.conf`, `wg*.conf`, `nftables.conf` | - |
+| observability | `prometheus.yml`, `prometheus.yaml`, `*.rules.yml`, `*.rules.yaml`, `alertmanager.yml`, `alertmanager.yaml`, `otel-collector*.yaml`, `otelcol*.yaml`, `loki*.yaml`, `tempo*.yaml`, `grafana/provisioning/`, `grafana/dashboards/` | - |
 | arch-btw | `PKGBUILD`, `*.install`, `mkinitcpio.conf*`, `archinstall.json`, `etc/pacman.d/`, `etc/pacman.conf` | - |
 | debian-ubuntu | `debian/control`, `debian/changelog`, `debian/rules`, `debian/copyright`, `*.dsc`, `snapcraft.yaml`, `snap/snapcraft.yaml` | - |
 | rhel-fedora | `*.spec`, `.copr/`, `dracut.conf*`, `selinux/*.te`, `comps.xml*`, `dnf/modules.d/` | - |
@@ -109,6 +110,10 @@ echo "$files" | grep -qE '\.github/workflows/|\.gitlab-ci\.yml$|\.forgejo/workfl
 # networking
 echo "$files" | grep -qE 'nginx\.conf|Caddyfile|haproxy\.cfg|traefik\.(ya?ml|toml)|\.zone$|named\.conf|dnsmasq\.conf|wg[0-9]*\.conf$|nftables\.conf' \
   && matched+=(networking)
+
+# observability (Prometheus/Alertmanager/OTel/Loki/Tempo config, Grafana provisioning)
+echo "$files" | grep -qE '(^|/)prometheus\.ya?ml$|\.rules\.ya?ml$|(^|/)alertmanager\.ya?ml$|(^|/)otel-collector.*\.ya?ml$|(^|/)otelcol.*\.ya?ml$|(^|/)loki.*\.ya?ml$|(^|/)tempo.*\.ya?ml$|(^|/)grafana/(provisioning|dashboards)/' \
+  && matched+=(observability)
 
 # arch-btw
 echo "$files" | grep -qE '(^|/)PKGBUILD$|\.install$|(^|/)mkinitcpio\.conf|(^|/)archinstall\.json$|(^|/)etc/pacman\.(d/|conf)' \

--- a/skills/full-review/SKILL.md
+++ b/skills/full-review/SKILL.md
@@ -15,6 +15,8 @@ metadata:
 
 Run four independent audits in parallel and present each report separately. One command that catches bugs, slop, security issues, and stale docs across the entire codebase without invoking each skill manually.
 
+**This is the fast path.** Fixed four passes, predictable cost, fire-and-forget before a merge. When you need exhaustive coverage across every applicable lens (up to 30 agents, conditional domain waves, persisted findings, generated tasks), that is the deep path: use **deep-audit**. Full-review is the pre-merge reflex; deep-audit is the deliberate, heavyweight audit.
+
 The four audits:
 
 1. **Code Review** (`code-review` skill) - bugs, logic errors, edge cases, race conditions, resource leaks, convention violations. Uses confidence-based filtering (>= 80%), adversarial self-check, and evidence-based verification.
@@ -36,7 +38,7 @@ Each audit runs in its own parallel agent/subprocess with a fresh context window
 - Style/slop cleanup without the other audit passes - use **anti-slop**
 - A dedicated security review only - use **security-audit**
 - A documentation-only maintenance sweep - use **update-docs**
-- A comprehensive audit across all applicable lenses (up to 29 audit agents, including 20 conditional Wave 3 domain lenses) - use **deep-audit**
+- A comprehensive audit across all applicable lenses (up to 30 audit agents, including 21 conditional Wave 3 domain lenses) - use **deep-audit**
 - Auditing the skill collection for consistency or quality - use **skill-creator**
 - CI/CD pipeline design or pipeline-config review - use **ci-cd**
 

--- a/skills/observability/SKILL.md
+++ b/skills/observability/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: observability
+description: >
+  · Instrument and audit observability: metrics, traces, logs, alerts, SLOs, dashboards.
+  Triggers: 'observability', 'metrics', 'tracing', 'prometheus', 'opentelemetry', 'grafana',
+  'slo', 'alerting'. Not for live diagnostics (use cluster-health) or manifests (use
+  kubernetes).
+license: MIT
+compatibility: "Optional: prometheus, otelcol, grafana, promtool, amtool, jq"
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-06-14"
+  effort: high
+  argument_hint: "[service-or-stack]"
+---
+
+# Observability
+
+Design and audit the signals a running system emits so failures are visible before users report
+them. This skill builds the standing pipeline - instrumentation, metrics, traces, structured
+logs, alert rules, SLOs, and dashboards-as-code - and audits a repo for the gaps that leave a
+service blind. It produces config (exporters, recording/alerting rules, OTLP pipelines,
+dashboard JSON), so the AI Self-Check applies.
+
+**Target versions** (June 2026):
+- Prometheus: 3.12.0 (May 2026)
+- OpenTelemetry Collector: v0.154.0 (June 2026)
+- Grafana: 13.0.2 (June 2026)
+- Grafana Loki: 3.7.2 (May 2026)
+- Grafana Tempo: 3.0 (2026)
+- Alertmanager: 0.32.1 (April 2026)
+
+## When to use
+
+- Adding instrumentation to a service: metrics (Prometheus/OTLP), traces (OpenTelemetry), or
+  structured logs
+- Writing or reviewing alert rules, recording rules, and Alertmanager routing
+- Defining SLOs and error budgets, and the multi-burn-rate alerts that back them
+- Building dashboards as code (provisioned JSON, grafonnet/Grizzly)
+- Designing the signal collection layer: OTel Collector pipelines, exporters, scrape config
+- Auditing a repo for observability gaps: uninstrumented services, no SLOs, alert-fatigue
+  patterns, cardinality risks, logs with no trace correlation
+
+## When NOT to use
+
+- Checking whether a live cluster is healthy right now (point-in-time, read-only diagnostics) -
+  use **cluster-health**
+- Writing or reviewing Kubernetes manifests, Helm charts, or the Prometheus Operator CRDs as
+  K8s objects - use **kubernetes**
+- Wiring CI/CD pipelines (the skill defines what they should emit and gate on, not the pipeline
+  itself) - use **ci-cd**
+- Localizing an unknown-layer live failure once signals exist (consuming signals to find root
+  cause) - use **debug-triage**
+- Application security review or secret scanning in telemetry - use **security-audit**
+
+---
+
+## AI Self-Check
+
+AI tools produce the same observability mistakes. Before returning any generated instrumentation,
+rule, pipeline, or dashboard, verify:
+
+- [ ] **Metric cardinality bounded**: no unbounded label values (user IDs, request paths with IDs,
+  timestamps, full URLs) on metrics. High cardinality is the top cause of Prometheus OOM.
+- [ ] **Rules validated**: PromQL/alert rules pass `promtool check rules`; routing passes
+  `amtool config routes`. AI invents plausible-but-wrong PromQL functions and label matchers.
+- [ ] **Alerts are actionable**: every alert has `for:`, severity, a runbook link, and fires on
+  symptoms (SLO burn, user-facing error) not raw causes. No alert that a human cannot act on.
+- [ ] **SLO math is real**: error budget = `1 - SLO`; burn-rate alerts use multi-window
+  multi-burn-rate, not a single threshold. State the window and budget explicitly.
+- [ ] **Trace context propagated**: W3C `traceparent` propagation is configured end to end;
+  spans carry `service.name`. Logs include `trace_id`/`span_id` for correlation.
+- [ ] **No secrets in telemetry**: no tokens, auth headers, PII, or full request bodies in span
+  attributes, log fields, or metric labels.
+- [ ] **Versions and signals real**: exporter names, OTLP receiver/exporter names, PromQL
+  functions, and Grafana panel types verified against current docs - not assumed.
+- [ ] **Sampling intentional**: trace sampling rate is stated and justified (head vs tail), not
+  silently defaulted; 100% sampling on a hot path is flagged.
+
+---
+
+## Workflow
+
+### Step 1: Identify the signals and the questions
+
+Pin down what the system must answer before choosing tools. For each service: what does "broken"
+look like to a user, and which signal proves it? Map to the **golden signals** (latency, traffic,
+errors, saturation) or **RED** (rate, errors, duration) for request-driven services and **USE**
+(utilization, saturation, errors) for resources. Pick the minimum signal set that answers those
+questions - do not instrument everything because you can.
+
+### Step 2: Choose the collection path
+
+| Need | Default |
+|---|---|
+| Metrics | Prometheus scrape, or OTLP metrics through the OTel Collector to a Prometheus-compatible store |
+| Traces | OpenTelemetry SDK -> OTLP -> Collector -> Tempo (or vendor backend) |
+| Logs | Structured JSON -> agent (Alloy/Promtail/OTel) -> Loki |
+| Unified pipeline | OpenTelemetry Collector as the single ingest/route/transform layer |
+
+Prefer OTLP and the OTel Collector as the vendor-neutral seam: instrument once, re-route backends
+in config. Use direct Prometheus scrape where pull and existing exporters already fit.
+
+### Step 3: Instrument and configure
+
+- **Metrics**: use auto-instrumentation where it exists; add custom metrics only for
+  domain-specific questions. Keep labels low-cardinality. Add recording rules for expensive
+  queries that dashboards or alerts repeat.
+- **Traces**: enable context propagation, set `service.name` and resource attributes, choose a
+  sampling strategy (head sampling at the SDK, or tail sampling in the Collector for
+  error/latency-biased retention).
+- **Logs**: emit structured JSON, include `trace_id`/`span_id`, avoid logging what a metric
+  already counts.
+- **Alerts and SLOs**: write symptom-based alert rules, define SLOs with explicit windows, back
+  them with multi-window multi-burn-rate alerts, route by severity in Alertmanager.
+- **Dashboards**: keep them as code (provisioned JSON or grafonnet) so they are reviewable and
+  reproducible, not click-built.
+
+### Step 4: Validate
+
+- `promtool check config` / `promtool check rules` for Prometheus config and rules
+- `promtool test rules` for unit tests on alerting/recording rules against sample series
+- `otelcol validate --config` for Collector pipelines
+- `amtool config routes test` / `amtool check-config` for Alertmanager routing
+- Confirm a test signal traverses the full path (emit -> collect -> store -> query -> alert) on at
+  least one service before declaring coverage
+
+---
+
+## Signals reference
+
+### Metrics
+
+- Naming: `unit`-suffixed, base units (seconds, bytes), `_total` for counters. Follow Prometheus
+  and OpenTelemetry semantic conventions; do not invent metric names where a convention exists.
+- Cardinality is the budget. Series count = product of label-value sets. Keep label values bounded
+  and finite. Exemplars link a metric sample to a trace - enable them for latency histograms.
+- Recording rules precompute heavy expressions; alerting rules fire on conditions. Keep them in
+  version control and unit-test them with `promtool test rules`.
+
+### Traces
+
+- One trace = one request across services, stitched by propagated context. Without propagation you
+  get disconnected spans, not traces.
+- Sampling: head sampling is cheap and simple but blind to rare errors; tail sampling (in the
+  Collector) keeps error/slow traces at the cost of buffering. State which and why.
+- TraceQL queries Tempo; exemplars and `trace_id` in logs are the cross-signal jumps that make a
+  trace findable from a metric spike or a log line.
+
+### Logs
+
+- Structured over free text: JSON fields are queryable (LogQL), prose is grep-only. Include
+  `service`, `level`, `trace_id`, `span_id`, and a stable message key.
+- Logs are the most expensive signal per byte of insight. If a metric can answer it, count it;
+  reserve logs for the context a metric cannot carry.
+
+### Alerts and SLOs
+
+- An SLO is a target on an SLI (e.g. 99.9% of requests < 300ms over 30 days). Error budget is the
+  allowed failure: `1 - SLO`. Alert on **budget burn rate**, not on every breach.
+- Multi-window multi-burn-rate alerting (fast-burn + slow-burn windows) catches both acute
+  outages and slow erosion while suppressing flapping. A single static threshold does neither.
+- Alert hygiene: page only on user-impacting symptoms with a runbook; everything else is a ticket
+  or a dashboard. Alert fatigue is an outage you stop seeing.
+
+### Dashboards as code
+
+- Provision dashboards from version-controlled JSON or generate them with grafonnet/Grizzly. A
+  click-built dashboard is an undiffable, unreviewable, un-restorable artifact.
+
+---
+
+## Audit lens (Wave 3 in deep-audit)
+
+When auditing a repo for observability, report findings on:
+
+- **Coverage gaps**: services that emit no metrics/traces/logs; endpoints with no latency or error
+  signal; background jobs with no success/failure metric.
+- **No SLOs / no error budget**: alerting exists but is threshold-based with no SLO backing.
+- **Alert anti-patterns**: cause-based alerts with no `for:`, no runbook, no severity; duplicate or
+  flapping alerts; paging on non-actionable conditions.
+- **Cardinality risk**: unbounded labels (IDs, paths, emails) on metrics; high-cardinality log
+  fields used as metric labels.
+- **Broken correlation**: logs without `trace_id`; traces without `service.name`; metrics without
+  exemplars on key histograms.
+- **Untested rules**: alert/recording rules with no `promtool test rules` coverage.
+- **Drift risk**: dashboards stored as exported blobs nobody edits, or not in version control.
+
+Report only what the repo files show. Do not assume a running backend exists; flag "signal defined
+but no evidence it is collected" as a gap, not a pass.
+
+---
+
+## Related Skills
+
+- **cluster-health** - point-in-time, read-only Kubernetes diagnostics ("is it healthy now").
+  Observability builds the standing signal pipeline ("can we see it over time"). cluster-health
+  reads signals live; observability defines and audits them.
+- **kubernetes** - authors manifests, Helm, and Operator CRDs as K8s objects. Observability authors
+  the instrumentation, rules, and SLO/alert config those objects carry, platform-agnostic.
+- **debug-triage** - consumes signals to localize an unknown-layer live failure. Observability
+  produces the signals it consumes: producer vs consumer.
+- **ci-cd** - wires the pipeline. Observability defines what the pipeline should emit and gate on,
+  not the pipeline itself.
+- **security-audit** - reviews exploitable vulnerabilities and secret exposure. Observability flags
+  secrets-in-telemetry as a gap but does not replace a security review.
+
+## Rules
+
+1. **Cardinality is a hard budget.** Never put unbounded values (IDs, paths, emails, timestamps) in
+   metric labels. Bounded label sets only.
+2. **Validate before returning.** Run `promtool`, `otelcol validate`, and `amtool` on generated
+   config and rules; do not ship unverified PromQL or routing.
+3. **Alert on symptoms with runbooks.** Every alert is actionable, has `for:` and severity, and
+   links a runbook. No cause-only or non-actionable pages.
+4. **SLO-back the alerts.** Define SLOs with explicit windows and use multi-window multi-burn-rate
+   alerting, not single static thresholds.
+5. **Propagate context.** Configure W3C trace propagation, `service.name`, and `trace_id`/`span_id`
+   in logs so signals correlate.
+6. **No secrets in telemetry.** No tokens, PII, auth headers, or full bodies in labels, span
+   attributes, or log fields.
+7. **Dashboards as code.** Provision from version control; never treat a click-built dashboard as
+   the source of truth.
+8. **Run the AI Self-Check** before returning any generated instrumentation, rule, pipeline, or
+   dashboard.
+9. **Verify versions and signal names.** Confirm exporter/receiver names, PromQL functions, and
+   panel types against current docs; pin versions with dates.

--- a/skills/observability/SKILL.md
+++ b/skills/observability/SKILL.md
@@ -133,7 +133,9 @@ in config. Use direct Prometheus scrape where pull and existing exporters alread
 - Naming: `unit`-suffixed, base units (seconds, bytes), `_total` for counters. Follow Prometheus
   and OpenTelemetry semantic conventions; do not invent metric names where a convention exists.
 - Cardinality is the budget. Series count = product of label-value sets. Keep label values bounded
-  and finite. Exemplars link a metric sample to a trace - enable them for latency histograms.
+  and finite. Per-entity detail (user, request, order, full path) belongs on a trace attribute or
+  log field, never a metric label. Exemplars link a metric sample to a trace - enable them for
+  latency histograms.
 - Recording rules precompute heavy expressions; alerting rules fire on conditions. Keep them in
   version control and unit-test them with `promtool test rules`.
 
@@ -157,6 +159,11 @@ in config. Use direct Prometheus scrape where pull and existing exporters alread
 
 - An SLO is a target on an SLI (e.g. 99.9% of requests < 300ms over 30 days). Error budget is the
   allowed failure: `1 - SLO`. Alert on **budget burn rate**, not on every breach.
+- The burn-rate alert threshold is `burn_rate * (1 - SLO)` compared against the error-*ratio* SLI -
+  not the raw error rate against a bare multiplier (a common off-by-budget bug). Standard tiers for
+  a 99.9% SLO: fast-burn 14.4x (1h + 5m windows, page), slow-burn 6x (6h + 30m, page), erosion 3x
+  (24h + 2h, ticket). Both windows in a tier must breach together before the alert fires - express
+  as an `and`: `ratio_rate1h > 14.4*(1-SLO) and ratio_rate5m > 14.4*(1-SLO)`.
 - Multi-window multi-burn-rate alerting (fast-burn + slow-burn windows) catches both acute
   outages and slow erosion while suppressing flapping. A single static threshold does neither.
 - Alert hygiene: page only on user-impacting symptoms with a runbook; everything else is a ticket
@@ -166,6 +173,9 @@ in config. Use direct Prometheus scrape where pull and existing exporters alread
 
 - Provision dashboards from version-controlled JSON or generate them with grafonnet/Grizzly. A
   click-built dashboard is an undiffable, unreviewable, un-restorable artifact.
+- Committed-in-git is necessary but not sufficient: an *exported* JSON blob (regenerated on each
+  export, never hand-edited) still drifts from the running dashboard and diffs unreadably. The
+  source of truth is authored or generated config that flows file -> Grafana, not the reverse.
 
 ---
 
@@ -189,6 +199,15 @@ Report only what the repo files show. Do not assume a running backend exists; fl
 but no evidence it is collected" as a gap, not a pass.
 
 ---
+
+## Output Contract
+
+See `references/output-contract.md` for the full contract.
+
+- **Skill name:** OBSERVABILITY
+- **Deliverable bucket:** `audits`
+- **Mode:** conditional. When invoked to **audit a repo for observability gaps** (the Wave 3 lens), emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/observability/<YYYY-MM-DD>-<slug>.md`. When invoked to **build instrumentation, rules, pipelines, or dashboards**, respond freely without the contract.
+- **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit mode).
 
 ## Related Skills
 

--- a/skills/observability/SKILL.md
+++ b/skills/observability/SKILL.md
@@ -2,9 +2,8 @@
 name: observability
 description: >
   · Instrument and audit observability: metrics, traces, logs, alerts, SLOs, dashboards.
-  Triggers: 'observability', 'metrics', 'tracing', 'prometheus', 'opentelemetry', 'grafana',
-  'slo', 'alerting'. Not for live diagnostics (use cluster-health) or manifests (use
-  kubernetes).
+  Triggers: observability, metrics, tracing, prometheus, opentelemetry, grafana, slo. Not for
+  live diagnostics (cluster-health) or manifests (kubernetes).
 license: MIT
 compatibility: "Optional: prometheus, otelcol, grafana, promtool, amtool, jq"
 metadata:

--- a/skills/observability/references/output-contract.md
+++ b/skills/observability/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.


### PR DESCRIPTION
## What

Adds a new high-effort **observability** skill: instrument and audit running-system signals - metrics, traces, structured logs, alerts, SLOs/error budgets, and dashboards-as-code (Prometheus, OpenTelemetry, Grafana, Loki, Tempo, Alertmanager).

Outcome of a deep-grill on the collection that set a **curated-sharp** direction: the redundancy hunt found zero cuts, and observability was the one gap that cleared the "gaps tolerated" bar (daily-frequency, no current home, no upstream substitute).

## Registration (deep-audit Wave 3 audit lens)

- Detection patterns + script entry (Prometheus/Alertmanager/OTel/Loki/Tempo config, Grafana provisioning)
- Report-only dispatch override
- Added to the coverage gate's wave list
- Bumped documented dispatch counts: 29->30 agents, 20->21 Wave 3 lenses (deep-audit + full-review)
- README inventory 44->45 skills

## Boundaries (rule B - one line, no borrowing)

- **cluster-health**: standing signal pipeline vs point-in-time read-only diagnostics
- **kubernetes**: instrumentation/alert/SLO config vs manifests
- **debug-triage** (planned): produces signals vs consumes them
- **ci-cd**: what the pipeline emits/gates on vs the pipeline itself

## Verification

- validate-spec: PASS
- check-deep-audit-coverage: PASS (45 public skills, 30 wave, 15 excluded)
- contract-sync, freshness-dates, private-leak: PASS
- lint-skills: PASS (0 errors)
- detection pattern: 4/4 observability files match, 0 false positives
- Versions verified for June 2026 (Prometheus 3.12.0, OTel Collector v0.154.0, Grafana 13.0.2, Loki 3.7.2, Tempo 3.0, Alertmanager 0.32.1)