### PR TITLE
feat(debug-triage): add live-incident layer-localization skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ That's it. For specific skills, alternative tools, the bundled installer, or sym
 
 ## What's in here
 
-45 skills covering infra (Kubernetes, Terraform, Docker, Ansible), cluster health diagnostics, observability and SRE signal pipelines, distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review, code slimming, and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, plan interrogation and session handoff (deep-grill and handoff, inspired by Matt Pocock's grill-me and handoff skills), and meta-tooling (the skill creator, refiner, router, and full-review orchestrator).
+46 skills covering infra (Kubernetes, Terraform, Docker, Ansible), cluster health diagnostics, observability and SRE signal pipelines, live-incident triage, distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review, code slimming, and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, plan interrogation and session handoff (deep-grill and handoff, inspired by Matt Pocock's grill-me and handoff skills), and meta-tooling (the skill creator, refiner, router, and full-review orchestrator).
 
 Browse [`skills/`](skills/) for the full list, or query it:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-45 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
+46 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-open_standard-blue.svg)](https://agentskills.io)
@@ -23,7 +23,7 @@ AI coding tools used to mean prompts. Prompts don't compose, don't carry between
 
 Then Karpathy pointed an agent at a 630-line training script overnight. It edited the code, ran a 5-minute training, kept changes that improved the score, discarded the rest. 700 runs, 20 wins, on one GPU. The pattern works on anything you can score.
 
-This repo applies that pattern conservatively to 45 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
+This repo applies that pattern conservatively to 46 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
 
 ## The autoresearch loop
 
@@ -133,4 +133,4 @@ Skills are self-contained: each one references only files inside its own directo
 
 ---
 
-`kubernetes` `terraform` `docker` `ansible` `archlinux` `cachyos` `pacman` `paru` `aur` `systemd` `nixos` `nix` `flakes` `home-manager` `nix-darwin` `helm` `argocd` `ci-cd` `github-actions` `gitlab-ci` `postgresql` `mongodb` `mysql` `networking` `dns` `wireguard` `tailscale` `vpn` `nftables` `opnsense` `pfsense` `mcp` `model-context-protocol` `security-audit` `owasp` `pentesting` `code-slimming` `privilege-escalation` `ctf` `code-review` `git` `shell` `zsh` `bash` `prompt-engineering` `pci-dss` `compliance` `devops` `infrastructure-as-code` `iac` `containers` `podman` `buildah` `sealed-secrets` `haproxy` `caddy` `traefik` `nginx` `autoresearch` `self-improving` `llm` `rag` `embedding` `vector-store` `langchain` `langgraph` `openai-sdk` `anthropic-sdk` `agents` `fine-tuning` `ollama` `vllm` `promptfoo` `vitest` `jest` `playwright` `pytest` `tdd` `e2e` `accessibility` `axe-core` `load-testing` `k6` `proxmox` `qemu` `kvm` `libvirt` `packer` `cloud-init` `gpu-passthrough` `virtualization` `hypervisor` `observability` `prometheus` `opentelemetry` `grafana` `metrics` `tracing` `slo`
+`kubernetes` `terraform` `docker` `ansible` `archlinux` `cachyos` `pacman` `paru` `aur` `systemd` `nixos` `nix` `flakes` `home-manager` `nix-darwin` `helm` `argocd` `ci-cd` `github-actions` `gitlab-ci` `postgresql` `mongodb` `mysql` `networking` `dns` `wireguard` `tailscale` `vpn` `nftables` `opnsense` `pfsense` `mcp` `model-context-protocol` `security-audit` `owasp` `pentesting` `code-slimming` `privilege-escalation` `ctf` `code-review` `git` `shell` `zsh` `bash` `prompt-engineering` `pci-dss` `compliance` `devops` `infrastructure-as-code` `iac` `containers` `podman` `buildah` `sealed-secrets` `haproxy` `caddy` `traefik` `nginx` `autoresearch` `self-improving` `llm` `rag` `embedding` `vector-store` `langchain` `langgraph` `openai-sdk` `anthropic-sdk` `agents` `fine-tuning` `ollama` `vllm` `promptfoo` `vitest` `jest` `playwright` `pytest` `tdd` `e2e` `accessibility` `axe-core` `load-testing` `k6` `proxmox` `qemu` `kvm` `libvirt` `packer` `cloud-init` `gpu-passthrough` `virtualization` `hypervisor` `observability` `prometheus` `opentelemetry` `grafana` `metrics` `tracing` `slo` `debug-triage` `incident-response` `outage` `troubleshooting` `root-cause`

--- a/skills/debug-triage/SKILL.md
+++ b/skills/debug-triage/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: debug-triage
+description: >
+  · Triage a live incident across layers to localize an unknown failure, then route to the
+  domain skill. Triggers: 'incident', 'outage', 'triage', 'production down', 'crashloop',
+  '502', 'which layer'. Not for known-component app debugging (systematic-debugging) or repo
+  audits (use deep-audit).
+license: MIT
+compatibility: "Optional, stack-dependent: kubectl, dig, curl, openssl, ss, journalctl, jq"
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-06-14"
+  effort: high
+  argument_hint: "[symptom-or-service]"
+---
+
+# Debug Triage
+
+A live system is broken and you do not yet know which layer is at fault. This skill localizes the
+failure - narrows an unknown-layer outage to one layer with evidence - and then hands off to the
+skill that owns that layer. It does not fix; it finds where to look.
+
+It layers on top of the host harness's `systematic-debugging` skill: that skill is the root-cause
+method for one *known* component. Use this skill *first*, when the component is unknown, to decide
+which component `systematic-debugging` (or a domain skill) should then investigate. Triage
+localizes; the domain skill diagnoses; neither guesses a fix before the cause is found.
+
+## When to use
+
+- A live service is down or degraded and the failing layer is not yet known ("it's broken", "502s
+  started", "pods CrashLooping", "users report timeouts")
+- An outage spans multiple layers (DNS, network, ingress, app, data, secrets) and you need to find
+  which one before going deep
+- Post-deploy or post-change breakage where the blast radius is unclear
+- You are about to start guessing fixes - stop and localize first
+
+## When NOT to use
+
+- The failing component is already known and you need the root-cause method - use the host
+  `systematic-debugging` skill, then the matching domain skill
+- Auditing repo files for problems that are not a live incident - use **deep-audit** or **code-review**
+- Running the standing Kubernetes health checklist when you already know it is a cluster question -
+  use **cluster-health**
+- Building the signals you wish you had mid-incident - use **observability** (do that before the
+  next incident, not during this one)
+- A security incident with a suspected intrusion - triage the layer, then escalate to
+  **security-audit** and your incident-response process; this skill localizes, it does not contain
+
+---
+
+## AI Self-Check
+
+Diagnostic work fails in specific ways. Before reporting a localization or running checks, verify:
+
+- [ ] **No fix before localization.** The cause is identified with evidence before any change is
+  proposed. A guessed fix on an unknown layer is the failure mode this skill exists to prevent.
+- [ ] **Failure modes differentiated.** "Unreachable", "permission denied", and "not present" are
+  distinct findings with distinct next steps - never collapse them into "missing".
+- [ ] **No silent masking.** Diagnostic commands do not hide errors behind `2>/dev/null`. A failed
+  check surfaces its reason; an empty result is not read as "all clear".
+- [ ] **Cheapest discriminating check first.** Each step is chosen to *exclude* the most layers per
+  command, not to confirm a hunch. State what a pass and a fail each rule out.
+- [ ] **Evidence, not inference.** Each layer is excluded or implicated by an observed signal
+  (command output, metric, log line), not by assumption.
+- [ ] **Read-only by default.** Triage observes. Any state-changing command (restart, failover,
+  scale, flush) is called out as an action requiring explicit confirmation, not run silently.
+- [ ] **Handoff is explicit.** The output names the implicated layer, the evidence, and the exact
+  skill to route to next.
+
+---
+
+## Workflow
+
+Run the checks listed for the candidate layers. Do not improvise checks with assumed service names
+or paths; if a layer needs coverage not listed here, note it as a gap and ask, do not invent it.
+
+### Step 1: Scope the symptom
+
+Pin the observable failure before touching anything. Capture: what is failing (endpoint, job,
+user action), since when, what changed near that time (deploy, config, cert rotation, infra
+change), and the blast radius (one service, one node, one region, everything). A recent change is
+the strongest prior - check it first.
+
+### Step 2: Form layer hypotheses
+
+Map the symptom to candidate layers (see the layer map). A symptom usually implicates 2-4 layers,
+not one. List them; do not commit to a favorite.
+
+### Step 3: Run the cheapest discriminating check
+
+For the candidate layers, run the check that excludes the most layers per command (see the
+discriminating-signal table). After each result, drop the layers it rules out. Repeat until one
+layer remains. Report *why* each layer was excluded, with the evidence.
+
+### Step 4: Localize and hand off
+
+State the implicated layer, the evidence that localized it, and the skill that owns the next step.
+Do not cross into fixing - that is the domain skill's job, or `systematic-debugging`'s once the
+component is known.
+
+---
+
+## Layer map
+
+Work outside-in along the request path. Each layer is owned by a domain skill for the deep dive.
+
+| Layer | Typical symptom | Owner skill for the deep dive |
+|---|---|---|
+| DNS resolution | NXDOMAIN, wrong IP, intermittent name failures | **networking** |
+| Network / routing (L3-L4) | timeouts, no route, connection refused | **networking** |
+| TLS / certificates | cert expired, SAN mismatch, handshake failure | **networking** (or the distro/appliance skill) |
+| Load balancer / ingress | 502/503/504, backend not found, routing rule miss | **kubernetes** (ingress/Gateway) or **firewall-appliance** |
+| Service / pod | CrashLoopBackOff, OOMKilled, readiness failing | **kubernetes**, then **cluster-health** for the broad sweep |
+| App runtime | 500s, exceptions, deadlocks in one component | host `systematic-debugging`, then the language/domain skill |
+| Dependency (DB/cache/queue) | slow queries, connection pool exhaustion, broker lag | **databases** |
+| Secrets / auth chain | 401/403, token expired, Vault path unreachable | **security-audit**; trace the Vault->IaC->runtime chain |
+| Host / node | disk full, memory pressure, kernel/systemd unit down | the distro skill (**debian-ubuntu**, **rhel-fedora**, **arch-btw**, **nixos-btw**) |
+| Config / deploy (GitOps) | broke right after a sync; drift from desired state | **kubernetes** / **terraform**, check the last change |
+
+## Discriminating-signal table
+
+Pick the check that splits the candidate set fastest. These are starting points - adapt the
+service names and paths to the actual stack, and surface errors rather than masking them.
+
+| Question | Check (adapt to stack) | A pass rules out | A fail implicates |
+|---|---|---|---|
+| Does the name resolve? | `dig +short <host>` (or `getent hosts <host>`) | DNS | DNS / upstream resolver |
+| Is the port reachable? | `curl -sS -o /dev/null -w '%{http_code}' <url>`; `ss -tnp` | network/routing | network, LB, or the listener |
+| Is TLS valid? | `openssl s_client -connect <host:port> -servername <host> </dev/null` | TLS/cert | cert expiry / SAN / chain |
+| Is the pod actually up? | `kubectl get pods -o wide`; `kubectl describe pod` | service/pod | scheduling, image, probes, OOM |
+| Is the dependency answering? | dependency ping/health (e.g. `pg_isready`, broker health) | data layer | DB/cache/queue or its credentials |
+| Did something just change? | `kubectl rollout history` / git log of the manifests / deploy log | config/deploy | the last change (roll back to test) |
+| Is the host healthy? | `df -h`, `journalctl -p err -b`, unit status (surface errors) | host/node | disk, memory, a failed unit |
+
+Read metrics for what they measure, not what they seem to say (e.g. K8s HPA `targetCPU` is a
+percentage of the CPU *request*, not raw CPU; `df` is allocation, not live content). When a
+resource is on a schedule (backups, rotations), judge freshness against that schedule.
+
+## What NOT to do
+
+- Do not propose a fix before a layer is localized with evidence.
+- Do not run state-changing commands (restart, failover, scale, flush, apply) as part of triage;
+  name them as actions and get explicit confirmation.
+- Do not mask command failures with `2>/dev/null`; a failed check is a finding.
+- Do not invent service names, namespaces, or paths; if coverage is missing, ask.
+
+## Related Skills
+
+- **observability** - produces the metrics, traces, and logs triage reads. This skill consumes
+  those signals to localize; observability builds them. If a layer is dark mid-incident, that is an
+  observability gap to fix afterward.
+- **cluster-health** - the broad read-only Kubernetes checklist. Triage routes to it once the
+  symptom is localized to the cluster; cluster-health then sweeps node/workload/event/storage state.
+- **networking** - owns DNS, routing, TLS, and proxy deep dives once triage points there.
+- **databases** - owns the data-layer deep dive (slow queries, pools, replication) once implicated.
+- **security-audit** - owns the auth/secrets deep dive and exploitability; triage localizes a
+  401/403 or a broken Vault chain, security-audit investigates it.
+- **deep-audit** / **code-review** - operate on repo files, not a live incident. Triage is for a
+  running system that is currently broken.
+
+## Rules
+
+1. **Localize before fixing.** Identify the failing layer with evidence before proposing any
+   change. No guessed fixes on unknown layers.
+2. **One layer at a time, cheapest check first.** Choose each check to exclude the most layers per
+   command; drop ruled-out layers and state why.
+3. **Differentiate failure modes.** Unreachable, denied, and absent are different findings - never
+   collapse them.
+4. **Surface errors.** No `2>/dev/null` on diagnostic commands; an empty or failed result is
+   reported, not assumed benign.
+5. **Read-only by default.** Triage observes; any state-changing action is flagged for explicit
+   confirmation, never run silently.
+6. **Run listed checks, do not improvise.** Adapt names and paths to the stack; if a needed check
+   is not covered, note the gap and ask rather than inventing one.
+7. **Hand off explicitly.** Output the implicated layer, the evidence, and the exact skill (or
+   `systematic-debugging`) to continue with.
+8. **Run the AI Self-Check** before reporting a localization.

--- a/skills/debug-triage/SKILL.md
+++ b/skills/debug-triage/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: debug-triage
 description: >
-  · Triage a live incident across layers to localize an unknown failure, then route to the
-  domain skill. Triggers: 'incident', 'outage', 'triage', 'production down', 'crashloop',
-  '502', 'which layer'. Not for known-component app debugging (systematic-debugging) or repo
-  audits (use deep-audit).
+  · Triage a live incident to localize an unknown failing layer, then route. Triggers:
+  incident, outage, triage, production down, crashloop, 502. Not for known-component debugging
+  (systematic-debugging) or repo audits (deep-audit).
 license: MIT
 compatibility: "Optional, stack-dependent: kubectl, dig, curl, openssl, ss, journalctl, jq"
 metadata:

--- a/skills/debug-triage/SKILL.md
+++ b/skills/debug-triage/SKILL.md
@@ -5,7 +5,7 @@ description: >
   incident, outage, triage, production down, crashloop, 502. Not for known-component debugging
   (systematic-debugging) or repo audits (deep-audit).
 license: MIT
-compatibility: "Optional, stack-dependent: kubectl, dig, curl, openssl, ss, journalctl, jq"
+compatibility: "Optional, stack-dependent: kubectl, dig, curl, openssl, ss, journalctl, pg_isready, jq"
 metadata:
   source: iuliandita/skills
   date_added: "2026-06-14"
@@ -108,7 +108,7 @@ Work outside-in along the request path. Each layer is owned by a domain skill fo
 | DNS resolution | NXDOMAIN, wrong IP, intermittent name failures | **networking** |
 | Network / routing (L3-L4) | timeouts, no route, connection refused | **networking** |
 | TLS / certificates | cert expired, SAN mismatch, handshake failure | **networking** (or the distro/appliance skill) |
-| Load balancer / ingress | 502/503/504, backend not found, routing rule miss | **kubernetes** (ingress/Gateway) or **firewall-appliance** |
+| Load balancer / ingress | 502 (upstream sent an invalid/no reply), 503 (no healthy backend), 504 (upstream timed out) | **kubernetes** (ingress/Gateway) or **firewall-appliance** |
 | Service / pod | CrashLoopBackOff, OOMKilled, readiness failing | **kubernetes**, then **cluster-health** for the broad sweep |
 | App runtime | 500s, exceptions, deadlocks in one component | host `systematic-debugging`, then the language/domain skill |
 | Dependency (DB/cache/queue) | slow queries, connection pool exhaustion, broker lag | **databases** |
@@ -119,7 +119,12 @@ Work outside-in along the request path. Each layer is owned by a domain skill fo
 ## Discriminating-signal table
 
 Pick the check that splits the candidate set fastest. These are starting points - adapt the
-service names and paths to the actual stack, and surface errors rather than masking them.
+service names and paths to the actual stack, and surface errors rather than masking them. Run
+reachability checks from the right network vantage point - inside the cluster or namespace for
+ClusterIP services and split-horizon DNS, not from a laptop - or a wrong exclusion follows. For a
+*degraded* symptom (slow, no errors) the discriminators shift from up/down to fast/slow and
+which-fraction; see the last row - read its percentiles first (uniform vs tail vs one slow
+replica), then chase only the resource that split implicates.
 
 | Question | Check (adapt to stack) | A pass rules out | A fail implicates |
 |---|---|---|---|
@@ -127,9 +132,11 @@ service names and paths to the actual stack, and surface errors rather than mask
 | Is the port reachable? | `curl -sS -o /dev/null -w '%{http_code}' <url>`; `ss -tnp` | network/routing | network, LB, or the listener |
 | Is TLS valid? | `openssl s_client -connect <host:port> -servername <host> </dev/null` | TLS/cert | cert expiry / SAN / chain |
 | Is the pod actually up? | `kubectl get pods -o wide`; `kubectl describe pod` | service/pod | scheduling, image, probes, OOM |
+| Does the ingress have backends? | `kubectl get endpoints <svc>` (empty = nothing to route to) | ingress wiring | empty endpoints (selector mismatch or all pods unready) -> 502 |
 | Is the dependency answering? | dependency ping/health (e.g. `pg_isready`, broker health) | data layer | DB/cache/queue or its credentials |
 | Did something just change? | `kubectl rollout history` / git log of the manifests / deploy log | config/deploy | the last change (roll back to test) |
 | Is the host healthy? | `df -h`, `journalctl -p err -b`, unit status (surface errors) | host/node | disk, memory, a failed unit |
+| Slow, not down (no errors)? | latency percentiles per endpoint/pod (p50 vs p99); CPU throttle ratio; pool-wait (`pg_stat_activity`); cache hit/miss ratio | a flat, healthy distribution rules out saturation | tail latency or one slow replica: CPU throttle, pool exhaustion, slow query, cache-miss shift |
 
 Read metrics for what they measure, not what they seem to say (e.g. K8s HPA `targetCPU` is a
 percentage of the CPU *request*, not raw CPU; `df` is allocation, not live content). When a
@@ -142,6 +149,15 @@ resource is on a schedule (backups, rotations), judge freshness against that sch
   name them as actions and get explicit confirmation.
 - Do not mask command failures with `2>/dev/null`; a failed check is a finding.
 - Do not invent service names, namespaces, or paths; if coverage is missing, ask.
+
+## Output Contract
+
+See `references/output-contract.md` for the full contract.
+
+- **Skill name:** DEBUG-TRIAGE
+- **Deliverable bucket:** `audits`
+- **Mode:** conditional. Live triage is conversational - walk the layers, localize, and route inline without the contract. When invoked to **write up a triage or post-incident summary** as a durable artifact, emit the full contract - boxed inline header, per-layer detail in the deliverable file, boxed conclusion, conclusion table - and write it to `docs/local/audits/debug-triage/<YYYY-MM-DD>-<slug>.md`.
+- **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; used only in the written-summary mode).
 
 ## Related Skills
 

--- a/skills/debug-triage/references/output-contract.md
+++ b/skills/debug-triage/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/deep-audit/references/exclusions.md
+++ b/skills/deep-audit/references/exclusions.md
@@ -7,6 +7,7 @@ so future contributors do not re-add them by reflex.
 |---|---|
 | **browse** | Operational tool (fetch a page, fill a form). Not an audit lens. |
 | **cluster-health** | Live Kubernetes diagnostics. Requires an explicit cluster context and may load local protected overlays; repo-side K8s files are covered by kubernetes in Wave 3. |
+| **debug-triage** | Live-incident layer localization. Requires a running, broken system; observes runtime state and routes to a domain skill. Not a file-pattern audit lens. |
 | **dev-cycle** | Workflow orchestrator (start-to-finish dev: branch -> ship). Acts on the repo; does not audit it. |
 | **prompt-generator** | Creative authoring of LLM prompts. Produces content; does not evaluate code. |
 | **routine-writer** | Creative authoring of cloud-routine prompts. Same shape as prompt-generator. |


### PR DESCRIPTION
## What

Adds a high-effort **debug-triage** skill: when a live system is broken and the failing layer is unknown, localize the failure to one layer with evidence, then hand off to the domain skill that owns the deep dive.

Second of two additions from the curated-sharp deep-grill. Scoped as the *delta* over the host harness's `systematic-debugging` skill (root-cause method for a known component) - triage runs first, to find *which* component, then routes to systematic-debugging or a domain skill. Not a generic debugging skill (that would duplicate upstream).

## Contents

- Triage loop: scope symptom -> form layer hypotheses -> cheapest discriminating check -> localize -> hand off
- Layer map (DNS, network, TLS, LB/ingress, pod, app, dependency, secrets/auth chain, host, deploy) with the owner skill per layer
- Discriminating-signal table (which check rules out / implicates each layer)
- Diagnostic-pitfall discipline per conventions section 7.5: no fix before localization, failure-mode differentiation, no silent error masking, read-only by default

## Registration

- Added to `deep-audit/references/exclusions.md` - it acts on a running system and routes to domain skills, so it is not a file-pattern audit lens (mirrors cluster-health / dev-cycle)
- README inventory 45->46

## Boundaries (rule B)

- **observability**: consumes signals to localize vs produces them
- **cluster-health**: localizes the failing layer vs runs the k8s checklist once it is known to be the cluster
- host `systematic-debugging`: finds which component vs roots-causes a known one
- **deep-audit** / **code-review**: live incident vs repo files

## Verification

- validate-spec: PASS (0 violations)
- check-deep-audit-coverage: PASS (46 public skills, 30 wave, 16 excluded)
- contract-sync, freshness, private-leak: PASS
- lint-skills: PASS (0 errors)

> Stacked on #93 (observability). Retarget to main after #93 merges.