### PR TITLE
fix(skills): refresh July versions and advisories

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,7 +93,7 @@ pre-commit install --hook-type pre-commit --hook-type pre-push
 
 The hooks enforce that `skills/cluster-health/protected/` remains ignored and untracked, and they scan public files for protected private patterns when the local overlay is present.
 
-They also check freshness markers in public skills. Lines that claim currentness, such as `Target versions`, `verified <month year>`, `recheck`, `snapshot`, or `as of <month year>`, must use the current collection label. Override the expected label during a refresh with `SKILLS_FRESHNESS_LABEL="June 2026" ./scripts/check-freshness-dates.sh`.
+They also check freshness markers in public skills. Lines that claim currentness, such as `Target versions`, `Reviewed`, `Updated for`, `verified <month year>`, `recheck`, `snapshot`, or `as of <month year>`, must use the current collection label. Override the expected label during a refresh with `SKILLS_FRESHNESS_LABEL="July 2026" ./scripts/check-freshness-dates.sh`.
 
 ### Manual
 

--- a/scripts/check-freshness-dates.sh
+++ b/scripts/check-freshness-dates.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-FRESHNESS_LABEL="${SKILLS_FRESHNESS_LABEL:-June 2026}"
+FRESHNESS_LABEL="${SKILLS_FRESHNESS_LABEL:-July 2026}"
 
 mapfile -t files < <(
   git -C "$ROOT" ls-files \
@@ -12,8 +12,8 @@ mapfile -t files < <(
 
 errors=0
 
-stale_claim_re='(as of|verified|recheck|snapshot|current as of|Pinned to|Research preview context|Key facts \(|Skill Inventory \(|Target versions|Versions worth pinning)'
-freshness_line_re='(^\*\*Target versions|^\*\*Versions worth pinning|^#+ .*Target versions|^#+ .*Versions worth pinning|Research preview context|Key facts \([A-Z][a-z]+ 20[0-9]{2}\)|Skill Inventory \([A-Z][a-z]+ 20[0-9]{2}\)|current as of|as of [A-Z][a-z]+ 20[0-9]{2}|verified [A-Z][a-z]+ 20[0-9]{2}|[A-Z][a-z]+ 20[0-9]{2} recheck|[A-Z][a-z]+ 20[0-9]{2} snapshot|Pinned to [A-Z][a-z]+ 20[0-9]{2})'
+stale_claim_re='(as of|verified|recheck|snapshot|current as of|Pinned to|Reviewed|Updated for|Research preview context|Key facts \(|Skill Inventory \(|Target versions|Versions worth pinning)'
+freshness_line_re='(^\*\*Target versions|^\*\*Versions worth pinning|^#+ .*Target versions|^#+ .*Versions worth pinning|Reviewed [A-Z][a-z]+ 20[0-9]{2}|Updated for .*[A-Z][a-z]+ 20[0-9]{2}|Research preview context|Key facts \([A-Z][a-z]+ 20[0-9]{2}\)|Skill Inventory \([A-Z][a-z]+ 20[0-9]{2}\)|current as of|as of [A-Z][a-z]+ 20[0-9]{2}|verified [A-Z][a-z]+ 20[0-9]{2}|[A-Z][a-z]+ 20[0-9]{2} recheck|[A-Z][a-z]+ 20[0-9]{2} snapshot|Pinned to [A-Z][a-z]+ 20[0-9]{2})'
 
 for file in "${files[@]}"; do
   path="$ROOT/$file"

--- a/skills/ai-ml/SKILL.md
+++ b/skills/ai-ml/SKILL.md
@@ -17,7 +17,7 @@ Build, review, and architect applications that use AI models - from single-API c
 multi-agent systems with RAG pipelines. The goal is production-grade AI apps that are reliable,
 cost-effective, and don't hallucinate their way into an incident.
 
-**Target versions**: June 2026 snapshot. Read `references/target-versions.md` before
+**Target versions**: July 2026 snapshot. Read `references/target-versions.md` before
 pinning model IDs (Claude/OpenAI families), SDKs, runtimes, vector stores, or evaluation tools.
 
 ## When to use
@@ -435,7 +435,7 @@ PII detection setup, and content policy implementation.
 - `references/fine-tuning.md` - data prep, PEFT/LoRA, training evaluation, full vs parameter-efficient methods
 - `references/local-inference.md` - quantization, model selection, GPU memory, production serving config
 - `references/safety.md` - prompt injection defense, output validation, PII handling, content filtering, audit logging
-- `references/target-versions.md` - June 2026 snapshot: Claude/OpenAI model families, AI SDKs, runtimes, vector stores, and eval tools
+- `references/target-versions.md` - July 2026 snapshot: Claude/OpenAI model families, AI SDKs, runtimes, vector stores, and eval tools
 
 ## Output Contract
 

--- a/skills/ai-ml/references/target-versions.md
+++ b/skills/ai-ml/references/target-versions.md
@@ -1,24 +1,26 @@
 # AI/ML Target Versions
 
-June 2026 snapshot. Verified 2026-06-14 against PyPI, npm, and upstream GitHub release APIs.
+July 2026 snapshot. Verified 2026-07-22 against provider docs, PyPI, npm, GitHub releases,
+and GitHub Security Advisories.
 Verify current releases before pinning.
 
 ## Model families
 
 Model IDs move faster than SDK versions and are not covered by routine minor-version bumps.
-Verify against provider docs before pinning. Current as of June 2026:
+Verify against provider docs before pinning. Current as of July 2026:
 
 | Provider | Tier | Model ID | Notes |
 |----------|------|----------|-------|
 | Anthropic | Frontier | `claude-fable-5` | Most capable public model: SWE, vision, research, autonomy. Blocks high-risk domains, falls back to Opus 4.8 (GA 2026-06-09) |
 | Anthropic | Flagship | `claude-opus-4-8` | Most capable: complex reasoning, long-horizon agentic coding (GA 2026-05-28) |
-| Anthropic | Balanced | `claude-sonnet-4-6` | Default coding model. 4.6+ dropped dated snapshots: the bare ID IS the pinned snapshot |
+| Anthropic | Balanced | `claude-sonnet-5` | Current speed/intelligence balance. 4.6+ dropped dated snapshots: the bare ID IS the pinned snapshot |
 | Anthropic | Fast | `claude-haiku-4-5` | Low cost/latency. Dated snapshot: `claude-haiku-4-5-20251001` |
-| OpenAI | Flagship | `gpt-5.5` | Current frontier chat model; recommended replacement for `gpt-4o` |
-| OpenAI | Cost tier | `gpt-5.4-mini`, `gpt-5.4-nano` | Smaller/cheaper tiers |
+| OpenAI | Flagship | `gpt-5.6-sol` | Complex reasoning and coding; `gpt-5.6` is its alias |
+| OpenAI | Balanced | `gpt-5.6-terra` | Balance intelligence and cost |
+| OpenAI | Cost tier | `gpt-5.6-luna` | Cost-sensitive, high-volume workloads |
 
-`gpt-4o` is retired from ChatGPT (2026-02-13) but still API-available; new code should default to
-`gpt-5.5`. Do not append a dated suffix to Claude 4.6+ IDs - the bare ID is the snapshot, and a
+`gpt-4o` is retired from ChatGPT (2026-02-13) but still API-available; new code should select the
+appropriate GPT-5.6 tier. Do not append a dated suffix to Claude 4.6+ IDs - the bare ID is the snapshot, and a
 guessed suffix like `claude-sonnet-4-6-20250514` is invalid (that date belonged to the original
 Sonnet 4) and returns a 404.
 
@@ -26,20 +28,20 @@ Sonnet 4) and returns a 404.
 
 | Component | Version | Notes |
 |-----------|---------|-------|
-| Anthropic Python SDK | 0.109.1 | Claude models, streaming, tool use, structured output |
-| Anthropic TS SDK | 0.104.1 | Same capabilities, TypeScript-first |
-| Claude Agent SDK (TS) | 0.3.177 | Programmatic agent building with Claude Code capabilities |
-| OpenAI Python SDK | 2.41.1 | GPT/o-series models, Responses API |
-| OpenAI Agents SDK | 0.17.5 | Multi-agent orchestration, tracing, sessions |
-| Vercel AI SDK | 6.0.205 | Unified provider interface, ToolLoopAgent, streaming |
-| LangChain | 1.3.9 | Orchestration framework |
-| LangGraph | 1.2.5 | Stateful agent graphs, cycles, persistence |
-| LlamaIndex | 0.14.22 | RAG framework, 300+ integrations |
-| Transformers | 5.12.0 | Model inference, fine-tuning, PyTorch 2.4+ required |
-| vLLM | 0.23.0 | High-throughput serving, continuous batching |
-| Ollama | 0.30.7 | Local inference, MLX backend on Apple Silicon |
-| pgvector | 0.8.2 | PostgreSQL extension, HNSW + IVFFlat |
-| Qdrant | 1.18.2 | Self-hosted vector DB, hybrid search |
+| Anthropic Python SDK | 0.117.1 | Claude models, streaming, tool use, structured output |
+| Anthropic TS SDK | 0.112.5 | Same capabilities, TypeScript-first |
+| Claude Agent SDK (TS) | 0.3.217 | Programmatic agent building with Claude Code capabilities |
+| OpenAI Python SDK | 2.46.0 | GPT-5.6 models, Responses API |
+| OpenAI Agents SDK | 0.18.3 | Multi-agent orchestration, tracing, sessions |
+| Vercel AI SDK | 7.0.34 | Major: Node.js 22+ and ESM required; agents, workflows, telemetry, multimodal APIs |
+| LangChain | 1.3.14 | Orchestration framework |
+| LangGraph | 1.2.9 | Stateful agent graphs, cycles, persistence |
+| LlamaIndex | 0.14.23 | RAG framework, 300+ integrations |
+| Transformers | 5.14.1 | Model inference, fine-tuning, PyTorch 2.4+ required |
+| vLLM | 0.25.1 | Upgrade from 0.23.x for June/July 2026 DoS, ReDoS, and multi-tenant memory-disclosure fixes |
+| Ollama | 0.32.1 | CVE-2026-65315 has no fixed-version range yet; keep current and do not trust unreviewed GGUF files |
+| pgvector | 0.8.5 | PostgreSQL extension, HNSW + IVFFlat |
+| Qdrant | 1.18.3 | Self-hosted vector DB, hybrid search |
 | Pinecone (Python) | 9.1.0 | Managed vector DB |
 | ChromaDB | 1.5.9 | Lightweight vector DB, local-first |
-| promptfoo | 0.121.15 | LLM eval framework, red teaming |
+| promptfoo | 0.121.19 | LLM eval framework, red teaming |

--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -15,11 +15,11 @@ metadata:
 
 Write, review, and architect Ansible automation - from single playbooks to multi-tier, compliance-hardened infrastructure management. The goal is idempotent, auditable, maintainable automation that works the same locally and in CI/CD.
 
-**Target versions** (June 2026):
-- ansible-core **2.21.x** (current stable, Python 3.12+ controller, 3.9+ target, EOL Nov 2027); 2.20.x still maintained (2.20.6, EOL May 2027)
-- ansible (community package) 14.x (depends on ansible-core 2.21)
-- molecule 26.x (CalVer), ansible-lint 26.x (CalVer), ansible-navigator 26.x (CalVer)
-- ansible-builder 3.1.x (EE definition v3)
+**Target versions** (July 2026):
+- ansible-core **2.21.2** (current stable, Python 3.12+ controller, 3.9+ target, EOL Nov 2027); 2.20.x remains maintained through May 2027
+- ansible (community package) **14.2.0** (depends on ansible-core 2.21)
+- molecule **26.6.0**, ansible-lint **26.6.0**, ansible-navigator **26.6.0** (CalVer)
+- ansible-builder **3.1.1** (EE definition v3)
 - AWX 24.6.1 (last formal release Jul 2024; upstream AWX releases paused for a major refactor, devel branch active - track ansible/awx; awx-operator ~2.19.x still ships for K8s deploys). Verify current AWX/AAP release status before recommending a specific version or install path.
 - AAP 2.7 (GA June 3, 2026 - containerized/Operator only; 2.6 was the last RPM-installable release, still patched)
 

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -467,8 +467,6 @@ Report:
 - Down from 48 words to 22, with concrete claims instead of posture
 ```
 
----
-
 ## Output Contract
 
 See `references/output-contract.md` for the full contract.

--- a/skills/arch-btw/SKILL.md
+++ b/skills/arch-btw/SKILL.md
@@ -17,23 +17,23 @@ Administer Arch Linux and Arch-style systems without falling into rolling-releas
 Focus on vanilla Arch first, then layer in CachyOS behavior, `paru` workflow, systemd-native
 service management, boot recovery, kernel handling, and derivative-specific cautions.
 
-**Versions worth pinning** (June 2026):
+**Versions worth pinning** (July 2026):
 
 Only pin versions here when they materially affect compatibility or troubleshooting shape. For
 ordinary rolling packages, prefer the current repo state over stale version tables.
 
 | Component | Version | Why it matters |
 |-----------|---------|----------------|
-| systemd | 260.1-1 | boot and session behavior |
-| mkinitcpio | 40-5 | initramfs pipeline changed enough to matter |
-| dracut | 110-2 | alternative initramfs pipeline with different expectations |
-| linux-cachyos | 6.19.10-1 | kernel and module compatibility |
-| linux-cachyos-eevdf | 6.19.10-1 | alternate kernel lane with different behavior surface |
-| Hyprland | 0.54.3-2 | old 0.4x and early 0.5x guidance is frequently stale here |
-| xdg-desktop-portal-hyprland | 1.3.11-4 | Wayland portal behavior depends on this layer |
-| PipeWire | 1:1.6.2-1 | audio and capture stack anchor |
-| WirePlumber | 0.5.14-1 | policy layer paired with PipeWire behavior |
-| nvidia-utils | 595.58.03-1 | driver branch matters for gaming and Wayland breakage |
+| systemd | 261.1-1 | boot and session behavior |
+| mkinitcpio | 41-5 | initramfs pipeline changed enough to matter |
+| dracut | 111-1 | alternative initramfs pipeline with different expectations |
+| linux-cachyos | 7.1.3-2 | kernel and module compatibility |
+| linux-cachyos-eevdf | 7.1.3-2 | alternate kernel lane with different behavior surface |
+| Hyprland | 0.55.4-1.1 | old 0.4x and early 0.5x guidance is frequently stale here |
+| xdg-desktop-portal-hyprland | 1.3.12-2.1 | Wayland portal behavior depends on this layer |
+| PipeWire | 1:1.6.8-1.1 | audio and capture stack anchor |
+| WirePlumber | 0.5.15-1.1 | policy layer paired with PipeWire behavior |
+| nvidia-utils | 610.43.03-1 | driver branch matters for gaming and Wayland breakage |
 
 ## When to use
 

--- a/skills/backend-api/SKILL.md
+++ b/skills/backend-api/SKILL.md
@@ -16,10 +16,10 @@ metadata:
 Design and review HTTP APIs that stay coherent as they grow. Focus on contracts, auth
 boundaries, error models, and framework structure for Python and Node.js services.
 
-**Target versions** (June 2026):
-- FastAPI **0.136.3** (released 2026-05-23)
+**Target versions** (July 2026):
+- FastAPI **0.139.2**
 - Express **5.2.1** (published 2025-12-01)
-- NestJS **11.1.26** (published 2026-06-08)
+- NestJS **11.1.28**
 - OpenAPI Specification **3.2.0** (published 2025-09-19)
 - HTTP Semantics: **RFC 9110** (June 2022)
 - Problem Details for HTTP APIs: **RFC 9457** (July 2023)

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -16,10 +16,10 @@ Guide AI agents through web browsing tasks using the cheapest tool that gets the
 Every browsing action has a token cost - this skill minimizes it through progressive disclosure,
 smart format selection, and backend-aware strategies.
 
-**Target versions** (June 2026):
+**Target versions** (July 2026):
 - Lightpanda: 0.3.1
-- @playwright/mcp: 0.0.76
-- agent-browser: 0.27.0
+- @playwright/mcp: 0.0.78
+- agent-browser: 0.32.3
 
 ## When to use
 

--- a/skills/browse/references/tool-setup.md
+++ b/skills/browse/references/tool-setup.md
@@ -180,7 +180,7 @@ built-in reasoning.
 ### Installation
 
 ```bash
-npx agent-browser@0.27.0
+npx agent-browser@0.32.3
 # or: npm install -g agent-browser
 ```
 

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -24,7 +24,7 @@ Write, review, and architect CI/CD pipelines across GitHub Actions, GitLab CI/CD
 Actions, Gitea Actions, and Woodpecker. The goal is secure, fast, auditable pipelines that
 satisfy both engineering needs and compliance requirements (PCI-DSS 4.0).
 
-**Target versions**: June 2026 snapshot. Read `references/target-versions.md` before
+**Target versions**: July 2026 snapshot. Read `references/target-versions.md` before
 pinning forge, runner, CI, or supply-chain tool versions.
 
 This skill covers workflow design, security, compliance, cross-platform migration,
@@ -444,7 +444,7 @@ the OWASP Top 10 for Agentic Applications, read `references/supply-chain.md`
 - `references/runners.md` - Self-hosted runners (actions-runner, gitlab-runner, forgejo-runner, act_runner, woodpecker-agent) - install, register, executor choice, Linux vs macOS, security hardening
 - `references/best-practices.md` - Dependency updates (Dependabot/Renovate), layered linting, scanning matrix (secrets/SCA/container/IaC/SAST), review gates, merge queues, rollout order
 - `references/supply-chain.md` - supply chain security, incident timeline, SHA pinning, SBOM/SLSA, PCI-DSS compliance, image signing
-- `references/target-versions.md` - June 2026 version snapshot for forges, runners, CI systems, and supply-chain tools
+- `references/target-versions.md` - July 2026 version snapshot for forges, runners, CI systems, and supply-chain tools
 
 ## Output Contract
 

--- a/skills/ci-cd/references/best-practices.md
+++ b/skills/ci-cd/references/best-practices.md
@@ -227,7 +227,7 @@ Both are good. Pick one per pipeline and stick with it.
 
 - **Trivy** - one binary, scans images + filesystems + IaC + secrets + licenses. Good
   default for teams who want fewer tools. After the 2025 TeamPCP incident, pin to a
-  verified version (`v0.71.0+` from official releases; `v0.69.3` was the March 2026
+  verified version (`v0.72.0+` from official releases; `v0.69.3` was the March 2026
   rollback version; avoid `v0.69.4/5/6` which were compromised).
 - **Grype** - vulnerability-matching only, but has **risk scoring** that combines CVSS
   + EPSS (exploit probability) + CISA KEV. Better signal-to-noise on severity gates -

--- a/skills/ci-cd/references/github-actions.md
+++ b/skills/ci-cd/references/github-actions.md
@@ -1,6 +1,6 @@
 # GitHub Actions: Patterns & Templates
 
-Production-ready patterns for GitHub Actions workflows. Updated for March 2026: ubuntu-24.04
+Production-ready patterns for GitHub Actions workflows. Updated for July 2026: ubuntu-24.04
 runners, arm64 GA, artifact v4, attestations, SHA pinning enforcement.
 
 ---
@@ -19,7 +19,7 @@ runners, arm64 GA, artifact v4, attestations, SHA pinning enforcement.
 
 **No `ubuntu-latest-arm` label exists.** Use explicit `ubuntu-24.04-arm`.
 
-**Pricing (March 2026)**: hosted runner prices dropped up to 39% on Jan 1, 2026. A planned
+**Pricing (verified July 2026)**: hosted runner prices dropped up to 39% on Jan 1, 2026. A planned
 $0.002/min self-hosted runner fee was announced but **postponed indefinitely** after community
 backlash. Public repo usage remains free.
 
@@ -530,7 +530,7 @@ security:
         sarif_file: trivy.sarif
 ```
 
-**Trivy safe versions (June 2026)**: use binary v0.71.0+ from official releases and pin
+**Trivy safe versions (July 2026)**: use binary v0.72.0+ from official releases and pin
 actions to full commit SHAs. The March 2026 rollback set was binary v0.69.3,
 `trivy-action@v0.35.0`, and `setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6
 (compromised by TeamPCP).

--- a/skills/ci-cd/references/gitlab-ci.md
+++ b/skills/ci-cd/references/gitlab-ci.md
@@ -1,13 +1,13 @@
 # GitLab CI/CD: Patterns & Templates
 
-Production-ready patterns for GitLab CI/CD pipelines. Updated for GitLab 19.0 (May 2026):
+Production-ready patterns for GitLab CI/CD pipelines. Updated for GitLab 19.2 (July 2026):
 CI/CD Catalog GA, Components with typed inputs, rules-based workflows.
 
 ---
 
 ## Current State (2026)
 
-- **GitLab 19.0** (released May 21, 2026; 19.0.1 current patch). Monthly releases on the third Thursday; majors land each May. 19.0 is a major with breaking changes - notably Redis 6 support removed (migrate to Redis 7.2 / Valkey 7.2), no more Ubuntu 20.04 packages, and Gateway API + Envoy Gateway replaces NGINX Ingress as the Helm chart default. 18.11.x / 18.10.x remain on backports.
+- **GitLab 19.2.0** (released July 16, 2026). Monthly releases land on the third Thursday; majors land each May. The 19.x major removed Redis 6 support (migrate to Redis 7.2 / Valkey 7.2), Ubuntu 20.04 packages, and NGINX Ingress as the Helm chart default in favor of Gateway API + Envoy Gateway. Current backport lanes are 19.1.2, 19.0.4, and 18.11.7.
 - **CI/CD Catalog** GA since GitLab 17.0 (May 2024). Max 100 components per project (raised in 18.5).
 - **CI Components** are the endorsed path for reusable pipeline logic. `include:` templates still work
   but components have versioning, typed inputs, and discoverability.

--- a/skills/ci-cd/references/supply-chain.md
+++ b/skills/ci-cd/references/supply-chain.md
@@ -1,7 +1,7 @@
 # CI/CD Supply Chain Security
 
 Cross-platform supply chain hardening patterns, incident timeline, and PCI-DSS 4.0 compliance.
-Updated June 2026 - post-Trivy compromise and the TeamPCP npm/PyPI worm wave.
+Reviewed July 2026 - post-Trivy compromise and the TeamPCP npm/PyPI worm wave.
 
 ---
 
@@ -38,7 +38,7 @@ they inform every recommendation in this document.
 - **Lesson**: even security tools' own CI is a target. "We trust our scanning tool" is circular reasoning.
 
 **Known safe Trivy versions**:
-- Current new pins (June 2026): binary v0.71.0+ from official releases, pinned by checksum or image digest
+- Current new pins (July 2026): binary v0.72.0+ from official releases, pinned by checksum or image digest
 - March 2026 rollback: binary v0.69.2 or v0.69.3
 - `trivy-action`: **v0.35.0** was the March rollback tag; pin the verified commit SHA, not the tag
 - `setup-trivy`: v0.2.6 was the March rollback tag; pin the verified commit SHA, not the tag

--- a/skills/ci-cd/references/target-versions.md
+++ b/skills/ci-cd/references/target-versions.md
@@ -1,11 +1,11 @@
 # CI/CD Target Versions
 
-June 2026 snapshot. Verified 2026-06-14 against GitLab/Gitea/Forgejo APIs, GitHub releases,
+July 2026 snapshot. Verified 2026-07-22 against GitLab/Gitea/Forgejo APIs, GitHub releases,
 and supply-chain tool releases. Verify current releases before pinning.
 
 - **GitHub Actions**: ubuntu-24.04 runners (ubuntu-latest), arm64 GA, artifact v4, attestations GA
-- **GitLab CI/CD**: GitLab 19.0.2 current (19.0 major released May 21, 2026; 19.0.2 / 18.11.5 / 18.10.8 patch release June 10, 2026); 18.10.x reaches EOL in June 2026, so move backported instances to 18.11.x. CI/CD Catalog GA, CI Components with typed `spec: inputs`
-- **Forgejo Actions**: Forgejo v15.0.3, Runner v12.10.1 (check `data.forgejo.org/forgejo/runner` releases before pinning)
-- **Gitea Actions**: Gitea v1.26.2, act runner v1.0.4 (GA since Gitea 1.21, March 2024)
-- **Woodpecker CI**: v3.15.0 (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)
-- **Supply chain**: cosign v3.1.1 (Sigstore), Syft v1.45.1, Trivy v0.71.0, SLSA v1.1
+- **GitLab CI/CD**: GitLab 19.2.0 current (released July 16, 2026); 19.1.2 / 19.0.4 / 18.11.7 are the latest backported patch lanes. CI/CD Catalog GA, CI Components with typed `spec: inputs`
+- **Forgejo Actions**: Forgejo v16.0.1 current, v15.0.5 current LTS; Runner v12.13.1 (check `data.forgejo.org/forgejo/runner` releases before pinning)
+- **Gitea Actions**: Gitea v1.27.0, act runner v2.1.0 (runner 2.x is a major upgrade; review migration notes)
+- **Woodpecker CI**: v3.16.0 (container-native, Gitea/Forgejo/GitHub/GitLab-compatible)
+- **Supply chain**: cosign v3.1.2 (Sigstore), Syft v1.49.0, Trivy v0.72.0, SLSA v1.1

--- a/skills/code-review/references/ai-age-patterns.md
+++ b/skills/code-review/references/ai-age-patterns.md
@@ -2,7 +2,7 @@
 
 Bug patterns specific to AI-generated code, LLM API integrations, agentic AI systems, and MCP (Model Context Protocol) implementations. As of 2025-2026, AI-generated code is present in most codebases - these patterns catch what traditional review misses.
 
-Research date: March 2026.
+Research date: July 2026.
 
 ---
 
@@ -270,6 +270,7 @@ MCP is still maturing in security. As of March 2026: 43% of MCP servers contain 
 - Grafana MCP binding to `0.0.0.0:8000` by default - accessible from any network, not just localhost
 - DNS rebinding attacks on localhost-bound SSE servers - multiple SDKs lack protection
 - Cross-client data leaks in TypeScript SDK (CVE-2026-25536)
+- Python SDK WebSocket servers without Host/Origin validation (CVE-2026-59950; fixed in mcp 1.28.1)
 
 ### Data Exposure
 

--- a/skills/command-prompt/SKILL.md
+++ b/skills/command-prompt/SKILL.md
@@ -16,11 +16,11 @@ metadata:
 Reference skill for writing commands, scripts, and configuration across Unix shells. Detects
 the target shell from context and routes to the appropriate reference.
 
-**Target versions** (June 2026):
+**Target versions** (July 2026):
 - Zsh: 5.10
 - Bash: 5.3
-- Fish: 4.6
-- Nushell: 0.113.1
+- Fish: 4.8.1
+- Nushell: 0.114.1
 - Tcsh: 6.24
 - Dash: 0.5.13
 
@@ -347,7 +347,7 @@ Before returning any shell script, check:
 - `references/zsh.md` - Zsh 5.9/5.10 patterns, glob qualifiers, arrays, parameter expansion, completions, autoloading, dotfile config, prompt hooks, zsh-only features, 5.10 additions (non-forking `${ }`, namerefs, SRANDOM), bash porting matrix
 - `references/bash.md` - Bash 5.3 patterns, parameter expansion, arrays, conditionals, process substitution, error handling, traps, heredocs, coprocesses, bash 5.x features (non-forking `${ cmd; }`, GLOBSORT, SRANDOM), script template
 - `references/posix-sh.md` - Portable POSIX sh patterns, what's POSIX and what's not, bashism avoidance checklist, which-sh-am-I, arithmetic, parameter expansion, portable conditionals
-- `references/alt-shells.md` - Fish 4.6 (syntax, functions, completions, config, 4.6 additions), tcsh/csh 6.24 (syntax, when you'll encounter it), nushell 0.111 (structured pipelines, types), elvish 0.22/oils 0.37 (brief)
+- `references/alt-shells.md` - Fish 4.8 (syntax, functions, completions, config), tcsh/csh 6.24 (syntax, when you'll encounter it), Nushell 0.114 (structured pipelines, types), Elvish/Oils (brief)
 - `references/ssh-tmux-autostart.md` - safe shell startup pattern for interactive SSH sessions that attach to tmux without breaking non-interactive commands
 
 ## Output Contract

--- a/skills/command-prompt/references/alt-shells.md
+++ b/skills/command-prompt/references/alt-shells.md
@@ -5,7 +5,7 @@
 
 ---
 
-## Fish (4.6)
+## Fish (4.8)
 
 Fish is a modern, user-friendly shell that intentionally breaks POSIX compatibility for a
 better interactive experience. You'll encounter it when users have it as their login shell or
@@ -268,7 +268,7 @@ bash (`pkg install bash`) or write POSIX sh.
 
 ---
 
-## Nushell (0.111)
+## Nushell (0.114)
 
 Nushell is a modern shell that treats data as structured tables instead of text streams. It's
 gaining traction among developers who work with JSON/YAML/CSV regularly.

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -15,13 +15,13 @@ metadata:
 
 Configure, tune, design schemas, migrate, back up, and review database engines - from single-node dev setups to PCI-compliant production clusters. The goal is correct, performant, durable databases that survive failures, pass audits, and don't wake you up at 3am.
 
-**Target versions** (June 2026):
-- PostgreSQL **18.4** (EOL 2030-11; May 14, 2026 security release), back-branches: 17.10, 16.14, 15.18, 14.23 (no June stable release; PG 19 in beta)
+**Target versions** (July 2026):
+- PostgreSQL **18.4** (EOL 2030-11; May 14, 2026 security release), back-branches: 17.10, 16.14, 15.18, 14.23; PostgreSQL 19 Beta 2 is for testing only
 - MongoDB **8.0.26** (GA, EOL 2029-10; June 11, 2026 security release fixing CVE-2026-11933); rapid lane (8.2+) is Atlas-only with a short window - verify live before pinning
 - MariaDB **11.8.8** (LTS, EOL 2028-06); 12.x rolling GA is quarterly and EOLs at each successor, with 12.3 the next yearly LTS - verify live
-- MySQL **8.4.9** (LTS); innovation lane (9.6) has a short support window - verify live
-- SQL Server **2025 RTM + CU5** (CU5 KB5084896, 2026-05-20)
-- PgBouncer **1.25.2**, Pgpool-II **4.7.2**, ProxySQL **3.0.8**
+- MySQL **8.4.10** (LTS; June 2026 Critical Security Patch); innovation lane has a short support window - verify live
+- SQL Server **2025 RTM + CU7** (released 2026-07-16)
+- PgBouncer **1.25.2**, Pgpool-II **4.7.2**, ProxySQL **3.0.9** (fixes CVE-2026-48772/48773/48774)
 
 This skill covers six domains depending on context:
 - **Configuration** - engine settings, authentication, TLS, tuning parameters

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -368,6 +368,27 @@ Read `references/migration-patterns.md` for cross-engine type mapping, ORM migra
 
 ---
 
+## Output Contract
+
+See `references/output-contract.md` for the full contract.
+
+- **Skill name:** DATABASES
+- **Deliverable bucket:** `audits`
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/databases/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+- **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
+
+## Related Skills
+
+- **code-review** - has a `databases.md` reference for application-level database **bug patterns** (transaction misuse, NULL handling, ORM N+1, type coercion). This skill covers engine configuration and operations; code-review covers how the application uses the database.
+- **security-audit** - for SQL injection detection and credential scanning in application code
+- **kubernetes** - for deploying databases on K8s (StatefulSets, operators, PVCs)
+- **terraform** - for provisioning managed databases (RDS, Cloud SQL, Atlas)
+- **docker** - for database containers in Docker Compose
+- **ansible** - for database server configuration management
+- **ci-cd** - for CI/CD pipelines that run migrations (schema execution in CI, migration gating, rollback automation)
+
+---
+
 ## Rules
 
 These are non-negotiable. Violating any of these is a bug.
@@ -387,24 +408,3 @@ These are non-negotiable. Violating any of these is a bug.
 13. **Patch PgBouncer.** PgBouncer < 1.25.1 (CVE-2025-12819) can allow unauthenticated SQL execution when `track_extra_parameters` includes `search_path` AND `auth_user` is set (both non-default). The May 2026 1.25.2 release adds further fixes (CVE-2026-6664/6665/6666/6667: integer overflow, SCRAM, null-deref, KILL_CLIENT authz). Upgrade to 1.25.2+ - the fixes are low-risk.
 14. **Chunk bulk inserts.** Never build a single `INSERT ... VALUES` with an unbounded row list. Compute batch size from the lowest host-parameter ceiling across supported backends (`floor(limit / columns_per_row)`). Wrap chunks in one transaction when atomicity matters.
 15. **Run the AI self-check.** Every generated migration, schema, or config gets verified against the checklist above before returning.
-
----
-
-## Output Contract
-
-See `references/output-contract.md` for the full contract.
-
-- **Skill name:** DATABASES
-- **Deliverable bucket:** `audits`
-- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/databases/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
-- **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
-
-## Related Skills
-
-- **code-review** - has a `databases.md` reference for application-level database **bug patterns** (transaction misuse, NULL handling, ORM N+1, type coercion). This skill covers engine configuration and operations; code-review covers how the application uses the database.
-- **security-audit** - for SQL injection detection and credential scanning in application code
-- **kubernetes** - for deploying databases on K8s (StatefulSets, operators, PVCs)
-- **terraform** - for provisioning managed databases (RDS, Cloud SQL, Atlas)
-- **docker** - for database containers in Docker Compose
-- **ansible** - for database server configuration management
-- **ci-cd** - for CI/CD pipelines that run migrations (schema execution in CI, migration gating, rollback automation)

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -19,7 +19,7 @@ security-distro workflow. Focus on Debian stable and Ubuntu LTS first, then laye
 derivative-specific behavior, PPA workflows, snap confinement, Ubuntu HWE, and explicit checks
 for derivatives that diverge on init, packaging defaults, or intended use.
 
-**Versions worth pinning** (verified June 2026):
+**Versions worth pinning** (verified July 2026):
 
 Only pin versions here when they materially affect compatibility or troubleshooting shape. For
 ordinary Debian and Ubuntu package work, prefer the live distro lane and package policy over a

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deep-audit
 description: >
-  · Run an exhaustive 5-wave repo audit (every applicable lens, up to 30 agents), persist findings, generate phased tasks. Triggers: 'deep audit', 'comprehensive audit', 'full audit', 'mega review', 'deep review', 'audit report'. Not for a quick fixed 4-skill sweep (use full-review).
+  · Run exhaustive 5-wave repo audits, persist findings, and generate phased tasks. Triggers: 'deep audit', 'comprehensive audit', 'full audit', 'mega review', 'deep review', 'audit report'. For quick sweeps, use full-review.
 license: MIT
 compatibility: "Requires iuliandita/skills collection installed. Subagent support strongly recommended. Optional: a brainstorming or ideation skill in the host harness (matched by name pattern) for large-audit planning handoff."
 metadata:

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -374,6 +374,13 @@ See `references/output-contract.md` for the full contract.
 - **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/dev-cycle/<YYYY-MM-DD>-<slug>.md`. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
+## Reference Files
+
+- `references/start.md` - detailed start-mode workflow, branch naming conventions, spec file template, brainstorming fallback chain (including headless-mode behavior)
+- `references/finish.md` - detailed finish-mode workflow with per-forge commands (GitHub/GitLab/Forgejo/Gitea/Bitbucket) and bare-git paths (format-patch, bundle, local merge). Covers forge detection, toolchain detection with custom-script fallback, CI watch traps, release cutting, and rollback
+- `references/size-heuristics.md` - complete size-classification table with concrete signals, edge cases, and the ambiguity-resolution questions
+- `references/version-bump-sites.md` - grep patterns and locations for version strings across common ecosystems (Docker, K8s, Helm, package managers)
+
 ## Rules
 
 1. **Read before edit.** Always read files you're about to modify in the current session. No exceptions.
@@ -386,10 +393,3 @@ See `references/output-contract.md` for the full contract.
 8. **Don't bundle unrelated work.** If mid-finish you notice a bug outside the branch's scope, file it (roadmap skill or an issue) - don't sneak it into the PR.
 9. **Plain ASCII only.** No em-dashes, no `--` substitutes, no curly quotes, no decorative emoji. Functional status markers (`[OK]`, `[FAIL]`, severity emoji in reports from delegated skills) are fine.
 10. **Mode boundaries are sacred.** Start mode ends with a handoff, not implementation. Finish mode starts with verification, not committing new code. Don't blur them.
-
-## Reference Files
-
-- `references/start.md` - detailed start-mode workflow, branch naming conventions, spec file template, brainstorming fallback chain (including headless-mode behavior)
-- `references/finish.md` - detailed finish-mode workflow with per-forge commands (GitHub/GitLab/Forgejo/Gitea/Bitbucket) and bare-git paths (format-patch, bundle, local merge). Covers forge detection, toolchain detection with custom-script fallback, CI watch traps, release cutting, and rollback
-- `references/size-heuristics.md` - complete size-classification table with concrete signals, edge cases, and the ambiguity-resolution questions
-- `references/version-bump-sites.md` - grep patterns and locations for version strings across common ecosystems (Docker, K8s, Helm, package managers)

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 Write, review, and architect Dockerfiles, Compose stacks, and container workflows - from single-service dev setups to multi-arch production pipelines with image signing and compliance gates. The goal is minimal, secure, reproducible images that a team can maintain and a QSA can audit.
 
-**Target versions**: June 2026 snapshot. Read `references/target-versions.md` before
+**Target versions**: July 2026 snapshot. Read `references/target-versions.md` before
 pinning Docker, Compose, BuildKit, containerd, Podman, Buildah, or runc.
 
 This skill covers Dockerfiles, Compose, container hardening, supply chain, registry/CI
@@ -131,7 +131,7 @@ docker scout cves --only-severity critical,high <image>
 cosign verify --key <key> <image>     # verify signature
 syft <image> -o spdx-json             # generate SBOM
 grype <image>                         # vulnerability scan (alternative to Scout)
-trivy image <image>                   # use v0.70.0+; never v0.69.4-6
+trivy image <image>                   # use v0.72.0+; never v0.69.4-6
 ```
 
 ## Dockerfile
@@ -272,7 +272,7 @@ Read `references/security-and-compliance.md` for the full PCI-DSS 4.0 container 
 | CVE-2025-31133 | runc | High | Container escape via /dev/null symlink race | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
 | CVE-2025-52565 | runc | High | Container escape via /dev/console mount race | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
 | CVE-2025-52881 | runc | High | Host procfs writes via /proc redirect (DoS/escape) | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
-| CVE-2026-33634 | Trivy | Critical | Supply chain - malware in Docker Hub images (v0.69.4-6) | Trivy v0.70.0+ for new pins; v0.69.3 only as rollback |
+| CVE-2026-33634 | Trivy | Critical | Supply chain - malware in Docker Hub images (v0.69.4-6) | Trivy v0.72.0+ for new pins; v0.69.3 only as rollback |
 | CVE-2026-2664 | Docker Desktop | Medium | gRPC-FUSE kernel module OOB read | Desktop 4.62.0+ |
 | CVE-2025-13743 | Docker Desktop | Low | Expired Hub PATs leaked in diagnostics bundles | Desktop 4.54.0 |
 | CVE-2026-28400 | Model Runner | 7.5 High | Runtime flag injection - arbitrary file overwrite, container escape | Desktop 4.61.0+ |
@@ -334,7 +334,7 @@ For a hardened Dockerfile pattern, see `references/dockerfile-patterns.md` (Lang
 - **Verify at deploy**: `cosign verify --key cosign.pub <image>@<digest>`
 - **Pin CI tool images to SHA256 digests.** Mutable tags are a proven attack vector (Trivy March 2026, tj-actions/reviewdog March 2025).
 - **Use Docker Scout** or Grype for continuous vulnerability monitoring.
-- **Trivy**: use v0.70.0+ from official releases for new pins. v0.69.3 was the March 2026 rollback version. v0.69.4-6 contained credential-stealing malware. If any CI pipeline ran compromised Trivy between March 19-23, 2026, rotate ALL secrets.
+- **Trivy**: use v0.72.0+ from official releases for new pins. v0.69.3 was the March 2026 rollback version. v0.69.4-6 contained credential-stealing malware. If any CI pipeline ran compromised Trivy between March 19-23, 2026, rotate ALL secrets.
 
 ### PCI-DSS 4.0 container requirements (summary)
 
@@ -344,7 +344,7 @@ PCI-DSS 4.0 is the only active version. Key container-specific requirements:
 - **Req 2.2**: Harden containers - non-root, drop caps, read-only rootfs, one process per container
 - **Req 4**: Encrypt transmissions - TLS between CDE containers in Compose (mount certs, use TLS-enabled images, or front with a TLS-terminating reverse proxy)
 - **Req 5.2/5.3**: Immutable images (deploy by digest), Falco for runtime detection
-- **Req 6.3**: Vulnerability scanning on every image before deployment (Docker Scout, Grype, Trivy v0.70.0+)
+- **Req 6.3**: Vulnerability scanning on every image before deployment (Docker Scout, Grype, Trivy v0.72.0+)
 - **Req 6.3.2**: SBOM for every production image
 - **Req 8.6.2**: No hardcoded secrets in images, compose files, or env vars
 - **Req 10**: Audit logging - container stdout/stderr to immutable log store
@@ -389,10 +389,10 @@ See AI Self-Check above for the full build-time checklist (Dockerfile correctnes
 - [ ] runc >= 1.4.0 (CVE-2025-31133/52565/52881 patched)
 - [ ] BuildKit >= 0.28.1 (CVE-2026-33747/33748 patched)
 - [ ] Docker Desktop >= 4.71.0 (adds CVE-2026-5817/5843 Model Runner container-to-host RCE fixes; floor was 4.66.1 for CVE-2025-9074/CVE-2026-28400)
-- [ ] Trivy v0.70.0+ from official releases (v0.69.4-6 COMPROMISED)
+- [ ] Trivy v0.72.0+ from official releases (v0.69.4-6 COMPROMISED)
 - [ ] Images signed with cosign, verified at deploy
 - [ ] SBOM generated for every production image
-- [ ] Vulnerability scanning in CI (Docker Scout, Grype, or Trivy v0.70.0+)
+- [ ] Vulnerability scanning in CI (Docker Scout, Grype, or Trivy v0.72.0+)
 - [ ] CI tools pinned to SHA256 digests (not mutable tags)
 - [ ] Base images rebuilt/updated regularly (weekly minimum)
 - [ ] Separate override files for dev/prod
@@ -418,7 +418,7 @@ See AI Self-Check above for the full build-time checklist (Dockerfile correctnes
 - `references/compose-patterns.md` - Compose patterns and common stack layouts
 - `references/security-and-compliance.md` - container hardening, compliance guidance, and safe public custom image publishing
 - `references/alternative-runtimes.md` - Podman, Buildah, Skopeo, and related runtime patterns
-- `references/target-versions.md` - June 2026 version snapshot for Docker, Compose, BuildKit, containerd, Podman, Buildah, and runc
+- `references/target-versions.md` - July 2026 version snapshot for Docker, Compose, BuildKit, containerd, Podman, Buildah, and runc
 
 ## Output Contract
 
@@ -453,7 +453,7 @@ See `references/output-contract.md` for the full contract.
 5. **Deps before source.** Copy dependency manifests first, install, then copy source. Layer cache depends on it.
 6. **Healthchecks on everything.** Dockerfile `HEALTHCHECK` and Compose `healthcheck:`.
 7. **Pin CI tools to SHA256 digests.** Mutable tags are compromised supply chain vectors (Trivy CVE-2026-33634 March 2026, tj-actions CVE-2025-30066 (upstream: reviewdog CVE-2025-30154) March 2025).
-8. **Trivy v0.70.0+ for new pins.** v0.69.3 was the March 2026 rollback version; v0.69.4-6 contained credential-stealing malware. If you ran it, rotate secrets.
+8. **Trivy v0.72.0+ for new pins.** v0.69.3 was the March 2026 rollback version; v0.69.4-6 contained credential-stealing malware. If you ran it, rotate secrets.
 9. **Compose: no `version:` field.** It's deprecated and removed. Just delete it.
 10. **Clean apt cache in the same RUN layer.** `apt-get update && apt-get install -y ... && rm -rf /var/lib/apt/lists/*` - all one `RUN`.
 11. **`.dockerignore` is not optional.** `.git`, `node_modules`, `.env`, secrets, test fixtures, docs - all excluded.

--- a/skills/docker/references/alternative-runtimes.md
+++ b/skills/docker/references/alternative-runtimes.md
@@ -1,6 +1,6 @@
 # Alternative Container Runtimes
 
-Podman, Buildah, Skopeo, and containerd patterns. Updated March 2026.
+Podman, Buildah, Skopeo, and containerd patterns. Reviewed July 2026.
 
 ---
 
@@ -245,7 +245,7 @@ skopeo list-tags docker://ghcr.io/org/myapp
 
 Low-level container runtime. Kubernetes uses it directly. Docker Engine uses it under the hood.
 
-### Key facts (June 2026)
+### Key facts (July 2026)
 
 - **containerd 2.3.0** was released in April 2026 as the first annual LTS release, supported for 2+ years
 - **containerd 2.2.3** remains a supported 2.2 patch release through November 2026

--- a/skills/docker/references/compose-patterns.md
+++ b/skills/docker/references/compose-patterns.md
@@ -1,6 +1,6 @@
 # Docker Compose Patterns & Templates
 
-Production-ready Compose patterns for Docker Compose v5.1+ (no `version:` field). Updated March 2026.
+Production-ready Compose patterns for Docker Compose v5.1+ (no `version:` field). Reviewed July 2026.
 
 ---
 

--- a/skills/docker/references/dockerfile-patterns.md
+++ b/skills/docker/references/dockerfile-patterns.md
@@ -117,7 +117,7 @@ Attestations are stored in the registry alongside the image. Requires `--push`.
 
 \* Chainguard dev variants include shell; prod variants don't.
 
-**Choose Chainguard** for: zero-CVE at build time, built-in SBOM + Sigstore, nightly rebuilds, glibc compat, PCI/regulatory compliance. 2000+ images available as of June 2026 recheck.
+**Choose Chainguard** for: zero-CVE at build time, built-in SBOM + Sigstore, nightly rebuilds, glibc compat, PCI/regulatory compliance. 2000+ images available as of July 2026 recheck.
 
 **Choose Alpine** when: you need a shell, all deps work with musl, image size is top priority.
 

--- a/skills/docker/references/security-and-compliance.md
+++ b/skills/docker/references/security-and-compliance.md
@@ -1,6 +1,6 @@
 # Container Security & PCI-DSS 4.0 Compliance
 
-Security hardening, vulnerability management, supply chain integrity, and PCI-DSS 4.0 mapping for containerized environments. Updated March 2026.
+Security hardening, vulnerability management, supply chain integrity, and PCI-DSS 4.0 mapping for containerized environments. Reviewed July 2026.
 
 ---
 
@@ -14,7 +14,7 @@ Security hardening, vulnerability management, supply chain integrity, and PCI-DS
 | CVE-2025-31133 | High | runc | Mount manipulation (/dev/null symlink) enables host procfs writes | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
 | CVE-2025-52565 | High | runc | /dev/console race condition grants premature mount access | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
 | CVE-2025-52881 | High | runc | procfs write redirect bypasses LSM relabel, host procfs writes | runc 1.2.8, 1.3.3, 1.4.0-rc.3 |
-| CVE-2026-33634 | Critical | Trivy | Supply chain - credential-stealing malware in aquasec/trivy Docker Hub images v0.69.4-6 | Trivy v0.70.0+ for new pins; v0.69.3 only as rollback |
+| CVE-2026-33634 | Critical | Trivy | Supply chain - credential-stealing malware in aquasec/trivy Docker Hub images v0.69.4-6 | Trivy v0.72.0+ for new pins; v0.69.3 only as rollback |
 | CVE-2026-2664 | Medium | Docker Desktop | gRPC-FUSE kernel module out-of-bounds read | Desktop 4.62.0+ |
 | CVE-2025-13743 | Low | Docker Desktop | Expired Hub PATs leaked in diagnostic bundles via error object serialization | Desktop 4.54.0+ |
 | CVE-2026-28400 | 7.5 High | Model Runner | Runtime flag injection via _configure endpoint - arbitrary file overwrite, container escape | Desktop 4.61.0+ |
@@ -94,7 +94,7 @@ The attackers are a cloud-native threat group active 2025-2026, known for Docker
 | Tool | Scans | SBOM | Signs | Free | Notes |
 |------|-------|------|-------|------|-------|
 | **Docker Scout** | Images, SBOM, policies | Generate | No | Free tier | Built into Docker CLI. `docker scout cves`, `docker scout sbom` |
-| **Trivy** (v0.70.0+) | Images, IaC, repos, SBOM | Generate | No | Yes | Multi-purpose. Pin exact version and digest |
+| **Trivy** (v0.72.0+) | Images, IaC, repos, SBOM | Generate | No | Yes | Multi-purpose. Pin exact version and digest |
 | **Grype** (Anchore) | Images | No | No | Yes | Fast CVE scanner. Pair with Syft |
 | **Syft** (Anchore) | N/A | Generate | No | Yes | SBOM generator. SPDX + CycloneDX |
 | **Cosign** (Sigstore) | N/A | Attach | Yes | Yes | Keyless OCI signing. Industry standard |
@@ -109,7 +109,7 @@ docker buildx build --provenance=true --sbom=true -t $IMAGE --push .
 
 # 2. Scan (use multiple tools for coverage)
 docker scout cves $IMAGE --exit-code --only-severity critical,high
-trivy image --severity HIGH,CRITICAL --exit-code 1 $IMAGE    # pinned v0.70.0+ binary or image digest
+trivy image --severity HIGH,CRITICAL --exit-code 1 $IMAGE    # pinned v0.72.0+ binary or image digest
 
 # 3. Sign (keyless via Sigstore OIDC in CI)
 cosign sign $IMAGE@sha256:$DIGEST
@@ -296,7 +296,7 @@ PCI-DSS 4.0 is the only active version (3.2.1 retired March 2024). All future-da
 | 2.2.4-6 | Remove unnecessary functionality | Distroless/Chainguard base images. No shells, package managers, or dev tools in production. |
 | 5.2/5.3 | Malware protection, FIM | Immutable images (deploy by digest). `read_only: true`. Runtime detection (Falco/Tetragon). |
 | 6.2.1 | Bespoke and custom software developed securely | Images from verified publishers. Signed with cosign. Verified at deployment (admission control). |
-| 6.3.1 | Vulnerability identification | Image scanning in CI (Docker Scout, Grype, Trivy v0.70.0+) and before every deployment. |
+| 6.3.1 | Vulnerability identification | Image scanning in CI (Docker Scout, Grype, Trivy v0.72.0+) and before every deployment. |
 | 6.3.2 | Component inventory | SBOM generated for every production image. Stored and queryable. |
 | 6.4.2 | WAF on public-facing apps | Reverse proxy with WAF (ModSecurity, Cloud Armor) in front of CDE containers. |
 | 8.6.2 | No hardcoded secrets | No secrets in Dockerfiles, Compose files, env vars, committed `.env` files. Use Compose secrets or Vault. |

--- a/skills/docker/references/target-versions.md
+++ b/skills/docker/references/target-versions.md
@@ -1,11 +1,11 @@
 # Docker Target Versions
 
-June 2026 snapshot. Verified 2026-06-14 against Docker release notes, Docker Desktop appcast,
+July 2026 snapshot. Verified 2026-07-22 against Docker release notes, Docker Desktop releases,
 and upstream GitHub release APIs. Verify current releases before pinning.
 
-- Docker Engine 29.5.3, Docker Desktop 4.77.0 (same version across Windows, macOS, Linux)
-- Docker Compose v5.1.4 (Go SDK, Bake-delegated builds)
-- BuildKit v0.30.0
-- containerd 2.3.1 (2.3.x LTS, recommended for production after checking release notes)
-- Podman 5.8.3, Buildah 1.44.0
-- runc 1.4.3 (CVE-2025-31133/52565/52881 patched since 1.4.0; GHSA-xjvp-4fhw-gc47, a low-severity /dev symlink issue, fixed in 1.4.3/1.3.6)
+- Docker Engine 29.6.2, Docker Desktop 4.83.0 (same version across Windows, macOS, Linux)
+- Docker Compose v5.3.1 (Go SDK, Bake-delegated builds)
+- BuildKit v0.31.2
+- containerd 2.3.3 (2.3.x LTS, recommended for production after checking release notes)
+- Podman 6.0.2 (major release; review migration notes), Buildah 1.44.0
+- runc 1.5.1 (CVE-2025-31133/52565/52881 patched since 1.4.0; GHSA-xjvp-4fhw-gc47, a low-severity /dev symlink issue, fixed in 1.4.3/1.3.6)

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -16,9 +16,9 @@ metadata:
 Manage, troubleshoot, and harden OPNsense and pfSense firewalls via SSH. Both are FreeBSD-based,
 pf-powered firewall distributions - most concepts, commands, and patterns apply to both.
 
-**Target versions** (June 2026):
-- OPNsense CE: 26.1.9 (current Community Edition stable, "Witty Woodpecker"; CE ships odd quarters .1/.7, with 26.7 in beta). Business Edition is 26.4.x (even quarters .4/.10) - do not quote the BE number as the CE version
-- pfSense CE: 2.8.1 / pfSense Plus: 26.03
+**Target versions** (July 2026):
+- OPNsense CE: 26.7.1 (current Community Edition stable, "Xenial Xenops"; 26.7.1 contains four core security advisories). Business Edition remains a separate even-quarter lane - do not quote the BE number as the CE version
+- pfSense CE: 2.8.1 / pfSense Plus: 26.03.1
 - CrowdSec: v1.7.8
 
 ## When to use

--- a/skills/firewall-appliance/references/plugins.md
+++ b/skills/firewall-appliance/references/plugins.md
@@ -6,7 +6,7 @@ inspect via `pkg info <name>` and check `/usr/local/etc/` for their configs.
 ## Security
 
 ### os-crowdsec (CrowdSec)
-Local LAPI + bouncer (verify OPNsense package with `pkg info os-crowdsec`; upstream CrowdSec v1.7.8 as of June 2026 recheck). Parses logs locally, applies local bans + crowd-sourced blocklists.
+Local LAPI + bouncer (verify OPNsense package with `pkg info os-crowdsec`; upstream CrowdSec v1.7.8 as of July 2026 recheck). Parses logs locally, applies local bans + crowd-sourced blocklists.
 
 **Two separate enforcement layers:**
 - **Local decisions** (`crowdsec_blacklists` pf table): IPs your firewall detected and banned

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -17,13 +17,13 @@ A pragmatic, perfectionist UI engineer with strong taste. Treats interfaces as c
 
 This skill replaces the upstream generic `frontend-design` skill in this collection. The persona is the point: bland, accommodating UI advice produces bland UIs.
 
-**Target versions** (June 2026 - pinned so staleness is visible):
+**Target versions** (July 2026 - pinned so staleness is visible):
 
-- Astro 6.4.4 (Astro 5.17 also production-ready)
-- SvelteKit 2.58.0 + Svelte 5.56.0 runes
-- Tailwind CSS v4.3.1
-- Vite 8.0.16
-- React 19.2.7 + Next.js 16.2.7 (heavier option, only when team is React-locked)
+- Astro 7.1.3 (major: Rust compiler, Vite 8, advanced routing; 7.1.0+ clears the June/July XSS and SSRF advisory set)
+- SvelteKit 2.70.1 + Svelte 5.56.7 runes
+- Tailwind CSS v4.3.3
+- Vite 8.1.5
+- React 19.2.8 + Next.js 16.2.11 (heavier option, only when team is React-locked)
 - @use-gesture/react 10.3.1 (modern; Hammer.js considered legacy)
 
 ## When to use

--- a/skills/frontend-design/references/frameworks.md
+++ b/skills/frontend-design/references/frameworks.md
@@ -1,6 +1,6 @@
 # Framework Picker
 
-Pinned to June 2026. Update versions when refreshing the skill. Hallucinating "Next.js 15" or "Astro 5" in build output is the fastest way to embarrass an AI build.
+Pinned to July 2026. Update versions when refreshing the skill. Hallucinating stale framework versions in build output is the fastest way to embarrass an AI build.
 
 The persona's bias: minimalist first. Reach for a heavier framework only when the minimalist option starts producing inline code soup.
 
@@ -9,10 +9,10 @@ The persona's bias: minimalist first. Reach for a heavier framework only when th
 ## Decision tree
 
 1. **No-build, single HTML file demo, codepen-style?** -> Plain HTML + CSS + JS, no framework. State the constraint at the top of the file.
-2. **Static content, marketing site, blog, docs?** -> **Astro 6.4.4** (or **Astro 5.17** if Astro 6 hasn't shipped a feature you need)
-3. **Interactive app, bundle size matters, you want runes?** -> **SvelteKit 2.58.0** + Svelte 5.56.0
-4. **Small app, no SSR needed, want Vite directly?** -> **Vite 8.0.16** + plain TypeScript or a thin layer (Lit, Solid, vanilla)
-5. **Team is React-locked or you genuinely need React's ecosystem?** -> **Next.js 16.2.7** + **React 19.2.7**
+2. **Static content, marketing site, blog, docs?** -> **Astro 7.1.3**
+3. **Interactive app, bundle size matters, you want runes?** -> **SvelteKit 2.70.1** + Svelte 5.56.7
+4. **Small app, no SSR needed, want Vite directly?** -> **Vite 8.1.5** + plain TypeScript or a thin layer (Lit, Solid, vanilla)
+5. **Team is React-locked or you genuinely need React's ecosystem?** -> **Next.js 16.2.11** + **React 19.2.8**
 
 The persona pushes back on Next.js as a default. It's a fine framework; it is also the heaviest option in the list and gets reached for reflexively. If the answer to "why Next" is "because everyone uses it", that's not a reason.
 
@@ -21,7 +21,7 @@ when they fit.
 
 ---
 
-## Astro 6.4.4 (Cloudflare-owned since January 16, 2026)
+## Astro 7.1.3 (Cloudflare-owned since January 16, 2026)
 
 **When.** Content-heavy: marketing pages, docs, blogs, portfolios, landing sites, hybrid sites with islands of interactivity.
 
@@ -33,15 +33,17 @@ when they fit.
 - Islands architecture - hydrate Svelte / React / Vue / Solid components only where needed
 - Built-in image optimization (`astro:assets`)
 - Server actions for forms
-- Astro 6 dev server runs on `workerd` (Cloudflare's open-source Workers runtime), so local dev matches production
-- Live Content Collections, stable CSP API, Node 22+ minimum
+- Rust compiler and Markdown/MDX pipeline, Vite 8, and faster queue-based rendering
+- Advanced Routing, structured development logs, stable route caching, CSP, and Node 22+ minimum
 
 **When NOT.**
 
 - Highly interactive single-page apps (use SvelteKit or Next)
 - App with heavy client state across many routes (use SvelteKit)
 
-**Note.** Astro 5.17 (January 29, 2026) is the latest 5.x and remains production-ready. Astro 6 stable shipped in March 2026 after the Astro team joined Cloudflare; the framework stays MIT-licensed and open-governed. Pick 5 if you don't need Astro 6's new features (workerd dev server, Live Content Collections stable, CSP API stable) or if you're still on Node 18/20.
+**Note.** Astro 7 is a major migration. Run the official upgrade path and review adapter,
+content, and routing changes. Require Astro 7.1.0+ because earlier supported lines include
+June/July 2026 XSS and host-header SSRF advisories.
 
 ```bash
 # Bun-first (preferred per repo convention)
@@ -50,7 +52,7 @@ bun create astro@latest
 
 ---
 
-## SvelteKit 2.58.0 + Svelte 5.56.0
+## SvelteKit 2.70.1 + Svelte 5.56.7
 
 **When.** Interactive apps where bundle size and runtime cost matter. Apps where the team wants explicit reactivity.
 
@@ -89,7 +91,7 @@ bun create svelte@latest
 
 ---
 
-## Vite 8.0.16 + plain TS
+## Vite 8.1.5 + plain TS
 
 **When.** Small apps, demos, tools where you want a build but no framework opinions. Single-page tools, internal dashboards with one or two views.
 
@@ -116,7 +118,7 @@ bun create vite@latest
 
 ---
 
-## Next.js 16.2.7 + React 19.2.7
+## Next.js 16.2.11 + React 19.2.8
 
 **When.** Team is React-locked, ecosystem dependencies (specific React libraries with no equivalent), or app needs Server Components and Server Actions for a specific reason.
 
@@ -125,7 +127,7 @@ bun create vite@latest
 **Strengths.**
 
 - Turbopack stable (default bundler in Next 16) - dev startup ~50% faster
-- React Server Components, Server Actions; React 19.2.7 features (View Transitions, useEffectEvent, Activity)
+- React Server Components, Server Actions; React 19.2 features (View Transitions, useEffectEvent, Activity)
 - Cache Components with Partial Pre-Rendering and the `"use cache"` directive
 - Largest ecosystem of components, hooks, libraries
 - Vercel-tier hosting integration
@@ -137,7 +139,7 @@ bun create vite@latest
 - You want explicit reactivity (Svelte 5 runes are clearer)
 - Bundle size matters (Next is the heaviest in this list)
 
-**Note.** Next.js 15 is still maintained but Next.js 16 stable shipped October 21, 2025. Use 16.2.4 for new projects. Middleware was renamed to `proxy.ts` in 16 to clarify the network boundary.
+**Note.** Next.js 15 is still maintained but Next.js 16 stable shipped October 21, 2025. Use 16.2.11 for new projects. Middleware was renamed to `proxy.ts` in 16 to clarify the network boundary.
 
 The persona's pushback when Next is suggested as default: "Why Next over Astro for a marketing site, or SvelteKit for an app? If the answer is 'we always use Next', the answer is wrong."
 
@@ -149,9 +151,10 @@ bun create next-app@latest
 
 ## Styling: Tailwind v4 by default
 
-**Tailwind CSS v4.2.4** (April 21, 2026) is the default styling layer.
+**Tailwind CSS v4.3.3** is the default styling layer.
 
-**Why this version matters.** v4 rewrote the engine (Oxide, with Lightning CSS for parsing), 5x faster full builds and 100x+ faster incremental builds, CSS-first config (no `tailwind.config.js`). The 4.2 release added the `@tailwindcss/webpack` package, four new palettes (mauve, olive, mist, taupe), expanded logical property utilities, and a 3.8x recompilation speedup.
+**Why this version matters.** v4 rewrote the engine (Oxide, with Lightning CSS for parsing),
+uses CSS-first configuration, and no longer assumes `tailwind.config.js` for new projects.
 
 ```css
 /* CSS-first config in v4 */

--- a/skills/full-review/SKILL.md
+++ b/skills/full-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: full-review
 description: >
-  · Run 4 fixed audits in parallel (code-review, anti-slop, security-audit, update-docs) as a quick quality gate. Triggers: 'full review', 'run all checks', 'full check', 'quad audit', 'review before merge'. Not for exhaustive/wave audits (use deep-audit) or single-dimension checks.
+  · Run 4 fixed audits in parallel (code-review, anti-slop, security-audit, update-docs) as a quick quality gate. Triggers: 'full review', 'run all checks', 'full check', 'quad audit', 'review before merge'. For deep coverage, use deep-audit.
 license: MIT
 compatibility: "Requires code-review, anti-slop, security-audit, update-docs skills installed"
 metadata:

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -18,16 +18,16 @@ cut releases, and maintain audit-grade change history across GitHub, GitLab, and
 The goal is clean, signed, traceable history that satisfies both engineering standards and
 compliance requirements (PCI-DSS 4.0).
 
-**Target versions** (June 2026):
-- **git**: 2.54.x (current stable). Git 3.0 expected late 2026 (reftable default, SHA-256 default)
-- **GitHub CLI (`gh`)**: 2.94.0
-- **GitLab CLI (`glab`)**: 1.90.x
-- **Forgejo CLI (`fj`)**: 0.5.0 (latest verified June 2026, released 2026-04-16; the project moves fast - verify the current release at `codeberg.org/forgejo-contrib/forgejo-cli`). Rust-written, official community CLI. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
-- **Forgejo**: v15.0 line current at June 2026 recheck; verify the stable branch before upgrade advice. Critical RCE (CVE-2025-68937) patched in v13.0.2+.
-- **prek**: 0.3.x (Rust, recommended) or **pre-commit**: 4.6.0 (Python, largest ecosystem)
+**Target versions** (July 2026):
+- **git**: 2.55.0 (current stable). Major additions include Linux fsmonitor, remote-group push, and parallel compatible hooks. Git 3.0 remains expected later in 2026.
+- **GitHub CLI (`gh`)**: 2.96.0
+- **GitLab CLI (`glab`)**: 1.109.0
+- **Forgejo CLI (`fj`)**: 0.6.0 (verify the current release at `codeberg.org/forgejo-contrib/forgejo-cli`). Rust-written, official community CLI. Covers PRs (incl. AGit), issues, repos, releases, tags, actions.
+- **Forgejo**: v16.0.1 current; v15.0.5 is the current LTS. Critical RCE (CVE-2025-68937) patched in v13.0.2+.
+- **prek**: 0.4.10 (Rust, recommended) or **pre-commit**: 4.6.1 (Python, largest ecosystem)
 - **git-filter-repo**: 2.47.x
 - **gitleaks**: 8.30.x (secret scanning)
-- **cosign**: 3.x (Sigstore, for tag/release signing context)
+- **cosign**: 3.1.2 (Sigstore, for tag/release signing context)
 
 This skill covers five domains depending on context:
 - **Operations** - commits, branches, merges, rebases, stashing, bisect, reflog, recovery

--- a/skills/git/references/forge-workflows.md
+++ b/skills/git/references/forge-workflows.md
@@ -2,7 +2,7 @@
 
 Patterns for GitHub, GitLab, and Forgejo - PRs/MRs, releases, branch protection, CLI usage.
 
-Research date: June 2026.
+Research date: July 2026.
 
 ---
 
@@ -247,7 +247,7 @@ does not cover yet (e.g. branch protection management).
 | Platform | Command |
 |----------|---------|
 | Arch / CachyOS (AUR) | `paru -S forgejo-cli` (or `cargo install forgejo-cli`) |
-| Debian sid / Ubuntu 25.10+ | `sudo apt install forgejo-cli` (not in Debian stable or Ubuntu LTS as of June 2026 recheck) |
+| Debian sid / Ubuntu 25.10+ | `sudo apt install forgejo-cli` (not in Debian stable or Ubuntu LTS as of July 2026 recheck) |
 | Fedora | `sudo dnf copr enable lihaohong/forgejo-cli && sudo dnf install forgejo-cli` |
 | macOS | `brew install forgejo-cli` |
 | Nix | `nix profile install nixpkgs#forgejo-cli` |

--- a/skills/git/references/recovery-and-maintenance.md
+++ b/skills/git/references/recovery-and-maintenance.md
@@ -2,7 +2,7 @@
 
 Reflog, bisect, rerere, filter-repo, stash, worktree, submodules, large repo optimization.
 
-Research date: June 2026.
+Research date: July 2026.
 
 ---
 

--- a/skills/git/references/security-and-signing.md
+++ b/skills/git/references/security-and-signing.md
@@ -2,7 +2,7 @@
 
 Credential management, commit signing setup, secret scanning, CVE reference, and hardening.
 
-Research date: June 2026.
+Research date: July 2026.
 
 ---
 
@@ -254,7 +254,7 @@ git push origin --force --tags
 | CVE-2024-50349 | < 2.48.1 | Medium | Credential leak via terminal escape in URL (Clone2Leak disclosure) |
 | CVE-2024-52006 | < 2.48.1 | Medium | Carriage return smuggling in credential protocol (same Clone2Leak disclosure as CVE-2024-50349) |
 
-**Action**: ensure git >= 2.50.1 (ideally 2.54.x). CVE-2025-48384 is **actively exploited in the
+**Action**: ensure git >= 2.50.1 (ideally 2.55.x). CVE-2025-48384 is **actively exploited in the
 wild** - a weaponized `.gitmodules` file can overwrite hook scripts to achieve RCE on `git clone
 --recursive`. Patched in v2.50.1, v2.49.1, v2.48.2, v2.47.3, and backports. Linux and macOS
 affected; Windows is not.

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -21,7 +21,7 @@ Kali is Debian-shaped, but the places where it goes wrong are usually Kali-speci
 mixing, metapackage sprawl, stale images, persistence mistakes, hardware edge cases, or people
 using the wrong tool family for the job.
 
-**Target versions** (verified June 2026):
+**Target versions** (verified July 2026):
 
 Only pin versions or dated anchors here when they materially affect compatibility or
 troubleshooting shape. For ordinary package work, prefer the live branch and repo state over a
@@ -29,10 +29,10 @@ stale package table.
 
 | Component | Version or date | Why it matters |
 |-----------|-----------------|----------------|
-| **Current dated Kali image release** | 2026.1 | current image baseline and release notes |
-| Branch docs | June 2026 recheck / verify live | branch behavior and safe lane selection matter more than a single package version |
+| **Current dated Kali image release** | 2026.2 | current image baseline and release notes |
+| Branch docs | July 2026 recheck / verify live | branch behavior and safe lane selection matter more than a single package version |
 | Metapackage docs | 2025-07 / verify live | tool-family grouping and install scope matter more than memorizing one package list |
-| Kali 2026.1 kernel lane | 6.18 | release-image baseline for hardware and driver expectations |
+| Kali 2026.2 kernel lane | 6.19 | release-image baseline for hardware and driver expectations |
 
 ## When to use
 

--- a/skills/kali-linux/references/gotchas-and-special-situations.md
+++ b/skills/kali-linux/references/gotchas-and-special-situations.md
@@ -1,6 +1,6 @@
 # Kali Gotchas and Special Situations
 
-Research date: June 2026
+Research date: July 2026
 
 The boring failures win a lot.
 

--- a/skills/kali-linux/references/metapackages-and-tool-families.md
+++ b/skills/kali-linux/references/metapackages-and-tool-families.md
@@ -1,6 +1,6 @@
 # Kali Metapackages and Tool Families
 
-Research date: June 2026
+Research date: July 2026
 
 Kali is easier to manage when you think in bundles and workflows instead of one giant package dump.
 The official metapackage docs and `kali-meta` page are the map.

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -16,7 +16,6 @@ metadata:
 Create, review, and architect Kubernetes infrastructure - from raw manifests to Helm charts to multi-cluster strategy. The goal is production-ready, security-hardened, cost-aware infrastructure that a team can maintain.
 
 **Target versions** (July 2026): Kubernetes 1.34-1.36 supported (1.36 "Haru" released April 22, 2026; 1.36.2 / 1.35.6 / 1.34.9 are the current patches). Upstream Kubernetes has no LTS; community support per minor is ~14 months. 1.33 reached upstream EOL June 28, 2026; 1.32 reached EOL February 28, 2026. Managed **vendor extended support** (AKS/EKS) carries older minors patches roughly 2 more years - attribute it to the platform, not upstream. Helm 4.2.3, Helm 3.21.3 (parallel v3 maintenance, security fixes until Nov 2026).
-
 This skill covers four domains depending on context:
 - **Manifests** - raw YAML for Deployments, Services, Gateway API routes, ConfigMaps, Secrets, PVCs
 - **Helm** - Helm 4 chart scaffolding, OCI registries, templating, multi-environment values
@@ -300,8 +299,6 @@ Reusable cross-cutting patches (monitoring, security context, sidecar injection)
 ### secretGenerator / name-suffix-hash pitfall
 
 `secretGenerator` and `configMapGenerator` append a content hash suffix to the resource name (e.g., `app-config-abc12345`). Deployments referencing the generated name by a fixed name break because the hash changes on every edit. Always reference generated resources by the base name and let Kustomize resolve the suffix, or set `options.disableNameSuffixHash: true` if the hash-based rolling update is not desired.
-
----
 
 ## Architecture
 

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Create, review, and architect Kubernetes infrastructure - from raw manifests to Helm charts to multi-cluster strategy. The goal is production-ready, security-hardened, cost-aware infrastructure that a team can maintain.
 
-**Target versions** (June 2026): Kubernetes 1.34-1.36 supported (1.36 "Haru" released April 22, 2026; 1.36.1 / 1.35.5 / 1.34.8 are the current patches). Upstream Kubernetes has no LTS; community support per minor is ~14 months. 1.33 entered maintenance April 28, 2026 and reaches upstream EOL June 28, 2026; 1.32 already hit upstream EOL February 28, 2026. Managed **vendor extended support** (AKS/EKS) carries older minors patches roughly 2 more years - attribute it to the platform, not upstream. Helm 4.2.1, Helm 3.21.x (parallel v3 maintenance, security fixes until Nov 2026).
+**Target versions** (July 2026): Kubernetes 1.34-1.36 supported (1.36 "Haru" released April 22, 2026; 1.36.2 / 1.35.6 / 1.34.9 are the current patches). Upstream Kubernetes has no LTS; community support per minor is ~14 months. 1.33 reached upstream EOL June 28, 2026; 1.32 reached EOL February 28, 2026. Managed **vendor extended support** (AKS/EKS) carries older minors patches roughly 2 more years - attribute it to the platform, not upstream. Helm 4.2.3, Helm 3.21.3 (parallel v3 maintenance, security fixes until Nov 2026).
 
 This skill covers four domains depending on context:
 - **Manifests** - raw YAML for Deployments, Services, Gateway API routes, ConfigMaps, Secrets, PVCs
@@ -173,7 +173,7 @@ Read `references/manifest-templates.md` for complete, copy-pasteable YAML templa
 
 ## Helm Charts
 
-**Helm 4** (4.0.0 released Nov 12, 2025; 4.2.1 current) is current. Helm 3.21.x gets security fixes until Nov 2026.
+**Helm 4** (4.0.0 released Nov 12, 2025; 4.2.3 current) is current. Helm 3.21.3 gets security fixes until Nov 2026.
 
 ### What changed in Helm 4
 
@@ -355,7 +355,7 @@ The Trivy supply chain attack (CVE-2026-33634) is the defining security event of
 - **Monitor for force-push events** on action repos you depend on. GitHub's audit log and StepSecurity Harden-Runner can detect this.
 - **Vendor critical CI tools** or use pre-built, verified binaries instead of pulling from upstream on every run.
 - **Rotate secrets** if any CI pipeline ran compromised Trivy (v0.69.4/5/6) between March 19-23, 2026. The infostealer exfiltrated SSH keys, cloud creds, Docker configs, and k8s tokens.
-- **Trivy safe version: v0.70.0+ for new pins.** v0.69.3 was the March 2026 rollback version. Actions such as `trivy-action@v0.35.0` and `setup-trivy@v0.2.6` still need verified commit SHAs, not mutable tags.
+- **Trivy safe version: v0.72.0+ for new pins.** v0.69.3 was the March 2026 rollback version. Actions such as `trivy-action@v0.35.0` and `setup-trivy@v0.2.6` still need verified commit SHAs, not mutable tags.
 
 ### Platform awareness
 

--- a/skills/kubernetes/references/architecture.md
+++ b/skills/kubernetes/references/architecture.md
@@ -109,7 +109,7 @@ spec:
 - Multi-source Applications (mature since ArgoCD 2.6) for separating chart version from env values.
 - `ignoreMissingValueFiles: true` for default/override patterns with ApplicationSets.
 - OCI charts: omit `oci://` prefix in ArgoCD's `repoURL`.
-- Wildcard valueFiles (documented in current Argo CD docs as of June 2026 recheck): `valueFiles: ["values/*.yaml"]`.
+- Wildcard valueFiles (documented in current Argo CD docs as of July 2026 recheck): `valueFiles: ["values/*.yaml"]`.
 - **Anti-pattern**: `randAlphaNum` or other random functions in Helm templates - causes perpetual OutOfSync.
 
 ### Promotion Strategy
@@ -223,7 +223,7 @@ The Trivy supply chain attack (CVE-2026-33634) demonstrated that **mutable Git t
 - **Separate CI secrets by environment**: staging pipeline should NOT have access to production credentials.
 - **Monitor action repos for force-push events**: subscribe to security advisories for all actions you use.
 
-**Trivy safe versions (June 2026):** use binary v0.70.0+ from official releases for new pins. The March 2026 rollback set was binary v0.69.3, `trivy-action@v0.35.0`, and `setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6.
+**Trivy safe versions (July 2026):** use binary v0.72.0+ from official releases for new pins. The March 2026 rollback set was binary v0.69.3, `trivy-action@v0.35.0`, and `setup-trivy@v0.2.6`. Do NOT use v0.69.4/5/6.
 
 ### Secrets Management
 

--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -13,7 +13,9 @@ metadata:
 
 # Localize: App Internationalization Workflow
 
-**Target versions (June 2026):** react-i18next 17.x, vue-i18n 11.x, next-intl 4.x, i18next 26.x
+**Target versions (July 2026):** react-i18next 17.0.10, vue-i18n 11.4.7, next-intl 4.13.3,
+i18next 26.3.6. For missing-key persistence, require i18next-http-middleware 3.9.7+ and
+i18next-fs-backend 2.6.6+ to fix critical prototype pollution (CVE-2026-48714).
 
 Systematic approach to internationalizing applications. Covers two scenarios: adding
 multilingual support from scratch and auditing existing i18n for gaps. Built from real

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -17,10 +17,10 @@ Build, review, and debug MCP servers that expose tools, resources, and prompts t
 assistants. The goal is secure, well-structured servers that follow the protocol spec and don't
 become yet another server with preventable injection vulnerabilities.
 
-**Target versions** (June 2026):
+**Target versions** (July 2026):
 - MCP specification: 2025-11-25 (current stable; 2026-07-28 release candidate in draft)
 - TypeScript SDK: @modelcontextprotocol/sdk 1.29.0 (1.x stable; 2.0.0-alpha in dev)
-- Python SDK: mcp 1.27.2 (v1.26.0+)
+- Python SDK: mcp 1.28.1 (minimum secure version for WebSocket Host/Origin validation; CVE-2026-59950)
 - Protocol transports: stdio, Streamable HTTP (the standalone HTTP+SSE transport was deprecated in spec 2025-03-26; SSE still streams inside Streamable HTTP)
 
 ## When to use

--- a/skills/networking/SKILL.md
+++ b/skills/networking/SKILL.md
@@ -17,24 +17,24 @@ Configure, troubleshoot, and optimize Linux networking infrastructure. Covers DN
 VPNs, firewalls (nftables), VLANs, subnetting, high availability, dynamic routing, and network
 performance tuning.
 
-**Target versions** (June 2026):
+**Target versions** (July 2026):
 
 | Tool | Version | Notes |
 |------|---------|-------|
-| Caddy | 2.11.2 | Auto-HTTPS, Caddyfile + JSON API |
-| Nginx | 1.30.0 stable / 1.29.8 mainline | New stable branch released Apr 2026; verify current advisories |
-| Traefik | 3.6.14 | Gateway API native, v2 EOL approaching |
-| HAProxy | 3.3.7 stable / 3.2.16 LTS | LTS EOL 2030-Q2 |
+| Caddy | 2.11.4 | Auto-HTTPS, Caddyfile + JSON API |
+| Nginx | 1.30.4 stable / 1.31.3 mainline | July security releases fix CVE-2026-42533/60005/56434 |
+| Traefik | 3.7.8 | Gateway API native, v2 EOL approaching |
+| HAProxy | 3.4.2 LTS / 3.3.12 stable / 3.2.21 LTS | 3.4 LTS EOL 2031-Q2 |
 | WireGuard tools | 1.0.20260223 | Kernel module + userspace tools |
-| strongSwan | 6.0.6 | swanctl config (legacy ipsec.conf deprecated) |
+| strongSwan | 6.0.7 | swanctl config (legacy ipsec.conf deprecated) |
 | nftables | 1.1.6 | iptables successor, default on modern distros |
-| keepalived | 2.3.4 | VRRP + health checks |
-| Unbound | 1.24.2 | CVE-2025-11411 fix (unsolicited NS RRSets) |
-| CoreDNS | 1.14.2 | K8s default DNS, plugin-based |
-| FRRouting | 10.6.0 | BGP, OSPF, IS-IS, PIM |
-| Tailscale / Headscale | Headscale 0.28.0 | Self-hosted control server |
-| cloudflared | 2026.3.0 | Cloudflare Tunnel (outbound-only) |
-| OpenVPN | 2.7.2 / 2.6.20 LTS | 2.7.x: multi-socket, DCO; 2.6 is the LTS branch |
+| keepalived | 2.4.3 | VRRP + health checks |
+| Unbound | 1.25.1 | CVE-2025-11411 fix (unsolicited NS RRSets) |
+| CoreDNS | 1.14.6 | K8s default DNS, plugin-based |
+| FRRouting | 10.7.0 | BGP, OSPF, IS-IS, PIM |
+| Tailscale / Headscale | Headscale 0.29.2 | Self-hosted control server |
+| cloudflared | 2026.7.2 | Cloudflare Tunnel (outbound-only) |
+| OpenVPN | 2.7.5 / 2.6.21 LTS | 2.7.x: multi-socket, DCO; 2.6 is the LTS branch |
 
 ## When to use
 

--- a/skills/networking/references/vpn.md
+++ b/skills/networking/references/vpn.md
@@ -291,7 +291,7 @@ tailscale up --advertise-exit-node     # on the exit node
 tailscale up --exit-node=<hostname>    # on the client
 ```
 
-**Headscale** (self-hosted, v0.28.0):
+**Headscale** (self-hosted, v0.29.2):
 ```bash
 # Create user and pre-auth key
 headscale users create myuser
@@ -344,7 +344,7 @@ ZeroTier is an overlay network with a simpler setup than Nebula. Requires a cont
 
 ## Cloudflare Tunnels
 
-Cloudflare Tunnel (`cloudflared`, v2026.3.0) creates outbound-only encrypted connections from
+Cloudflare Tunnel (`cloudflared`, v2026.7.2) creates outbound-only encrypted connections from
 your origin to Cloudflare's edge. No inbound ports needed - the tunnel connects out to
 Cloudflare, which proxies traffic back through it.
 

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -30,7 +30,7 @@ disposable dev shells, fleet-wide configuration without a separate config-manage
 and a single language for a workstation, a server, a container image, a NixOS VM, and a
 macOS laptop via nix-darwin.
 
-**Versions worth pinning** (verified June 2026):
+**Versions worth pinning** (verified July 2026):
 
 Pin versions only when they shape compatibility or troubleshooting. For ordinary package
 work, trust the live channel or flake lock over a stale table.
@@ -40,7 +40,7 @@ work, trust the live channel or flake lock over a stale table.
 | NixOS stable | 26.05 "Yarara" (May 2026) | current stable, released 2026-05-30, maintained until 2026-12-31 |
 | NixOS previous stable | 25.11 "Xantusia" (Nov 2025) | EOL 2026-06-30; upgrade off it now |
 | NixOS upcoming | 26.11 (~Nov 2026) | next release; do not target yet for production |
-| Nix (CLI / daemon) | 2.33 (Dec 2025) | stable upstream; 2.32 introduced skip-substitutable-downloads |
+| Nix (CLI / daemon) | 2.34 | stable upstream; verify the packaged distro lane before upgrading |
 | `nixos-rebuild-ng` | default in 25.11+ | Python rewrite of nixos-rebuild, default for new installs |
 | home-manager | release-26.05 (May 2026) | matches NixOS 26.05; unstable tracks nixos-unstable |
 | nix-darwin | tracks nixpkgs 26.05 and master | active macOS module system (Intel + Apple Silicon) |

--- a/skills/observability/SKILL.md
+++ b/skills/observability/SKILL.md
@@ -21,13 +21,13 @@ logs, alert rules, SLOs, and dashboards-as-code - and audits a repo for the gaps
 service blind. It produces config (exporters, recording/alerting rules, OTLP pipelines,
 dashboard JSON), so the AI Self-Check applies.
 
-**Target versions** (June 2026):
-- Prometheus: 3.12.0 (May 2026)
-- OpenTelemetry Collector: v0.154.0 (June 2026)
-- Grafana: 13.0.2 (June 2026)
-- Grafana Loki: 3.7.2 (May 2026)
-- Grafana Tempo: 3.0 (2026)
-- Alertmanager: 0.32.1 (April 2026)
+**Target versions** (July 2026):
+- Prometheus: 3.13.1
+- OpenTelemetry Collector: v0.156.0
+- Grafana: 13.1.1
+- Grafana Loki: 3.7.3
+- Grafana Tempo: 3.0.2
+- Alertmanager: 0.33.1
 
 ## When to use
 

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -19,7 +19,7 @@ fast-moving Fedora lane from the conservative enterprise lane, then account for 
 such as subscription-manager, CentOS Stream drift, Oracle UEK, Amazon's cloud-first defaults,
 and SELinux or firewalld behavior that people love to blame on the wrong layer.
 
-**Versions worth pinning** (verified June 2026):
+**Versions worth pinning** (verified July 2026):
 
 Only pin versions here when they materially affect compatibility or troubleshooting shape. For
 ordinary package work, prefer the live distro lane and repo state over a stale package table.

--- a/skills/routine-writer/SKILL.md
+++ b/skills/routine-writer/SKILL.md
@@ -17,7 +17,7 @@ Turn an unattended, repeatable task into a Claude Code routine: a saved prompt p
 
 **Why routines differ from chat prompts.** A routine runs as a full autonomous Claude Code cloud session. There is no permission-mode picker, no approval prompts, and no human to answer clarifying questions mid-run. A prompt that works fine in a conversation can stall or misfire silently inside a routine because the model has no one to ask. Every routine prompt must be self-contained, state its success criteria, and declare where output goes.
 
-**Research preview context** (June 2026 recheck): routines ship under the beta header `experimental-cc-routine-2026-04-01`. Behavior, limits, and the API surface can change. Pin any beta header references to that value and date so staleness is detectable.
+**Research preview context** (July 2026 recheck): routines ship under the beta header `experimental-cc-routine-2026-04-01`. Behavior, limits, and the API surface can change. Pin any beta header references to that value and date so staleness is detectable.
 
 ## When to use
 

--- a/skills/routine-writer/references/automation.md
+++ b/skills/routine-writer/references/automation.md
@@ -6,7 +6,7 @@ How to emit `/schedule` invocations, `/fire` curl templates, and GitHub Actions 
 
 ## What is automatable, and what is not
 
-The routines API surface, as of June 2026 recheck, is asymmetric:
+The routines API surface, as of July 2026 recheck, is asymmetric:
 
 | Action | Automatable? | How |
 |---|---|---|

--- a/skills/routine-writer/references/trigger-guide.md
+++ b/skills/routine-writer/references/trigger-guide.md
@@ -2,7 +2,7 @@
 
 Per-trigger specifics: cron rules, API fire semantics, GitHub event catalogue, filter fields, and how triggers combine.
 
-All details below reflect the research preview as of June 2026 recheck. The beta header is `experimental-cc-routine-2026-04-01`. Shapes, limits, and behavior can change; pin the beta header date so staleness is detectable.
+All details below reflect the research preview as of July 2026 recheck. The beta header is `experimental-cc-routine-2026-04-01`. Shapes, limits, and behavior can change; pin the beta header date so staleness is detectable.
 
 ---
 
@@ -60,7 +60,7 @@ The `routine_id` in the URL is prefixed `trig_`, not `routine_`. The full URL an
 | Header | Value |
 |---|---|
 | `Authorization` | `Bearer sk-ant-oat01-...` (per-routine token) |
-| `anthropic-beta` | `experimental-cc-routine-2026-04-01` (header dated 2026-04-01; verified June 2026) |
+| `anthropic-beta` | `experimental-cc-routine-2026-04-01` (header dated 2026-04-01; verified July 2026) |
 | `anthropic-version` | `2023-06-01` |
 | `Content-Type` | `application/json` (when body is present) |
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -17,10 +17,10 @@ Structured, multi-pass security audit. Combines automated tooling with manual pa
 
 Patterns drawn from real OSS incidents (unauthenticated admin endpoints, credential exfiltration, zip slip, auth bypass whitelists, Trivy supply chain compromise) and OpenSSF/SLSA/OWASP standards.
 
-**Target versions** (June 2026):
-- Semgrep 1.166.0, Bandit 1.9.4
-- Gitleaks 8.30.1, Betterleaks 1.1.1 (successor by same author), TruffleHog 3.95.5
-- Trivy 0.71.0 (0.69.4-0.69.6 was compromised - see known incidents; upgrade past the 0.69.x window)
+**Target versions** (July 2026):
+- Semgrep 1.170.1, Bandit 1.9.4
+- Gitleaks 8.30.1, Betterleaks 1.1.1 (successor by same author), TruffleHog 3.95.9
+- Trivy 0.72.0 (0.69.4-0.69.6 was compromised - see known incidents; upgrade past the 0.69.x window)
 - OpenSSF Scorecard 5.5.0 (v6 in proposal stage)
 - OWASP Top 10:2025 (confirmed January 2026), OWASP Agentic Top 10:2026 (released December 2025)
 
@@ -121,7 +121,7 @@ Find known CVEs in dependencies and assess supply chain risk.
 - **Python**: `pip-audit --format json` or `safety check --json`
 - **Go**: `govulncheck ./...`
 - **Rust**: `cargo audit --json` - also check for `unsafe` blocks without `// SAFETY:` comments, `transmute` misuse, unvalidated FFI boundaries
-- **General**: `trivy fs --scanners vuln .` (use Trivy 0.70.0+ from official releases, or 0.69.3 only as a March 2026 incident rollback; never use 0.69.4-0.69.6)
+- **General**: `trivy fs --scanners vuln .` (use Trivy 0.72.0+ from official releases, or 0.69.3 only as a March 2026 incident rollback; never use 0.69.4-0.69.6)
 
 **Flag**: HIGH/CRITICAL CVEs with fixes available, deps unmaintained 2+ years, lockfile out of sync with manifest, non-standard registries.
 

--- a/skills/security-audit/references/report-guide.md
+++ b/skills/security-audit/references/report-guide.md
@@ -85,7 +85,7 @@ X findings: N P0, N P1, N P2, N P3, N info.
 - semgrep: `pip install semgrep` or `brew install semgrep`
 - gitleaks: `brew install gitleaks` or `go install github.com/gitleaks/gitleaks/v8@latest`
 - trufflehog: `brew install trufflehog` or `go install github.com/trufflesecurity/trufflehog/v3@latest`
-- trivy: `brew install trivy` or see https://aquasecurity.github.io/trivy (use v0.70.0+ from official releases; v0.69.3 was the March 2026 incident rollback; never use v0.69.4-0.69.6)
+- trivy: `brew install trivy` or see https://aquasecurity.github.io/trivy (use v0.72.0+ from official releases; v0.69.3 was the March 2026 incident rollback; never use v0.69.4-0.69.6)
 - scorecard: `go install github.com/ossf/scorecard/v5/cmd/scorecard@latest`
 - checkov: `pip install checkov`
 

--- a/skills/skill-creator/references/conventions.md
+++ b/skills/skill-creator/references/conventions.md
@@ -16,7 +16,7 @@ when creating or reviewing skills to ensure consistency.
 7. AI Self-Check Patterns
 7.5. Diagnostic Skill Pitfalls
 8. Trigger Description Patterns
-9. Skill Inventory (June 2026)
+9. Skill Inventory (July 2026)
 
 ---
 
@@ -506,9 +506,9 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 
 ---
 
-## 9. Skill Inventory (June 2026)
+## 9. Skill Inventory (July 2026)
 
-### Published skills (44)
+### Published skills (46)
 
 | Skill | Effort | Date Added | Domain |
 |-------|--------|-----------|--------|
@@ -526,6 +526,7 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 | command-prompt | medium | 2026-03-25 | Shell scripting and config |
 | databases | high | 2026-03-24 | Database operations |
 | debian-ubuntu | high | 2026-04-22 | Debian / Ubuntu administration |
+| debug-triage | high | 2026-06-14 | Live incident localization and routing |
 | deep-audit | high | 2026-04-14 | Wave-based repo audit orchestrator |
 | deep-grill | high | 2026-06-13 | Plan stress-testing and red-team interrogation |
 | dev-cycle | high | 2026-04-14 | Start-to-finish development workflow |
@@ -543,6 +544,7 @@ Use this skill even when the user doesn't explicitly say "git" but is clearly do
 | mcp | high | 2026-03-30 | MCP server development |
 | networking | high | 2026-03-25 | DNS, reverse proxies, VPNs, nftables, HA |
 | nixos-btw | high | 2026-04-23 | NixOS / Nix administration |
+| observability | high | 2026-06-14 | Metrics, traces, logs, alerts, SLOs, dashboards |
 | prompt-generator | medium | 2026-03-25 | LLM prompt structuring |
 | rhel-fedora | high | 2026-04-22 | Fedora / RHEL-family administration |
 | roadmap | medium | 2026-04-05 | Gitignored roadmap management and competitor scouting |

--- a/skills/skill-refiner/SKILL.md
+++ b/skills/skill-refiner/SKILL.md
@@ -132,7 +132,7 @@ contested major flags (non-configurable).
      pre-written test cases, auto-generate 2-3 test prompts from the skill's "When to use"
      section and quality signals from its AI Self-Check. Log a warning that generated tests
      are lower quality than hand-written ones. Optionally save generated tests to a
-     test-cases-local.md file alongside test-cases.md so they accumulate across runs.
+     `references/test-cases-local.md` file alongside `references/test-cases.md` so they accumulate across runs.
    - Cross-model: skip on first iteration (no diff to review yet)
 7. **Log baseline scores**: record per-skill and aggregate scores
    in a score ledger before any edits. The ledger must include structural gate (G),
@@ -276,6 +276,20 @@ See `references/output-contract.md` for the full contract.
 - **Mode:** conditional. When invoked to **analyze, review, audit, or improve** existing repo content outside the refiner workflow, emit the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table - and write the deliverable to `docs/local/audits/skill-refiner/<YYYY-MM-DD>-<slug>.md`. When invoked to **run the refiner workflow** (its primary mode), use the existing Phase 3 "Final report" format described in the workflow; that build-mode output is unchanged by this contract.
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract; only used in audit/review mode).
 
+## Related Skills
+
+- **skill-creator** - the evaluation and improvement engine. skill-refiner invokes
+  skill-creator's review mode (Mode 2) for scoring and its improve mode for
+  generating changes. skill-creator handles individual skill quality; skill-refiner
+  handles iteration, prioritization, and orchestration. Primary dependency.
+- **full-review** - one-off collection audit across code-review, anti-slop,
+  security-audit, and update-docs. Use **full-review** for a single pass over
+  application code; use skill-refiner for iterative improvement of skill files.
+- **anti-slop** - code quality patterns. skill-refiner may invoke anti-slop
+  principles through skill-creator during improvement, but does not call anti-slop
+  directly. Different domain: anti-slop audits application code, skill-refiner
+  audits skill files.
+
 ## Rules
 
 1. **Immutability in phase 1**: never modify `references/evaluation-criteria.md`,
@@ -299,17 +313,3 @@ See `references/output-contract.md` for the full contract.
     Never edit from memory or assumption.
 12. **No score laundering**: do not call a run scored unless component scores were recorded.
     Retroactive scoring is allowed only when clearly labeled.
-
-## Related Skills
-
-- **skill-creator** - the evaluation and improvement engine. skill-refiner invokes
-  skill-creator's review mode (Mode 2) for scoring and its improve mode for
-  generating changes. skill-creator handles individual skill quality; skill-refiner
-  handles iteration, prioritization, and orchestration. Primary dependency.
-- **full-review** - one-off collection audit across code-review, anti-slop,
-  security-audit, and update-docs. Use **full-review** for a single pass over
-  application code; use skill-refiner for iterative improvement of skill files.
-- **anti-slop** - code quality patterns. skill-refiner may invoke anti-slop
-  principles through skill-creator during improvement, but does not call anti-slop
-  directly. Different domain: anti-slop audits application code, skill-refiner
-  audits skill files.

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Write, review, and architect Terraform/OpenTofu infrastructure - from individual resources to multi-account, PCI-compliant platform architectures. The goal is reproducible, drift-free, auditable infrastructure that passes both peer review and QSA assessment.
 
-**Target versions** (June 2026): Terraform 1.15.6 (IBM/HashiCorp, BSL; 1.15.x GA, 1.16.0 in alpha), OpenTofu 1.12.2 (Linux Foundation, MPL; 1.11.9 still maintained). Helm provider v3.1+, K8s provider v3.0+, AWS provider v6.x, Azure v4.x, GCP v7.x.
+**Target versions** (July 2026): Terraform 1.15.8 (IBM/HashiCorp, BSL; 1.15.x GA, 1.16 prereleases underway), OpenTofu 1.12.5 (Linux Foundation, MPL; 1.11 still maintained). Helm provider v3.1+, K8s provider v3.0+, AWS provider v6.x, Azure v4.x, GCP v7.x.
 
 This skill covers HCL, modules, operations, state, CI/CD, policy-as-code, audit trails,
 PCI-DSS 4.0 controls, drift detection, and CDE isolation.
@@ -412,7 +412,7 @@ provider "aws" {
 | Tool | Role | Status |
 |------|------|--------|
 | **Checkov** | Static HCL + plan analysis, 750+ checks, PCI/CIS/NIST frameworks | 🟢 Active, recommended |
-| **Trivy** (absorbed tfsec) | IaC + container + repo scanning, single binary | 🟢 Active (use v0.70.0+ for new pins; v0.69.4-6 COMPROMISED) |
+| **Trivy** (absorbed tfsec) | IaC + container + repo scanning, single binary | 🟢 Active (use v0.72.0+ for new pins; v0.69.4-6 COMPROMISED) |
 | **TFLint** | Provider-specific linting, catches misconfigs linters miss | 🟢 Active |
 | **OPA / Conftest** | Custom policy-as-code on JSON plan output | 🟢 Active (CNCF) |
 | **Sentinel** | Native TFC/TFE policy engine | 🟢 Active (proprietary) |

--- a/skills/terraform/references/production-checklist.md
+++ b/skills/terraform/references/production-checklist.md
@@ -35,7 +35,7 @@ Pre-deploy verification for Terraform configurations. Run through every section 
 - [ ] Separate IAM roles for plan (read-only) and apply (write)
 - [ ] CDE state files in separate backend with separate IAM role
 - [ ] GitHub Actions pinned to commit SHAs (post tj-actions compromise)
-- [ ] Trivy/Checkov pinned to safe versions (Trivy v0.70.0+ for new pins, NOT v0.69.4-6)
+- [ ] Trivy/Checkov pinned to safe versions (Trivy v0.72.0+ for new pins, NOT v0.69.4-6)
 
 ## Compliance (PCI-DSS 4.0)
 

--- a/skills/terraform/references/state-and-security.md
+++ b/skills/terraform/references/state-and-security.md
@@ -166,7 +166,7 @@ PR merged to main:
 ### Supply chain hardening for CI
 
 - **Pin ALL GitHub Actions to commit SHAs** - `uses: hashicorp/setup-terraform@<sha>`, not `@v3`. The tj-actions/changed-files compromise (March 2025, CVE-2025-30066) stole credentials from ~12 hours of CI runs via upstream reviewdog/action-setup (CVE-2025-30154).
-- **Pin Trivy to v0.70.0+ for new pins** - v0.69.3 was the March 2026 rollback version, and v0.69.4/5/6 were compromised (CVE-2026-33634). Pin to SHA or image digest.
+- **Pin Trivy to v0.72.0+ for new pins** - v0.69.3 was the March 2026 rollback version, and v0.69.4/5/6 were compromised (CVE-2026-33634). Pin to SHA or image digest.
 - **Pin Checkov to a specific version** - `pip install checkov==X.Y.Z` or use the container image with a digest
 - **Use StepSecurity Harden-Runner** to detect unexpected network connections in CI jobs
 - **Separate CI secrets by environment** - staging pipeline should NOT access prod credentials

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -15,15 +15,15 @@ metadata:
 
 Write, structure, and maintain tests across unit, integration, E2E, accessibility, and performance layers. The goal is tests that catch regressions, document behavior, and run fast in CI - not tests that exist to inflate coverage numbers.
 
-**Target versions** (June 2026):
-- Vitest **4.1.8**, Jest **30.4.2**
-- Playwright **1.60.0**, Cypress **15.13.0**
-- pytest **9.1.0**, pytest-cov **7.1.0**
-- Go **1.26.1** (testing stdlib, `testing/synctest` GA)
-- Rust **1.94.1** (`cargo test`, cargo-nextest **0.9.132**)
+**Target versions** (July 2026):
+- Vitest **4.1.10**, Jest **30.4.2**
+- Playwright **1.61.1**, Cypress **15.19.0**
+- pytest **9.1.1**, pytest-cov **7.1.0**
+- Go **1.26.5** (testing stdlib, `testing/synctest` GA)
+- Rust **1.97.1** (`cargo test`, cargo-nextest **0.9.140**)
 - Testing Library **16.3.2** (`@testing-library/react`)
-- axe-core **4.11.2** (`@axe-core/playwright`)
-- Grafana k6 **1.7.1** (load testing)
+- axe-core **4.12.1** (`@axe-core/playwright`)
+- Grafana k6 **2.1.0** (major release; review migration notes before upgrading load tests)
 
 ## When to use
 

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -18,19 +18,19 @@ setups to multi-node clusters with HA, live migration, and GPU passthrough. The 
 production-ready VM infrastructure with correct storage, memory, and CPU config that won't
 bite you at 3 AM.
 
-**Target versions** (verified June 2026):
+**Target versions** (verified July 2026):
 
 | Tool | Version | Release date | Notes |
 |------|---------|-------------|-------|
-| Proxmox VE | 9.1 | Nov 2025 | Debian 13.2 (trixie), kernel 6.17.2, QEMU 10.1.2 |
-| Proxmox Backup Server | 4.1 | Nov 2025 | Dedup, incremental, prune policies |
-| bpg/proxmox (Terraform) | 0.109.0 | Jun 2026 | Primary Proxmox IaC provider |
-| QEMU | 11.0.1 | Apr 2026 | Stable (11.0 series; GA Apr 22, 2026) |
-| libvirt | 12.4.0 | Jun 2026 | Hypervisor abstraction layer |
+| Proxmox VE | 9.2 | May 2026 | Current production lane; review upgrade notes from 9.1 |
+| Proxmox Backup Server | 4.2 | Apr 2026 | Dedup, incremental, prune policies |
+| bpg/proxmox (Terraform) | 0.111.1 | Jul 2026 | Primary Proxmox IaC provider |
+| QEMU | 11.0.2 | Jun 2026 | Stable 11.0 maintenance release |
+| libvirt | 12.5.0 | Jul 2026 | Hypervisor abstraction layer |
 | XCP-ng | 8.3 LTS | Oct 2024 | Xen-based, LTS since Jun 2025, EOL Nov 2028 |
 | VMware ESXi | 8.0 U3i | Feb 2026 | Broadcom-owned, licensing upheaval |
-| VirtualBox | 7.2.6 | Jan 2026 | Dev/testing only |
-| Packer | 1.15.1 | Mar 2026 | Image builder, multi-platform |
+| VirtualBox | 7.2.14 | Jul 2026 | Dev/testing only |
+| Packer | 1.15.4 | Jul 2026 | Image builder, multi-platform |
 | cloud-init | 26.1 | Feb 2026 | Instance initialization standard |
 
 ## When to use

--- a/skills/zero-day/SKILL.md
+++ b/skills/zero-day/SKILL.md
@@ -21,7 +21,7 @@ This is the *discovery* skill - it finds vulnerabilities nobody has catalogued y
 exploiting known weaknesses on live systems, use **lockpick**. For scanning code against known
 vulnerability patterns, use **security-audit**.
 
-**Target versions**: June 2026 snapshot. Read `references/target-versions.md` before
+**Target versions**: July 2026 snapshot. Read `references/target-versions.md` before
 pinning static analysis, reversing, fuzzing, or debugger tooling.
 
 ## When to use
@@ -465,7 +465,7 @@ and when to reach for each tool during source, binary, or live-system analysis.
 - `references/binary-analysis.md` - binary reverse engineering workflow, patch diffing, fuzzing harness development, dynamic analysis
 - `references/exploit-patterns.md` - proof-of-concept development templates by vulnerability class, with safety guidelines
 - `references/tooling-quick-reference.md` - tool catalog with install paths and best-fit usage notes
-- `references/target-versions.md` - June 2026 version snapshot for static analysis, reversing, fuzzing, and debugger tools
+- `references/target-versions.md` - July 2026 version snapshot for static analysis, reversing, fuzzing, and debugger tools
 
 ## Output Contract
 

--- a/skills/zero-day/references/target-versions.md
+++ b/skills/zero-day/references/target-versions.md
@@ -1,11 +1,11 @@
 # Zero-Day Target Versions
 
-June 2026 snapshot. Verified 2026-06-14 against GitHub release APIs and project release notes.
+July 2026 snapshot. Verified 2026-07-22 against GitHub release APIs and project release notes.
 Verify current releases before pinning.
 
-- CodeQL CLI: v2.25.6
-- Semgrep: v1.166.0
-- Joern: v4.0.557
+- CodeQL CLI: v2.26.1
+- Semgrep: v1.170.1
+- Joern: v4.0.583
 - Ghidra: 12.1.2
-- AFL++: v5.00c (5.x relicensed to AGPL-3.0; LLVM 23 support - review the license change before bundling)
-- Rizin: v0.8.2 (CVE-2026-22780 / mach0 heap overflow patched in 0.8.2)
+- AFL++: v5.02c (5.x relicensed to AGPL-3.0; LLVM 23 support - review the license change before bundling)
+- Rizin: v0.9.1 (CVE-2026-22780 / mach0 heap overflow patched since 0.8.2)


### PR DESCRIPTION
## Summary

- review all 46 published skills and refresh compatibility-relevant pins across 29 of them
- raise security floors for the June and July advisory set and document unresolved watch items
- flag major migrations for current framework, runtime, runner, and load-testing releases
- move freshness markers to July 2026 and make Reviewed and Updated for headers enforceable
- pass all 46 skills through skill-creator and fix eight collection issues across seven skills
- remove the remaining line-budget warnings, shorten oversized trigger descriptions, restore Rules-last ordering, and make one reference path explicit

## Verification

- lint-skills.sh: 46 skills, 0 errors, 0 warnings
- validate-spec.sh: 46 skills, 0 violations, 0 warnings
- skill-creator collection matrix: 46/46 clean; 630 routes resolve; no trigger pair exceeds the 50 percent overlap threshold
- freshness, contract, protected-overlay, private-leak, and deep-audit coverage checks pass
- installer and linter behavior tests pass
- shellcheck, actionlint, markdownlint, and link checks pass
- gitleaks and Semgrep report no findings

Closes #106
Closes #108
Closes #109
