### PR TITLE
fix(virtualization): validate Packer examples

### DIFF
--- a/.refiner-ledger.md
+++ b/.refiner-ledger.md
@@ -256,3 +256,20 @@ skill-creator and the lint scripts had no score-improving edit to keep.
 Terminated after iteration 3 because all phase-1 skills reached 100.0 and the
 requested minimum was satisfied. Phase 2 completed after explicit human approval.
 Commits: e78bf0d (phase 1 improvements), 65ab265 (phase 2 meta improvement).
+
+## Runtime validator recheck - 2026-07-22
+
+After the previously unavailable tools were installed, the skipped semantic checks were rerun:
+
+- `promtool 3.13.1`: `check rules` and `test rules` passed.
+- `otelcol 0.119.0-dev`: Collector configuration validation passed.
+- `packer 1.15.4`: syntax checks passed, then full validation with Proxmox plugin 1.2.4
+  and QEMU plugin 1.1.6 exposed an invalid Proxmox SCSI/I/O-thread combination,
+  deprecated ISO fields, non-parseable checksum placeholders, and an obsolete Debian 13.0.0
+  filename under the rolling `/current/` path.
+- The Packer and adjacent Proxmox examples were corrected under issue #115. Both complete
+  templates now pass plugin-backed validation, the Debian 13.6.0 installer URL resolves, and
+  focused fresh-context rereview returned NO_FLAGS.
+
+The virtualization structural, self-check, behavioral, and peer-review components remain
+100.0; the previously skipped runtime evidence is now captured rather than inferred.

--- a/.refiner-runs.json
+++ b/.refiner-runs.json
@@ -2669,5 +2669,37 @@
       "65ab2658ea7003a4411afef8fcd872dafe1c1e14"
     ],
     "notes": "Phase 2 completed after the non-configurable human checkpoint was explicitly approved. Generated phase-1 cases for four skills were promoted into the canonical catalog in phase 2. Detailed working evidence remains in ignored docs/local/."
+  },
+  {
+    "run_id": "2026-07-22-runtime-validator-recheck",
+    "kind": "verification_followup",
+    "date": "2026-07-22",
+    "branch": "fix/115-packer-runtime-validation",
+    "scored": false,
+    "scope": ["observability", "virtualization"],
+    "tools": {
+      "promtool": "3.13.1",
+      "otelcol": "0.119.0-dev",
+      "packer": "1.15.4",
+      "packer-plugin-proxmox": "1.2.4",
+      "packer-plugin-qemu": "1.1.6"
+    },
+    "findings": [
+      "Proxmox Packer template paired io_thread with an incompatible virtio-scsi-pci controller",
+      "Proxmox Packer template used deprecated top-level ISO fields",
+      "Packer examples used non-parseable checksum placeholders",
+      "Packer examples referenced the obsolete Debian 13.0.0 filename under the rolling current path"
+    ],
+    "verification": [
+      "promtool check rules PASS",
+      "promtool test rules PASS",
+      "otelcol validate PASS",
+      "Packer Proxmox template full validation PASS",
+      "Packer QEMU template full validation PASS",
+      "Debian 13.6.0 installer URL resolved with HTTP 200",
+      "focused fresh-context rereview NO_FLAGS"
+    ],
+    "issue": 115,
+    "notes": "Verification-only follow-up to the completed three-iteration collection run; no new composite score is claimed. The prior skipped-check record remains unchanged as historical fact."
   }
 ]

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -64,7 +64,7 @@ generated VM config, Terraform HCL, or Packer template, verify against this list
 
 - [ ] No hardcoded IPs, passwords, or SSH keys - use variables or cloud-init injection
 - [ ] Disk interface is virtio (scsi0 with virtio-scsi controller), not IDE, unless legacy OS
-- [ ] `iothread = true` on virtio-scsi disks for SSD-backed storage
+- [ ] `iothread = true` on SCSI disks only with the `virtio-scsi-single` controller
 - [ ] `ssd = true` emulation enabled when backing store is SSD (enables guest TRIM)
 - [ ] `discard = on` on QEMU disk config for thin-provisioned storage (fstrim passthrough)
 - [ ] Memory ballooning disabled unless tested on the specific guest OS (Alpine, some BSDs can't
@@ -84,7 +84,8 @@ generated VM config, Terraform HCL, or Packer template, verify against this list
 - [ ] Backup retention configured (not unlimited snapshots eating storage)
 - [ ] Network device uses `virtio` model, not `e1000` or `rtl8139`
 - [ ] `fstrim.timer` enabled in guest for thin-provisioned storage (completes the discard chain)
-- [ ] SCSI controller explicitly set (`virtio-scsi-single` for high IOPS, `virtio-scsi-pci` default)
+- [ ] SCSI controller explicitly set (`virtio-scsi-single` when using per-disk I/O threads;
+  `virtio-scsi-pci` only when they are disabled)
 - [ ] Machine type matches BIOS: `i440fx` with `seabios`, `q35` with `ovmf` (UEFI). Mixing
   `i440fx` + `ovmf` causes boot failures. `q35` + `seabios` works but wastes q35 features.
 - [ ] VGA type matches use case: `serial0` for headless cloud images, `virtio` for GUI VMs,
@@ -179,7 +180,7 @@ The fastest path to a production-ready VM. Skip Packer and ISO installs for stan
 1. Download a cloud image to the Proxmox node (note: the URL below points to a daily/testing image; prefer a stable release image - daily images may have cloud-init metadata gaps causing first-boot surprises):
    `wget -P /var/lib/vz/template/iso/ https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-amd64.qcow2`
 2. Create the VM shell:
-   `qm create 100 --name myvm --memory 2048 --cores 2 --cpu host --net0 virtio,bridge=vmbr0 --agent enabled=1 --scsihw virtio-scsi-pci`
+   `qm create 100 --name myvm --memory 2048 --cores 2 --cpu host --net0 virtio,bridge=vmbr0 --agent enabled=1 --scsihw virtio-scsi-single`
 3. Import and attach the disk with SSD optimizations:
    `qm importdisk 100 debian-13-generic-amd64.qcow2 local-lvm`
    `qm set 100 --scsi0 local-lvm:vm-100-disk-0,discard=on,iothread=1,ssd=1 --boot order=scsi0`
@@ -278,7 +279,7 @@ updates; disabling doesn't.
 
 **Disk interface hierarchy** (fastest to slowest):
 1. **virtio-scsi-single** + iothread - one controller per disk, best IOPS
-2. **virtio-scsi-pci** + iothread - shared controller, good for most workloads
+2. **virtio-scsi-pci** without per-disk iothreads - shared controller, good for moderate I/O
 3. **virtio-blk** - legacy virtio, good performance but fewer features
 4. **IDE** - legacy only, needed for some old OSes
 

--- a/skills/virtualization/references/image-building.md
+++ b/skills/virtualization/references/image-building.md
@@ -172,6 +172,10 @@ variable "ssh_password" {
   sensitive = true
 }
 
+variable "iso_checksum" {
+  type = string
+}
+
 source "proxmox-iso" "debian" {
   # Connection
   proxmox_url              = "https://pve1.example.com:8006/api2/json"
@@ -197,16 +201,16 @@ source "proxmox-iso" "debian" {
 
   # Disk
   disks {
-    type              = "scsi"
-    disk_size         = "20G"
-    storage_pool      = "local-lvm"
-    format            = "raw"
-    io_thread         = true
-    ssd               = true
-    discard           = true
+    type         = "scsi"
+    disk_size    = "20G"
+    storage_pool = "local-lvm"
+    format       = "raw"
+    io_thread    = true
+    ssd          = true
+    discard      = true
   }
 
-  scsi_controller = "virtio-scsi-pci"
+  scsi_controller = "virtio-scsi-single"
 
   # Network
   network_adapters {
@@ -216,10 +220,13 @@ source "proxmox-iso" "debian" {
   }
 
   # ISO
-  iso_url          = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.0.0-amd64-netinst.iso"
-  iso_checksum     = "sha256:CHECKSUM_HERE"
-  iso_storage_pool = "local"
-  unmount_iso      = true
+  boot_iso {
+    type             = "scsi"
+    iso_url          = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.6.0-amd64-netinst.iso"
+    iso_checksum     = var.iso_checksum
+    iso_storage_pool = "local"
+    unmount          = true
+  }
 
   # Cloud-init
   cloud_init              = true
@@ -265,14 +272,19 @@ build {
 }
 ```
 
-Load the temporary credentials from protected files into Packer's environment, never argv or
-shell history, and clear them after the build:
+Store only the verified 64-hex SHA-256 digest in `debian-13.6.0-amd64.sha256`. Load it and the
+temporary credentials from files into Packer's environment, never argv or shell history.
+Initialize and validate before building, then clear the variables:
 
 ```bash
 export PKR_VAR_proxmox_token="$(< /run/secrets/proxmox_token)"
 export PKR_VAR_ssh_password="$(< /run/secrets/packer_ssh_password)"
+export PKR_VAR_iso_checksum="sha256:$(< debian-13.6.0-amd64.sha256)"
+packer init proxmox-debian.pkr.hcl
+packer fmt -check proxmox-debian.pkr.hcl
+packer validate proxmox-debian.pkr.hcl
 packer build proxmox-debian.pkr.hcl
-unset PKR_VAR_proxmox_token PKR_VAR_ssh_password
+unset PKR_VAR_proxmox_token PKR_VAR_ssh_password PKR_VAR_iso_checksum
 ```
 
 ### Proxmox clone builder (faster)
@@ -320,20 +332,24 @@ variable "ssh_password" {
   sensitive = true
 }
 
+variable "iso_checksum" {
+  type = string
+}
+
 source "qemu" "debian" {
-  iso_url      = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.0.0-amd64-netinst.iso"
-  iso_checksum = "sha256:CHECKSUM_HERE"
+  iso_url      = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.6.0-amd64-netinst.iso"
+  iso_checksum = var.iso_checksum
 
   output_directory = "output-debian"
   vm_name          = "debian-13.qcow2"
 
-  format       = "qcow2"
-  disk_size    = "20G"
-  memory       = 2048
-  cpus         = 2
-  accelerator  = "kvm"
+  format      = "qcow2"
+  disk_size   = "20G"
+  memory      = 2048
+  cpus        = 2
+  accelerator = "kvm"
 
-  net_device   = "virtio-net"
+  net_device     = "virtio-net"
   disk_interface = "virtio-scsi"
 
   headless = true
@@ -367,6 +383,18 @@ build {
     ]
   }
 }
+```
+
+Validate the QEMU template with the same verified checksum input before building it:
+
+```bash
+export PKR_VAR_ssh_password="$(< /run/secrets/packer_ssh_password)"
+export PKR_VAR_iso_checksum="sha256:$(< debian-13.6.0-amd64.sha256)"
+packer init qemu-debian.pkr.hcl
+packer fmt -check qemu-debian.pkr.hcl
+packer validate qemu-debian.pkr.hcl
+packer build qemu-debian.pkr.hcl
+unset PKR_VAR_ssh_password PKR_VAR_iso_checksum
 ```
 
 ---
@@ -417,7 +445,7 @@ wget https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic
 # Create template VM
 qm create 9000 --name debian-13-template --memory 2048 --cores 2 \
   --net0 virtio,bridge=vmbr0 --agent enabled=1 \
-  --scsihw virtio-scsi-pci
+  --scsihw virtio-scsi-single
 
 # Import disk
 qm importdisk 9000 debian-13-generic-amd64.qcow2 local-lvm

--- a/skills/virtualization/references/proxmox.md
+++ b/skills/virtualization/references/proxmox.md
@@ -138,8 +138,9 @@ pveam download local debian-12-standard_12.7-1_amd64.tar.zst
 - Hugepages: configure on host first, then enable per-VM
 
 **Disk:**
-- Interface: `scsi0` with `virtio-scsi-pci` or `virtio-scsi-single` controller
-- `iothread=1` on each disk when using virtio-scsi (dedicated I/O thread per disk)
+- Interface: `scsi0` with `virtio-scsi-single` when using per-disk I/O threads;
+  `virtio-scsi-pci` is the shared-controller option without them
+- `iothread=1` on each SCSI disk only with `virtio-scsi-single`
 - `ssd=1` when the backing store is SSD (enables TRIM support in guest)
 - `discard=on` for thin-provisioned storage (passes UNMAP to storage backend)
 - Format: `raw` on LVM-thin (no overhead), `qcow2` on directory storage (snapshots)
@@ -197,7 +198,7 @@ qm create 9000 --name debian-13-template --memory 2048 --cores 2 \
   --net0 virtio,bridge=vmbr0 --agent enabled=1
 qm importdisk 9000 debian-13-generic-amd64.qcow2 local-lvm
 qm set 9000 --scsi0 local-lvm:vm-9000-disk-0,discard=on,iothread=1,ssd=1 \
-  --scsihw virtio-scsi-pci --boot order=scsi0
+  --scsihw virtio-scsi-single --boot order=scsi0
 
 # 3. Add cloud-init drive
 qm set 9000 --ide2 local-lvm:cloudinit
@@ -564,14 +565,15 @@ resource "proxmox_virtual_environment_vm" "vm" {
   name      = var.name
   vm_id     = var.vm_id
 
-  bios       = var.bios          # "seabios" or "ovmf"
-  machine    = var.machine        # "q35" for PCIe, null for default
-  on_boot    = true
-  boot_order = ["scsi0"]
+  bios          = var.bios    # "seabios" or "ovmf"
+  machine       = var.machine # "q35" for PCIe, null for default
+  scsi_hardware = "virtio-scsi-single"
+  on_boot       = true
+  boot_order    = ["scsi0"]
 
   agent {
     enabled = true
-    timeout = "2m"               # First boot timeout (cloud-init installs agent)
+    timeout = "2m" # First boot timeout (cloud-init installs agent)
   }
 
   cpu {
@@ -582,7 +584,7 @@ resource "proxmox_virtual_environment_vm" "vm" {
 
   memory {
     dedicated = var.memory_mb
-    floating  = 0                # 0 = balloon disabled
+    floating  = 0 # 0 = balloon disabled
   }
 
   disk {
@@ -602,7 +604,7 @@ resource "proxmox_virtual_environment_vm" "vm" {
 
   initialization {
     datastore_id = var.datastore
-    interface    = null           # null defaults to ide2
+    interface    = null # null defaults to ide2
 
     user_account {
       username = var.cloud_init_user
@@ -625,9 +627,9 @@ resource "proxmox_virtual_environment_vm" "vm" {
   lifecycle {
     prevent_destroy = true
     ignore_changes = [
-      disk,                      # Disk resized via qm, not Terraform
-      network_device[0].mac_address,  # Auto-generated
-      node_name,                 # Changes after live migration
+      disk,                          # Disk resized via qm, not Terraform
+      network_device[0].mac_address, # Auto-generated
+      node_name,                     # Changes after live migration
     ]
   }
 }


### PR DESCRIPTION
## Summary

- make the Proxmox and QEMU Packer templates pass full plugin-backed validation
- align SCSI I/O-thread guidance across Packer, CLI, and provider examples
- replace deprecated Proxmox ISO fields and require a verified checksum input
- update the rolling Debian installer filename to 13.6.0
- record the completed runtime-validator recheck

## Verification

- promtool check rules and test rules
- otelcol validate
- packer fmt, init, and validate with Proxmox 1.2.4 and QEMU 1.1.6 plugins
- Debian installer URL resolves with HTTP 200
- 46/46 skill lint and spec validation
- installer and lint regression suites
- Markdown, links, shell, workflow, secret, and static-analysis gates
- focused fresh-context rereview: no flags

Closes #115