### PR TITLE
fix(code-slimming): reconcile inconsistencies (3-round skill-creator review)

### DIFF
--- a/.refiner-ledger.md
+++ b/.refiner-ledger.md
@@ -99,3 +99,34 @@ iter2 aggregate (40): avg ~95.9 | min 89.6 (testing) | max 100 (networking) | >=
 - virtualization: add 'xcp-ng' trigger; testing: add ci-cd to Related Skills
 - NOT touching: version pins (Go/Rust/Cypress/FastAPI/Next.js/Helm/Proxmox), argument_hint,
   always-on contract debate, skill-creator reverse-ref (immutable in phase 1)
+
+---
+
+# Run: skill-refiner/2026-06-19-223207 (targeted: code-slimming)
+
+Primary: claude-code, claude-opus-4-8 (1M). Secondary: codex (PONG PASS) -> cross-model at 5%.
+Config: iterations>=3 (min), no-ceiling, target=99, mode=circuit-breaker.
+Scope: polish the PR #100 "updated code-slimming" (branched off skill-creator/2026-06-19-code-slimming-review).
+Gate every iter: lint-skills.sh 0 err, validate-spec.sh 0 violations.
+Composite: baseline 0.42*A + 0.58*B; improvement iters 0.40*A + 0.55*B + 0.05*X.
+Test source: test-cases-local.md (code-slimming) + synthetic /tmp/slim-rf fixture (4 axes, 4 traps).
+NOTE: version/CVE/EOL owned by freshness routine -- not touched.
+
+| iter | change | G | A | B | X | composite |
+|------|--------|---|-----|-----|-----|-----------|
+| 1 | baseline | pass | 93 | 99 | - | 96.5 |
+| 2 | extract Common Patterns -> references/patterns.md (550->492) | pass | 100 | 98.5 | 100 | 99.2 |
+| 3 | dedupe When-to-use vs Step 4 (keywords kept; 492->491) | pass | 100 | 99 | 100 | 99.45 |
+
+code-slimming: 96.5 -> 99.45 (+2.95). Target 99 reached.
+Iter1 A=93 dragged solely by the 550-line soft-target miss; everything else passed (cross-refs
+valid, no internal contradictions, action-scale override intentional). Iter2 extraction cleared it
+to A=100 with zero signal loss (content relocated). Iter3 was a score-neutral simplicity dedup,
+kept because B held at ceiling (codex NO_FLAGS + behavioral re-test preserved all 4 false-positive
+traps: string-dispatch exportReport, public-API computeChecksum, defensive withAuth, dispatch layer).
+Terminated: target + plateau (A maxed, B at ceiling, no score-improving change remains).
+Phase 2 meta: skipped (single-skill targeted run, not a full-collection sweep).
+Recurring info (not actioned): shared output-contract Priority column (P0/info, width 10) sits
+awkwardly with this skill's Risk override (low/med/high) -- byte-identical across 45 skills, out of
+scope, documented in the skill.
+Commits: e2efea0 (iter2), 0cca4bd (iter3).

--- a/.refiner-runs.json
+++ b/.refiner-runs.json
@@ -2327,5 +2327,92 @@
       "PR #93 squash: 839928d",
       "PR #96 squash: e08b95d (debug-triage, was PR #94)"
     ]
+  },
+  {
+    "run_id": "2026-06-19-223207-code-slimming",
+    "branch": "skill-refiner/2026-06-19-223207",
+    "date": "2026-06-19",
+    "primary": {
+      "harness": "claude-code",
+      "model": "claude-opus-4-8",
+      "context": "1M",
+      "effort": "default"
+    },
+    "secondary": {
+      "harness": "codex",
+      "model": "codex (PONG smoke PASS)",
+      "weight": "5%",
+      "result": "NO_FLAGS on iter2 and iter3 diffs"
+    },
+    "config": {
+      "iterations_min": 3,
+      "ceiling": "none",
+      "threshold": "ignored (push to target)",
+      "target": 99,
+      "mode": "circuit-breaker"
+    },
+    "pool": [
+      "code-slimming"
+    ],
+    "scope": "targeted single-skill polish on the PR #100 'updated code-slimming' (branched off skill-creator/2026-06-19-code-slimming-review)",
+    "gate": "lint-skills.sh 0 err, validate-spec.sh 0 violations (all iters)",
+    "composite_formula": "baseline 0.42*A + 0.58*B; improvement iters 0.40*A + 0.55*B + 0.05*X",
+    "iterations": [
+      {
+        "n": 1,
+        "kind": "baseline",
+        "A": 93,
+        "B": 99,
+        "X": null,
+        "composite": 96.5,
+        "note": "A dragged solely by 550-line soft-target miss; B nailed all 4 false-positive traps; routing test clean"
+      },
+      {
+        "n": 2,
+        "kind": "improve",
+        "change": "extract Common Patterns (9 subsections) to references/patterns.md + pointer; SKILL.md 550->492",
+        "A": 100,
+        "B": 98.5,
+        "X": 100,
+        "composite": 99.2,
+        "gate": "kept",
+        "test": "behavioral re-test held; codex NO_FLAGS"
+      },
+      {
+        "n": 3,
+        "kind": "improve",
+        "change": "trim When-to-use sub-enumerations owned by Step 4 (keywords preserved); SKILL.md 492->491",
+        "A": 100,
+        "B": 99,
+        "X": 100,
+        "composite": 99.45,
+        "gate": "kept (simplicity: score-neutral dedup, B confirmed)",
+        "test": "both scenarios at ceiling; codex NO_FLAGS"
+      }
+    ],
+    "termination": "target reached (99.45 >= 99); A maxed, B at ceiling, no score-improving change remains (plateau)",
+    "score_before_after": {
+      "code-slimming": {
+        "before": 96.5,
+        "after": 99.45,
+        "delta": 2.95
+      }
+    },
+    "changes": [
+      "code-slimming: extract 9-pattern recall layer to references/patterns.md (loaded on demand)",
+      "code-slimming: dedupe When-to-use enumerations against Step 4 (all trigger keywords kept)"
+    ],
+    "test_source": "test-cases-local.md (code-slimming) + synthetic /tmp/slim-rf fixture exercising 4 axes and 4 false-positive traps",
+    "out_of_scope": [
+      "version pins / CVE / EOL (freshness routine owns)",
+      "phase 2 meta-improvement (full-collection sweep only; single-skill run)",
+      "shared output-contract Priority/Risk column awkwardness (byte-identical across 45 skills; documented override)"
+    ],
+    "reverted": [],
+    "contested": [],
+    "commits": [
+      "e2efea0 (iter2 extract)",
+      "0cca4bd (iter3 dedupe)"
+    ]
   }
 ]

--- a/skills/code-slimming/SKILL.md
+++ b/skills/code-slimming/SKILL.md
@@ -31,18 +31,17 @@ performance, readability, and validation made explicit.
 
 ## When to use
 
-- Finding opportunities to simplify a repository, package, module, or PR
-- Finding behavior-preserving refactor opportunities without implementing them
-- Hunting dead code: unused functions, methods, variables, parameters, imports, types, exports,
-  constants, unreachable branches, orphan files never imported, and unused dependencies
-- Auditing duplicated logic, classes, structs, helpers, types, schemas, handlers, or adapters
-- Finding redundant blocks repeated across the repo or inside a single file, including exact clones
+- Finding behavior-preserving opportunities to simplify a repository, package, module, or PR
+  without implementing them
+- Hunting dead code: unused functions, variables, imports, types, exports, unreachable branches,
+  orphan files, and unused dependencies (Step 4 enumerates the full set)
+- Auditing duplicated logic, schemas, handlers, or adapters, and redundant blocks repeated across
+  the repo or inside a single file, including exact clones
 - Trimming comment volume: commented-out code, comments that restate the code, and banner walls
-- Looking for safe centralization candidates before a cleanup/refactor PR
-- Reviewing a bot or human cleanup PR that claims to reduce code size
-- Ranking maintainability refactors by value, risk, and validation needs
-- Handling duplicate code only when the main goal is smaller behavior-preserving structure,
-  not general cleanliness or AI-slop detection
+- Finding safe centralization candidates before a cleanup/refactor PR, or reviewing a bot or human
+  cleanup PR that claims to reduce code size
+- Ranking maintainability refactors by value, risk, and validation needs, when the goal is smaller
+  behavior-preserving structure rather than general cleanliness or AI-slop detection
 
 ## When NOT to use
 
@@ -438,68 +437,10 @@ Keep the report concise. Show the refactor shape, not a lecture.
 
 ## Common Patterns
 
-### Dead code and unused symbols
-
-Functions, methods, variables, constants, types, and exports that nothing references are pure
-maintenance cost. So are unused imports, orphan files nothing imports, unreachable branches, and
-removed-flag code paths. The deletion is safe only once no-reference is proven. The recurring false
-positives are entry points reached through indirection (see the no-reference paths in Best Practices
-and Step 5); treat any of those as "not dead" until proven otherwise.
-
-### Exact and intra-file clones
-
-Copy-paste blocks repeated across files, or repeated within one file, collapse cleanly when they are
-truly identical and share one contract. Same-file repetition (a loop body pasted three times, two
-near-identical switch arms) is often the easiest and safest win because the call sites are all
-visible at once. Confirm the blocks are exact or differ only in clearly parameterizable values
-before proposing a single shared form.
-
-### Commented-out code and comment walls
-
-Commented-out code is dead code in disguise: version control already preserves it, so recommend
-deletion. Comment walls - ASCII banners, section dividers, and comments that restate the next line
-of code - add bytes without signal. Keep comments that carry intent (the why), invariants,
-non-obvious constraints, links to issues or specs, license headers, and lint/type pragmas. This is a
-deletion lane only; rewriting AI-voiced prose belongs to anti-ai-prose.
-
-### Repeated boundary parsing
-
-Request parsing, CLI argument normalization, env var parsing, and config loading often duplicate
-defaulting and validation rules. Centralize only when the same boundary contract really applies.
-
-### Near-twin adapters
-
-Provider/client/repository adapters often start identical and then diverge. Recommend
-centralization only when the shared part is stable and the provider-specific differences stay
-explicit.
-
-### Duplicate data shapes
-
-Repeated DTOs, schemas, records, structs, or interfaces can be centralized when they represent the
-same contract. Keep separate shapes when they describe different lifecycle stages or trust
-boundaries. Do not merge inbound untrusted request shapes, internal/domain shapes, persistence
-entities, queue/event payloads, and outbound response shapes merely because fields overlap. Shared
-field lists are not shared contracts; centralize only the truly common validated subset, or keep
-explicit mappers.
-
-### Wrapper layers
-
-Thin wrappers that only forward calls usually add concept count without value. Prefer deleting or
-inlining them unless they isolate an external dependency, provide a stable public contract, or make
-testing materially easier. Leave them alone when they enforce validation, auth/authorization,
-tenant isolation, retries, idempotency, transactions, caching, rate limits, logging, tracing,
-metrics, feature flags, compatibility shims, dependency inversion, or fault isolation.
-
-### Oversized helper modules
-
-Large `utils`, `helpers`, `common`, `shared`, or `misc` modules are often junk drawers. Recommend
-splitting by domain concern or moving helpers closer to their only caller.
-
-### Performance-sensitive slimming
-
-Shorter code can be slower. Centralized generic code can add allocation, dynamic dispatch, reflection,
-bundle weight, cache misses, or indirect calls. In hot paths, require measurement or classify as
-`Defer`.
+Pattern-by-pattern recognition aids - dead code and unused symbols, exact and intra-file clones,
+commented-out code and comment walls, repeated boundary parsing, near-twin adapters, duplicate data
+shapes, wrapper layers, oversized helper modules, and performance-sensitive slimming - live in
+`references/patterns.md`. Consult it when a candidate's category or safe-collapse shape is unclear.
 
 ## Output Contract
 

--- a/skills/code-slimming/SKILL.md
+++ b/skills/code-slimming/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-slimming
 description: >
-  · Audit read-only code slimming: dead code, unused files, duplicate blocks, wrapper removal, comment-wall trimming. Triggers: 'slim codebase', 'dead code', 'unused functions', 'dedupe safely'. Not for bugs, tests, or broad reviews.
+  · Audit read-only code slimming: dead code, unused files, duplicate blocks, wrapper removal, commented-out code. Triggers: 'slim codebase', 'dead code', 'unused functions', 'dedupe'. Not for bugs or broad reviews.
 license: MIT
 compatibility: "None - works on any codebase"
 metadata:
@@ -258,7 +258,7 @@ Discovery recipe:
 
    | Concern | Common language-agnostic or per-language tools |
    |---|---|
-   | Unused symbols/exports | `knip`, `ts-prune` (TS/JS); `vulture`, `ruff` F401/F841 (Python); `staticcheck`, `deadcode` (Go); `cargo` `dead_code` warnings (Rust); compiler `-Wunused` (C/C++) |
+   | Unused symbols/exports | `knip` (TS/JS; supersedes the archived `ts-prune`); `vulture`, `ruff` F401/F841 (Python); `staticcheck`, `deadcode` (Go); `cargo` `dead_code` warnings (Rust); compiler `-Wunused` (C/C++) |
    | Unused dependencies | `knip`, `depcheck` (JS); `deptry` (Python); `cargo-machete` (Rust) |
    | Copy-paste clones | `jscpd` (multi-language), `PMD CPD` (multi-language) |
 
@@ -332,6 +332,11 @@ before classifying it as `Do now`.
 It is acceptable and often correct to return zero high-value opportunities. Do not manufacture a
 slimming recommendation to fill the report. Prefer a well-justified `Leave alone` finding over a
 low-confidence abstraction.
+
+The markdown template below is the body of the written deliverable. Wrap it with the boxed inline
+header and boxed conclusion table from the Output Contract when emitting to the transcript; the
+conclusion table uses the column mapping noted in the Output Contract section (action in `Type`,
+`Risk` in the `Priority` column).
 
 Use this format:
 
@@ -497,6 +502,7 @@ See `references/output-contract.md` for the full contract.
 - **Mode:** always-on for audit and review invocations. Every invocation that analyses existing code emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table. For a quick factual question (e.g., "what is wrapper removal?") respond freely without the contract.
 - **Deliverable path:** `docs/local/audits/code-slimming/<YYYY-MM-DD>-<slug>.md`
 - **Severity scale:** not the shared P0-P3 scale. Findings are classified by action - `Do now | Do with tests | Defer | Leave alone` - plus a `Risk: low | medium | high` field per finding (see the Workflow). This skill proposes deletions, not severity-ranked defects.
+- **Conclusion-table columns** (the shared table in `references/output-contract.md` is code-review-flavored; map it for this skill): `Type` is `rec` for opportunities or `found` when reviewing removed code; the `Priority` column carries this skill's `Risk` value (`low | medium | high`), not a P-level; `Action` is `proposed` for opportunities and `recommend` for removed-code safety findings. The file-deliverable groups findings by action label (`Do now`, `Do with tests`, `Defer`, `Leave alone`), not by `## P0`-style headings.
 
 ## Related Skills
 

--- a/skills/code-slimming/SKILL.md
+++ b/skills/code-slimming/SKILL.md
@@ -48,7 +48,9 @@ performance, readability, and validation made explicit.
 
 - Bug-focused reviews, regressions, races, edge cases, or crashes - use **code-review**
 - General cleanup, naming, AI tells, dependency creep, overengineering, comment noise as a
-  quality smell, or duplicate-code-as-slop without an explicit slimming goal - use **anti-slop**
+  quality smell, or duplicate-code-as-slop without an explicit slimming goal - use **anti-slop**.
+  (Comment lane: code-slimming deletes commented-out code, restating comments, and banner walls;
+  anti-slop judges comment noise as a smell; anti-ai-prose rewrites AI-voiced comment text.)
 - Rewriting comments or docstrings for tone and AI voice (not deleting them) - use **anti-ai-prose**
 - Security vulnerabilities, secret scanning, auth flaws, or exploitability - use **security-audit**
 - Writing, debugging, or adding validation tests for a slimming recommendation - use **testing**
@@ -63,6 +65,7 @@ performance, readability, and validation made explicit.
 | "Slim this codebase", "find safe deletions", "review LOC deletion" | **code-slimming** |
 | "Find dead/unused code", "unused functions/files", "remove duplicates" | **code-slimming** |
 | "Delete commented-out code", "cut these comment walls down" | **code-slimming** |
+| "Remove this wrapper/indirection layer", "inline this passthrough" | **code-slimming** |
 | "Clean this up", "does this look AI-written?", "overengineered/verbose" | **anti-slop** |
 | "These comments are noisy/AI-slop, clean them up" | **anti-slop** |
 | "This prose/comments read AI-written, rewrite the voice" | **anti-ai-prose** |
@@ -91,10 +94,12 @@ Before returning a code-slimming audit, verify:
   without the proposed shape
 - [ ] **Duplication judged in context**: likely divergence, framework conventions, and explicitness
   were considered before recommending centralization
+- [ ] **Defensive duplication preserved**: repeated guards across trust, process, persistence, or
+  public-API boundaries were not flagged for removal solely because an upstream layer validates the
+  same condition
 - [ ] **Dead code proven, not guessed**: every "unused" claim cites a no-reference search and rules
-  out dynamic dispatch, reflection, DI/IoC wiring, serialization, plugin/CLI/route registration,
-  framework entry points, public/exported API, conditional compilation, build tooling, and
-  test-only or fixture use before recommending deletion
+  out reflection, dynamic dispatch, DI, serialization, plugin/CLI/route registration, public API,
+  conditional compilation, and test discovery before recommending deletion
 - [ ] **Comment trimming is deletion, not rewriting**: only commented-out code, comments that
   restate the code, and dead banner walls are flagged; tone and AI-voice rewrites are routed to
   anti-ai-prose, and load-bearing comments (why, invariants, links, license, lint pragmas) are kept
@@ -121,9 +126,9 @@ Before returning a code-slimming audit, verify:
 
 - Treat smaller code as a hypothesis, not a win.
 - Treat "unused" as a claim that must be proven by search, not assumed from local reading. A symbol
-  with zero static references can still be live through reflection, dynamic dispatch, DI containers,
-  serialization, plugin/CLI/route registration, framework conventions, public API, conditional
-  compilation, code generation, or test discovery. Prove no-reference before recommending deletion.
+  with zero static references can still be live through reflection, dynamic dispatch, DI,
+  serialization, plugin/CLI/route registration, public API, conditional compilation, or test
+  discovery. Prove no-reference before recommending deletion.
 - Keep dead-looking code that is a stable public/exported API, a documented extension point, or
   guarded behind a feature flag, build target, or platform; deleting these changes a contract.
 - Treat commented-out code as dead code: recommend deleting it, since version control already
@@ -333,10 +338,12 @@ It is acceptable and often correct to return zero high-value opportunities. Do n
 slimming recommendation to fill the report. Prefer a well-justified `Leave alone` finding over a
 low-confidence abstraction.
 
-The markdown template below is the body of the written deliverable. Wrap it with the boxed inline
-header and boxed conclusion table from the Output Contract when emitting to the transcript; the
-conclusion table uses the column mapping noted in the Output Contract section (action in `Type`,
-`Risk` in the `Priority` column).
+The markdown template below is the body of the written deliverable. It is a read-only set of
+proposals: it groups findings by action label and intentionally opts out of the checkbox Fix
+protocol in the Output Contract (there is nothing for an implementer to flip here). Wrap it with the
+boxed inline header and boxed conclusion table when emitting to the transcript; the conclusion table
+remaps the shared columns exactly as defined in the Output Contract section below (`Type` =
+`rec`/`found`, `Priority` carries `Risk`, `Action` = `proposed`/`recommend`).
 
 Use this format:
 
@@ -501,7 +508,7 @@ See `references/output-contract.md` for the full contract.
 - **Deliverable bucket:** `audits`
 - **Mode:** always-on for audit and review invocations. Every invocation that analyses existing code emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table. For a quick factual question (e.g., "what is wrapper removal?") respond freely without the contract.
 - **Deliverable path:** `docs/local/audits/code-slimming/<YYYY-MM-DD>-<slug>.md`
-- **Severity scale:** not the shared P0-P3 scale. Findings are classified by action - `Do now | Do with tests | Defer | Leave alone` - plus a `Risk: low | medium | high` field per finding (see the Workflow). This skill proposes deletions, not severity-ranked defects.
+- **Severity scale:** this skill overrides the shared P0-P3 scale, which the contract permits via its scale-migration note. Findings are classified by action - `Do now | Do with tests | Defer | Leave alone` - plus a `Risk: low | medium | high` field per finding (see the Workflow). This skill proposes deletions, not severity-ranked defects. Old -> new: P0-P3 priority is not used; `Risk` replaces the `Priority` column (see Conclusion-table columns below).
 - **Conclusion-table columns** (the shared table in `references/output-contract.md` is code-review-flavored; map it for this skill): `Type` is `rec` for opportunities or `found` when reviewing removed code; the `Priority` column carries this skill's `Risk` value (`low | medium | high`), not a P-level; `Action` is `proposed` for opportunities and `recommend` for removed-code safety findings. The file-deliverable groups findings by action label (`Do now`, `Do with tests`, `Defer`, `Leave alone`), not by `## P0`-style headings.
 
 ## Related Skills

--- a/skills/code-slimming/SKILL.md
+++ b/skills/code-slimming/SKILL.md
@@ -268,8 +268,9 @@ Discovery recipe:
    | Copy-paste clones | `jscpd` (multi-language), `PMD CPD` (multi-language) |
 
    Treat tool output as a candidate list, not a verdict: confirm each hit by reading, and discount
-   known false positives (reflection, DI, serialization, plugin/CLI/route registration, public API,
-   conditional compilation, test discovery). When no tooling is available, say so as a coverage gap.
+   known false positives (reflection, dynamic dispatch, DI, serialization, plugin/CLI/route
+   registration, public API, conditional compilation, test discovery). When no tooling is available,
+   say so as a coverage gap.
 4. For each candidate, read the full candidate files, at least one nearby caller, and nearby tests
    to see whether the behavior contract is already captured, before classifying.
 

--- a/skills/code-slimming/references/patterns.md
+++ b/skills/code-slimming/references/patterns.md
@@ -1,0 +1,68 @@
+# Code Slimming: Pattern Recognition Guide
+
+Pattern-by-pattern recognition aids for classifying a slimming candidate by its shape.
+Consult this when a candidate's category is unclear. The operational workflow,
+no-reference discipline, and rules live in `SKILL.md`; this file is the recall layer.
+
+## Dead code and unused symbols
+
+Functions, methods, variables, constants, types, and exports that nothing references are pure
+maintenance cost. So are unused imports, orphan files nothing imports, unreachable branches, and
+removed-flag code paths. The deletion is safe only once no-reference is proven. The recurring false
+positives are entry points reached through indirection (see the no-reference paths in SKILL.md Best
+Practices and Step 5); treat any of those as "not dead" until proven otherwise.
+
+## Exact and intra-file clones
+
+Copy-paste blocks repeated across files, or repeated within one file, collapse cleanly when they are
+truly identical and share one contract. Same-file repetition (a loop body pasted three times, two
+near-identical switch arms) is often the easiest and safest win because the call sites are all
+visible at once. Confirm the blocks are exact or differ only in clearly parameterizable values
+before proposing a single shared form.
+
+## Commented-out code and comment walls
+
+Commented-out code is dead code in disguise: version control already preserves it, so recommend
+deletion. Comment walls - ASCII banners, section dividers, and comments that restate the next line
+of code - add bytes without signal. Keep comments that carry intent (the why), invariants,
+non-obvious constraints, links to issues or specs, license headers, and lint/type pragmas. This is a
+deletion lane only; rewriting AI-voiced prose belongs to anti-ai-prose.
+
+## Repeated boundary parsing
+
+Request parsing, CLI argument normalization, env var parsing, and config loading often duplicate
+defaulting and validation rules. Centralize only when the same boundary contract really applies.
+
+## Near-twin adapters
+
+Provider/client/repository adapters often start identical and then diverge. Recommend
+centralization only when the shared part is stable and the provider-specific differences stay
+explicit.
+
+## Duplicate data shapes
+
+Repeated DTOs, schemas, records, structs, or interfaces can be centralized when they represent the
+same contract. Keep separate shapes when they describe different lifecycle stages or trust
+boundaries. Do not merge inbound untrusted request shapes, internal/domain shapes, persistence
+entities, queue/event payloads, and outbound response shapes merely because fields overlap. Shared
+field lists are not shared contracts; centralize only the truly common validated subset, or keep
+explicit mappers.
+
+## Wrapper layers
+
+Thin wrappers that only forward calls usually add concept count without value. Prefer deleting or
+inlining them unless they isolate an external dependency, provide a stable public contract, or make
+testing materially easier. Leave them alone when they enforce validation, auth/authorization,
+tenant isolation, retries, idempotency, transactions, caching, rate limits, logging, tracing,
+metrics, feature flags, compatibility shims, dependency inversion, or fault isolation.
+
+## Oversized helper modules
+
+Large `utils`, `helpers`, `common`, `shared`, or `misc` modules are often junk drawers. Recommend
+splitting by domain concern or moving helpers closer to their only caller.
+
+## Performance-sensitive slimming
+
+Shorter code can be slower. Centralized generic code can add allocation, dynamic dispatch, reflection,
+bundle weight, cache misses, or indirect calls. In hot paths, require measurement or classify as
+`Defer`.


### PR DESCRIPTION
Follow-up to #98. Ran the **skill-creator** skill (Mode 2 review) over the expanded code-slimming skill for **3 independent iterations**, fixing every inconsistency found. Iteration 3 came back clean (0 P0/P1/P2/P3).

## Iteration 1 findings -> fixes
- **P1** `ts-prune` is archived -> dropped as a live recommendation; note that `knip` supersedes it.
- **P2** Trigger keywords didn't cover all four axes -> description now names dead code, unused files, duplicate blocks, wrapper removal, commented-out code (213 chars, under the 240 warn).
- **P3** Shared conclusion-table is code-review-flavored (P0-P3) but this skill uses an action scale -> added an explicit column mapping (`Type`=`rec`/`found`, `Priority` carries `Risk`, `Action`=`proposed`/`recommend`).
- **P3** Step 7 template vs boxed Output Contract -> clarified the markdown is the deliverable body wrapped by the boxed surfaces.

## Iteration 2 findings -> fixes
- **P1** Iter-1 Step 7 note self-contradicted the mapping ("action in `Type`") -> corrected to defer to the authoritative mapping; deliverables marked as opting out of the checkbox Fix protocol (read-only proposals).
- **P1** Action scale framed as an explicit migration override of P0-P3 (per the shared contract's migration note).
- **P2** The no-reference indirection list diverged across occurrences -> unified to one canonical 8 (reflection, dynamic dispatch, DI, serialization, plugin/CLI/route registration, public API, conditional compilation, test discovery).
- **P2** Added a "Defensive duplication preserved" AI self-check item (was only in prose).
- **info** Added a wrapper-removal routing row; spelled out the comment delete/de-noise/rewrite three-way lane in When-NOT-to-use.
- Follow-up commit: aligned the last list (Step 4 caveat was missing "dynamic dispatch").

## Iteration 3
Clean. Only 2 info notes, both out of scope: the shared `references/output-contract.md` uses em dashes/arrows, but it is byte-identical across all 45 skills (a collection-wide file, not a per-skill fix).

## Validation
- `validate-spec.sh`: 0 violations. `lint-skills.sh`: 0 errors (one soft <500-line WARN at 550; same WARN kubernetes ships with).
- All 7 cross-referenced skills exist; all internal cross-refs resolve; tooling table verified.