### PR TITLE
feat(anti-ai-prose): add confident-filler, rhetorical-setup, and faux-profundity buckets

### DIFF
--- a/skills/.refiner-runs.json
+++ b/skills/.refiner-runs.json
@@ -223,5 +223,26 @@
     ],
     "lint_status": "PASSED 0/0",
     "spec_status": "PASSED 0/0"
-  }
+  },
+  {
+  "run_id": "2026-06-25-antiaiprose",
+  "branch": "skill-creator/2026-06-25-antiaiprose",
+  "date": "2026-06-25",
+  "primary": {"harness": "claude-code", "model": "claude-opus-4-8", "effort": "high"},
+  "secondary": {"harness": "none", "note": "same-model fresh-context review (subagents), weighted 3%"},
+  "config": {"iterations": 4, "threshold": 99, "mode": "single-skill", "plateau": 2},
+  "pool_size": 1,
+  "pool": ["anti-ai-prose"],
+  "excluded": ["skill-creator", "skill-refiner"],
+  "terminated": "target-reached",
+  "iterations_completed": 4,
+  "cross_model_flags": {"minor": 1, "major": 0, "contested": 0, "note": "minor verified+fixed in iter2"},
+  "scores": {
+   "before": {"anti-ai-prose": {"G": "pass", "A": 96, "B": 97, "X": 100, "composite": 96.7}},
+   "after": {"anti-ai-prose": {"G": "pass", "A": 99, "B": 99.5, "X": 100, "composite": 99.3}}
+  },
+  "scoring_note": "Targeted manual rubric (A42/B58 renormalized, fresh self-review X at 3%); behavioral run as fresh-context subagents on hand-written + 2 generated tests. Labeled estimates, not full automated sweep.",
+  "changes": "iter2: precise stop-slop attribution + count-once cross-ref (fixes README double-flag 13>11). iter3: broaden faux-profundity Detect to fragment family. iter4: reconcile confident-filler exception with short-text density rule (fixes false P1 on earned rhetorical question).",
+  "phase2": "not entered (single-skill scope; meta-improvement requires explicit human approval)"
+ }
 ]

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -347,7 +347,7 @@ LLMs punctuate with manufactured confidence and rhetorical scaffolding that anno
 **Detect:**
 - Emphasis crutches: `Full stop.`, `Period.` (as standalone emphasis), `let that sink in`, `make no mistake`, `here's why that matters`
 - Rhetorical setups: `What if...`, `Imagine...`, `Think about it:`, `Picture this`
-- Faux-profundity fragment: `<short sentence>. That's it.`
+- Faux-profundity fragment: a curt closer that asserts depth instead of earning it - `<short sentence>. That's it.`, `Simple as that.`, `Nothing more.`
 
 **Fix:** Cut the wrapper; make the claim carry its own weight. Density is the tell: one earned `that's it` is voice, three is a tic. Overlaps significance padding (`serves as a reminder that`) and scaffolding padding (`let's dive into`); when a phrase fits more than one bucket, count it once under the densest cluster, not in every bucket it touches.
 

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -17,7 +17,7 @@ Detect and fix the linguistic tells that make written English read as machine-ge
 
 This skill applies to any text: **documentation**, **READMEs**, **wikis** (Confluence, Notion, internal), **pull request descriptions**, **commit messages**, **release notes**, **blog posts**, **emails**, **slide copy**, **creative writing**, and **code comments / docstrings**. The vocabulary, syntax, tone, and formatting checks are language-domain, not platform-domain.
 
-Based in part on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) - a field guide compiled by editors who have read enormous volumes of LLM-generated text and know what it actually looks like.
+Based in part on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) - a field guide compiled by editors who have read enormous volumes of LLM-generated text and know what it actually looks like - and on [stop-slop](https://github.com/hardikpandya/stop-slop) (MIT), which contributed the confident-filler check: emphasis crutches, rhetorical setups, and the faux-profundity fragment.
 
 ## When to use
 
@@ -60,6 +60,7 @@ Before returning any audit, verify:
 - [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
 - [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Adverb stacking checked**: `-ly` adverb density scanned; passages with multiple adverb-modified speech tags or adjacent adverb clusters flagged at the same density threshold as vocabulary tells
+- [ ] **Confident filler checked**: emphasis crutches, rhetorical setups, and faux-profundity fragments flagged by pattern/density, not on isolated earned uses
 - [ ] **Overflagging avoided**: plain but valid technical prose is not labeled AI-written without concrete evidence
 - [ ] **Audience preserved**: edits keep the author's domain vocabulary, intent, and required formality
 
@@ -339,6 +340,17 @@ Phrases that wrap around the actual content without adding information. LLMs lea
 
 **Fix:** Cut the wrapper and keep the content. `It's worth noting that X` becomes `X`. `In this article, we'll explore Y` becomes a first sentence that is about Y.
 
+#### Confident filler and false emphasis
+
+LLMs punctuate with manufactured confidence and rhetorical scaffolding that announces insight instead of delivering it.
+
+**Detect:**
+- Emphasis crutches: `Full stop.`, `Period.` (as standalone emphasis), `let that sink in`, `make no mistake`, `here's why that matters`
+- Rhetorical setups: `What if...`, `Imagine...`, `Think about it:`, `Picture this`
+- Faux-profundity fragment: `<short sentence>. That's it.`
+
+**Fix:** Cut the wrapper; make the claim carry its own weight. Density is the tell: one earned `that's it` is voice, three is a tic. Overlaps significance padding (`serves as a reminder that`) and scaffolding padding (`let's dive into`); when a phrase fits more than one bucket, count it once under the densest cluster, not in every bucket it touches.
+
 #### "Despite its X, faces challenges"
 
 LLMs reach for a formula when asked to describe any organization or project: positives first, then a "however" paragraph listing challenges, often ending with a "future outlook" paragraph.
@@ -381,6 +393,7 @@ These look like AI tells but are not:
 - **Lists that are actually lists** - a three-item list is only suspicious if the items are padded. An enumeration of three real things is fine
 - **Bold where it signals a term or path** - bolding a defined term on first use is standard
 - **Em dashes in publications that require them** - some style guides (Chicago, AP) allow or require em dashes. The rule applies to your project's conventions
+- **A genuine rhetorical question or single hard fragment** - one "What if X?" that the piece actually answers, or one deliberate "That's it." landing a point, is voice. Flag the pattern (stacked setups, repeated faux-profundity fragments), not the isolated use.
 
 ### Counter-example (prose that looks AI but is fine)
 

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -393,7 +393,7 @@ These look like AI tells but are not:
 - **Lists that are actually lists** - a three-item list is only suspicious if the items are padded. An enumeration of three real things is fine
 - **Bold where it signals a term or path** - bolding a defined term on first use is standard
 - **Em dashes in publications that require them** - some style guides (Chicago, AP) allow or require em dashes. The rule applies to your project's conventions
-- **A genuine rhetorical question or single hard fragment** - one "What if X?" that the piece actually answers, or one deliberate "That's it." landing a point, is voice. Flag the pattern (stacked setups, repeated faux-profundity fragments), not the isolated use.
+- **A genuine rhetorical question or single hard fragment** - one "What if X?" that the piece actually answers, or one deliberate "That's it." landing a point, is voice. Flag the pattern (stacked setups, repeated faux-profundity fragments), not the isolated use. An earned single use is not a tell, so it does not count toward the short-text density threshold or escalate to P1 on its own - it is the stacking that carries the severity.
 
 ### Counter-example (prose that looks AI but is fine)
 


### PR DESCRIPTION
## Summary

Adds the three AI-tell buckets `anti-ai-prose` lacked, borrowed from
[stop-slop](https://github.com/hardikpandya/stop-slop) (MIT). The skill already
covered ~90% of stop-slop; this closes the remaining gap.

New `#### Confident filler and false emphasis` subsection (under Tonal Tells):
- **Emphasis crutches**: `Full stop.`, `Period.`, `let that sink in`, `make no mistake`, `here's why that matters`
- **Rhetorical setups**: `What if...`, `Imagine...`, `Think about it:`, `Picture this`
- **Faux-profundity fragment**: `That's it.`, `Simple as that.`, `Nothing more.`

Plus: a `What NOT to Flag` exception (single earned rhetorical question / fragment
is voice), a stop-slop attribution credit, and an AI Self-Check checkbox. Density-framed
and exception-aware to match house style; no scoring rubric, no blanket bans imported.

## Refinement

Polished via skill-creator review + 4 skill-refiner iterations (composite 96.7 -> 99.3),
each gated by fresh-context behavioral tests and adversarial cross-review:
- iter2: count-once cross-ref to significance/scaffolding padding (fixed a README double-flag)
- iter3: broadened faux-profundity Detect to the fragment family
- iter4: reconciled the exception with the short-text density rule (fixed a false P1 on an earned rhetorical question)

## Test plan

- `lint-skills.sh`: PASSED (0 errors)
- `validate-spec.sh`: PASSED (0 spec violations)
- `test-install.sh`: install tests passed
- Behavioral: positive cases flag the new buckets; domain false-positive and earned-single-use negative cases correctly restrained
