### PR TITLE
feat(synology-dsm): add Synology DSM administration and btrfs recovery skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 npx skills add iuliandita/skills
 ```
 
-46 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
+47 skills for DevOps, security, infra, and software engineering, maintained with lint/spec checks, behavioral test coverage, and a [Karpathy-style autoresearch loop](https://github.com/karpathy/autoresearch).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-open_standard-blue.svg)](https://agentskills.io)
@@ -23,7 +23,7 @@ AI coding tools used to mean prompts. Prompts don't compose, don't carry between
 
 Then Karpathy pointed an agent at a 630-line training script overnight. It edited the code, ran a 5-minute training, kept changes that improved the score, discarded the rest. 700 runs, 20 wins, on one GPU. The pattern works on anything you can score.
 
-This repo applies that pattern conservatively to 46 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
+This repo applies that pattern conservatively to 47 hand-built skills. The loop helps find weak spots and propose improvements; the gates and review discipline decide what survives.
 
 ## The autoresearch loop
 
@@ -105,7 +105,7 @@ That's it. For specific skills, alternative tools, the bundled installer, or sym
 
 ## What's in here
 
-46 skills covering infra (Kubernetes, Terraform, Docker, Ansible), cluster health diagnostics, observability and SRE signal pipelines, live-incident triage, distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, security and pentesting, code review, code slimming, and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, plan interrogation and session handoff (deep-grill and handoff, inspired by Matt Pocock's grill-me and handoff skills), and meta-tooling (the skill creator, refiner, router, and full-review orchestrator).
+47 skills covering infra (Kubernetes, Terraform, Docker, Ansible), cluster health diagnostics, observability and SRE signal pipelines, live-incident triage, distros (Arch, Debian, Fedora, Kali, NixOS), networking and firewalls, Synology NAS administration and btrfs recovery, security and pentesting, code review, code slimming, and prose audits, frontend and UI design, AI/ML and MCP server work, virtualization, dev workflow tooling, plan interrogation and session handoff (deep-grill and handoff, inspired by Matt Pocock's grill-me and handoff skills), and meta-tooling (the skill creator, refiner, router, and full-review orchestrator).
 
 Browse [`skills/`](skills/) for the full list, or query it:
 
@@ -133,4 +133,4 @@ Skills are self-contained: each one references only files inside its own directo
 
 ---
 
-`kubernetes` `terraform` `docker` `ansible` `archlinux` `cachyos` `pacman` `paru` `aur` `systemd` `nixos` `nix` `flakes` `home-manager` `nix-darwin` `helm` `argocd` `ci-cd` `github-actions` `gitlab-ci` `postgresql` `mongodb` `mysql` `networking` `dns` `wireguard` `tailscale` `vpn` `nftables` `opnsense` `pfsense` `mcp` `model-context-protocol` `security-audit` `owasp` `pentesting` `code-slimming` `privilege-escalation` `ctf` `code-review` `git` `shell` `zsh` `bash` `prompt-engineering` `pci-dss` `compliance` `devops` `infrastructure-as-code` `iac` `containers` `podman` `buildah` `sealed-secrets` `haproxy` `caddy` `traefik` `nginx` `autoresearch` `self-improving` `llm` `rag` `embedding` `vector-store` `langchain` `langgraph` `openai-sdk` `anthropic-sdk` `agents` `fine-tuning` `ollama` `vllm` `promptfoo` `vitest` `jest` `playwright` `pytest` `tdd` `e2e` `accessibility` `axe-core` `load-testing` `k6` `proxmox` `qemu` `kvm` `libvirt` `packer` `cloud-init` `gpu-passthrough` `virtualization` `hypervisor` `observability` `prometheus` `opentelemetry` `grafana` `metrics` `tracing` `slo` `debug-triage` `incident-response` `outage` `troubleshooting` `root-cause`
+`kubernetes` `terraform` `docker` `ansible` `archlinux` `cachyos` `pacman` `paru` `aur` `systemd` `nixos` `nix` `flakes` `home-manager` `nix-darwin` `helm` `argocd` `ci-cd` `github-actions` `gitlab-ci` `postgresql` `mongodb` `mysql` `networking` `dns` `wireguard` `tailscale` `vpn` `nftables` `opnsense` `pfsense` `mcp` `model-context-protocol` `security-audit` `owasp` `pentesting` `code-slimming` `privilege-escalation` `ctf` `code-review` `git` `shell` `zsh` `bash` `prompt-engineering` `pci-dss` `compliance` `devops` `infrastructure-as-code` `iac` `containers` `podman` `buildah` `sealed-secrets` `haproxy` `caddy` `traefik` `nginx` `autoresearch` `self-improving` `llm` `rag` `embedding` `vector-store` `langchain` `langgraph` `openai-sdk` `anthropic-sdk` `agents` `fine-tuning` `ollama` `vllm` `promptfoo` `vitest` `jest` `playwright` `pytest` `tdd` `e2e` `accessibility` `axe-core` `load-testing` `k6` `proxmox` `qemu` `kvm` `libvirt` `packer` `cloud-init` `gpu-passthrough` `virtualization` `hypervisor` `synology` `dsm` `nas` `btrfs` `observability` `prometheus` `opentelemetry` `grafana` `metrics` `tracing` `slo` `debug-triage` `incident-response` `outage` `troubleshooting` `root-cause`

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -35,7 +35,7 @@ For a quick 4-skill sweep, use **full-review** instead.
 - Single-dimension audit (e.g., only security or only code quality) - use the individual skill directly (**security-audit**, **code-review**, etc.)
 - Auditing the skill collection itself - use **skill-creator** (Mode 3)
 - Offensive security engagement or CTF - use **lockpick** directly
-- Live-system OS administration (running `pacman`/`apt`/`dnf`, fixing a NixOS rebuild, configuring SELinux on a host, debugging an OPNsense appliance) - use the matching distro/appliance skill directly (**arch-btw**, **debian-ubuntu**, **rhel-fedora**, **nixos-btw**, **firewall-appliance**). Repo-level audit of OS-related files (PKGBUILDs, `debian/`, `*.spec`, `flake.nix`, `pf.conf`, etc.) belongs in Wave 3 of this skill
+- Live-system OS administration (running `pacman`/`apt`/`dnf`, fixing a NixOS rebuild, configuring SELinux on a host, debugging an OPNsense appliance, recovering a Synology volume) - use the matching distro/appliance skill directly (**arch-btw**, **debian-ubuntu**, **rhel-fedora**, **nixos-btw**, **firewall-appliance**, **synology-dsm**). Repo-level audit of OS-related files (PKGBUILDs, `debian/`, `*.spec`, `flake.nix`, `pf.conf`, etc.) belongs in Wave 3 of this skill
 
 ## AI Self-Check
 

--- a/skills/deep-audit/references/exclusions.md
+++ b/skills/deep-audit/references/exclusions.md
@@ -19,5 +19,6 @@ so future contributors do not re-add them by reflex.
 | **handoff** | Carries session context to another agent (writes a disposable .handoff/ doc). Moves work between sessions; does not audit repo files. |
 | **lockpick** | Offensive security / CTF / privesc. Different threat model from defensive audit; security-audit + zero-day cover the defensive side. |
 | **kali-linux** | Live-system administration of Kali. Kali is Debian-based, so repo-side packaging concerns are caught by debian-ubuntu in Wave 3. The skill itself is for running Kali, not auditing repos. |
+| **synology-dsm** | Live-appliance administration and btrfs recovery over SSH. Requires a running NAS; repos rarely contain DSM state, and DSM's storage stack is not a file-pattern audit lens. |
 | **full-review** | Alternate orchestrator (the smaller 4-skill version). Mutually exclusive with deep-audit by design. |
 | **deep-audit** | This skill. Self-invocation would loop. |

--- a/skills/synology-dsm/SKILL.md
+++ b/skills/synology-dsm/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: synology-dsm
+description: >
+  · Administer Synology DSM over SSH: volumes, btrfs, packages, snapshots, crash recovery. Triggers: 'synology', 'dsm', 'diskstation', '/volume1', 'synopkg', 'volume crashed'. Not for desktop Linux distros or their btrfs setups.
+license: MIT
+compatibility: "Requires SSH access to a Synology NAS running DSM 7, with an admin account for sudo. DSM 6 differences are noted but not covered in depth"
+metadata:
+  source: iuliandita/skills
+  date_added: "2026-07-27"
+  effort: high
+  argument_hint: "[task-or-host-or-volume]"
+---
+
+# Synology DSM: Administration and btrfs Recovery
+
+Operate Synology NAS appliances over SSH: package and service control, storage stack
+inspection, snapshots and backups, and recovery of btrfs volumes that will not mount.
+
+DSM is a Linux appliance with a heavily modified btrfs and a userspace that regenerates its own
+config. Two facts drive most of this skill: **DSM's btrfs on-disk format is newer than the
+btrfs-progs DSM ships and diverges from mainline**, so stock tools report healthy volumes as
+corrupt; and **DSM regenerates `/etc/fstab` and package state at boot**, so hand edits do not
+survive.
+
+**Target versions** (July 2026):
+- DSM 7.4.1-90080 - current release (7.4 GA was 90075, 2026-06-16)
+- DSM 7.3 (released 2025-10-08) - Long-Term Support line, maintained to October 2027. Patch
+  floor is **7.3.2-86009-3 or above**: `-2` carries the SA-26:06 fixes but not SA-26:03
+  (CVE-2026-32746). Later `-4` builds exist
+- DSM 7.2 - end of maintenance December 2025, yet it still received fixes in SA-26:06 (April
+  2026). Treat continued patching as unreliable rather than as policy, and plan an upgrade
+- Advisories: Synology-SA-26:03 (CVE-2026-32746, telnetd buffer overflow, CVSS 9.8, unauthenticated
+  RCE - keep Telnet off), Synology-SA-26:06 (nine DSM CVEs, 2026-04-15), Synology-SA-26:11 (MailPlus Server)
+- Userspace `btrfs` on the appliance is old (v4.0 on DSM 7.1 avoton). Check with `btrfs --version`
+  before assuming a subcommand exists
+
+DSM 7.1.x and earlier do not appear in current advisories' fixed-version lists; treat them as
+unpatched. That is a reason to plan an upgrade, not to run one on a unit with a broken volume.
+
+Verify the actual build before quoting any of this: `cat /etc.defaults/VERSION`.
+
+## When to use
+
+- Any task on a Synology NAS over SSH: shares, packages, services, users, storage pools
+- A volume that will not mount, shows "Volume Crashed", or has gone read-only
+- btrfs work on a Synology volume, including snapshots, subvolume flags, and offline recovery
+- Deciding whether a DSM warning is real damage or a stock-tool false positive
+- Planning disk replacement, RAID repair, or a migration between Synology units
+- Hardening DSM: SSH, admin accounts, firewall, package exposure
+
+## When NOT to use
+
+- Generic Linux administration on a normal distro - use **debian-ubuntu**, **arch-btw**,
+  **rhel-fedora**, **nixos-btw**
+- Mainline btrfs on a normal Linux host - Synology's format divergences do not apply there
+- Docker Compose authoring, image builds, registry work (Container Manager runs stock Docker) -
+  use **docker** for the container content, this skill only for DSM-side paths and permissions
+- Router, VLAN, DNS, or reverse proxy design around the NAS - use **networking**
+- OPNsense/pfSense appliances - use **firewall-appliance**
+- Kubernetes storage that happens to point at a Synology CSI target - use **kubernetes**
+- Application security review or dependency scanning - use **security-audit**
+- Localizing a live outage across an unknown stack - use **debug-triage** first, then come back here
+- Proxmox, libvirt, or generic hypervisor work - use **virtualization**
+
+## AI Self-Check
+
+Before returning any DSM command, verify. When no SSH session exists yet - the common case when
+answering a question - the appliance-state items convert into the first commands the user runs,
+in this order, rather than being skipped:
+
+- [ ] DSM major version confirmed (`cat /etc.defaults/VERSION`) - DSM 6 and DSM 7 differ in
+  service control, root login, and available tools
+- [ ] No command from the hard-refusal list below
+- [ ] Destructive storage operations run against a dm-snapshot overlay, not the live device
+- [ ] Any `mount`, `mdadm`, `dmsetup`, or `btrfs` write path stated with its blast radius
+- [ ] `cd /` before anything that unmounts `/volume1` (SSH sessions land in the home dir on it)
+- [ ] Shell syntax is ash-compatible (`/bin/sh` is ash - no process substitution, no bashisms)
+- [ ] Long-running jobs wrapped in `setsid nohup ... < /dev/null &`, not attached to the SSH session
+- [ ] Binaries deployed to `/root/` or a package dir, never `/tmp` (`noexec`)
+- [ ] Tool presence checked, not assumed - `lsof`, `fuser`, `mountpoint`, `modinfo` are absent
+- [ ] Config edits target files DSM does not regenerate, or the regeneration is accounted for
+- [ ] Backup or snapshot state verified before any repair, not after
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: DSM version, model, package dependencies, mounted volumes, and prior repair attempts are made explicit before acting
+- [ ] **Verification is real**: checks exercise the actual mount, service, or filesystem rather than reading a DSM banner
+- [ ] **Routing overlap checked**: generic Linux, container, and network tasks are routed to the matching skill
+- [ ] **Spec claims verified**: claims about DSM behavior are checked against the appliance or Synology's GPL kernel source, not recalled
+
+---
+
+## Hard refusals
+
+These are rules, not suggestions. Each one has destroyed a real volume.
+
+1. **Never run `btrfs check --repair --init-extent-tree` on a Synology volume.** Observed
+   behavior: full scan completes, then it writes a zero-entry node into the chunk tree, hits
+   `BUG_ON` in `btrfs_try_chunk_alloc`, and leaves the filesystem permanently unmountable
+   (`open_ctree failed`). There is no recovery from this short of restore or a data recovery lab.
+2. **Never `mount -o clear_cache` on a damaged volume.** Unconditional, because proving the free
+   space tree is *not* the damaged structure is exactly what a damaged filesystem prevents.
+   Clearing the tree requires freeing its own blocks, which requires the damaged block. The
+   transaction aborts during mount and the filesystem then fails `open_ctree` entirely - strictly
+   worse than before.
+3. **No repair of any kind without a dm-snapshot overlay in place.** One named exception: when
+   there is no usable backup, a single read-only mount attempt on the bare origin is permitted
+   to reach evacuation, accepting that the mount replays the log tree and is therefore a write.
+   Everything after that attempt goes through the overlay. See `references/btrfs-recovery.md`.
+4. **Never click "Repair" in DSM on a crashed volume before identifying which layer failed.**
+   The banner does not distinguish mdadm degradation from btrfs read-only. Repair at the wrong
+   layer writes to every disk in the pool.
+5. **Never run `mdadm --assemble --force` or `--create` as a first move on a suspect array.**
+   Force-assembly with stale event counts silently picks a wrong parity generation.
+6. **Never enable Telnet, including as an SSH workaround.** CVE-2026-32746 is an unauthenticated
+   RCE in DSM's telnetd (CVSS 9.8). If SSH is unusable, use the console or DSM's UI.
+
+Confirm with the user before any RAID repair, volume delete, DSM update, disk removal, or
+package uninstall. All of these are outward-facing or irreversible. When running unattended with
+no one to ask, stop and report what needs approval - never proceed on a default.
+
+---
+
+## Environment facts
+
+Observed on a DS415+ running DSM 7.1.1 (avoton). The mechanisms hold broadly, but re-check any
+row that a decision rests on - `scp -O`, in particular, follows from DSM's SFTP service being
+off, which is a toggle rather than a fixed property.
+
+| Fact | Consequence |
+|---|---|
+| `/tmp` is `noexec` | Deploy binaries to `/root/` or a package dir |
+| sftp subsystem disabled | `scp` needs `-O` (legacy protocol) or it fails with `subsystem request failed` |
+| User homes live on the data volume (`/volume1/homes/<user>`) | If the volume is down, key auth breaks (`authorized_keys` unreadable) and login prints `Could not chdir to home directory` |
+| Every SSH session lands in the home dir | `umount /volume1` fails with "target is busy". Always `cd /` first |
+| `/bin/sh` is ash | No bashisms, no process substitution `<(...)` |
+| Missing tools | `fuser`, `mountpoint`, `modinfo`, `lsof` absent - read `/proc` directly |
+| Present tools | `python3`, `mdadm`, `dmsetup`, `losetup`, `truncate`, `blockdev`, `btrfs`, `systemctl`, `smartctl` |
+| Root login | DSM 7 disables direct root SSH. Log in as an admin user and `sudo -i` |
+| `/etc/fstab` is regenerated at boot | Hand-edited mount options do not persist |
+| `syno_poweroff_task` | Exists on DSM 6, **not** on DSM 7.1+. Stop packages and services individually |
+| Defaults live in `/etc.defaults/` | Edits there survive DSM updates better than `/etc/`; both can be overwritten by a major upgrade |
+
+Read `references/dsm-cli.md` for the command reference (packages, services, shares, users,
+indexing, logs, SMART, notifications).
+
+---
+
+## Workflow
+
+### Step 1: Identify the appliance before anything else
+
+```sh
+cat /etc.defaults/VERSION                  # productversion, buildnumber, majorversion
+grep unique /etc.defaults/synoinfo.conf    # platform, e.g. synology_avoton_415+
+uname -a                                   # kernel (3.10.x or 4.4.x on most models)
+synopkg list --name                        # installed packages
+```
+
+Model and build determine which GPL kernel source to read, which btrfs features exist, and
+whether DSM 6 or DSM 7 semantics apply. Do not skip this step to save a round trip - almost
+every later decision depends on it.
+
+### Step 2: Establish the storage picture
+
+```sh
+cat /proc/mdstat                           # all md arrays, degraded state, resync progress
+sudo vgs; sudo lvs                         # LVM layer
+sudo btrfs filesystem show                 # filesystems and devices
+sudo btrfs filesystem usage /volume1       # data vs metadata allocation
+df -h /volume1
+mount | grep volume                        # actual mount options in force
+```
+
+The stack is `/dev/sdX3 -> mdN (RAID) -> vgN/volume_N -> cachedev_N (flashcache shim) -> btrfs`.
+`md0` (system, ~8 GB) and `md1` (swap, ~2 GB) are RAID1 across **all** disks and are commonly
+found degraded and ignored for months. Check them; repair is a plain `mdadm --add` and an 8 GB
+RAID1 resync finishes in under a minute.
+
+Read `references/storage-and-backup.md` for SHR, disk replacement, compatibility database,
+snapshots, and backup verification.
+
+### Step 3: Route on symptom
+
+| Symptom | Route |
+|---|---|
+| Volume mounts, DSM is healthy, routine task | `references/dsm-cli.md` |
+| Degraded array, disk replaced, pool repair | `references/storage-and-backup.md` |
+| Volume read-only, "Volume Crashed", will not mount | `references/gotchas.md`, then `references/storage-and-backup.md` section 4 **first** - the banner does not say which layer failed. Only once the array and LV are confirmed healthy does it become `references/btrfs-recovery.md` |
+| Stock `btrfs` reports corruption but the volume mounts and reads fine | Likely a Synology format divergence, not damage. `references/btrfs-recovery.md`, section on private trees |
+| Package keeps restarting after being disabled | Dependency resurrection - `references/dsm-cli.md` |
+
+### Step 4: Change with a stated blast radius
+
+Before any write: state what is affected, whether it is reversible, and what the rollback is.
+For storage operations, the rollback is the overlay or a verified backup - nothing else counts.
+
+### Step 5: Verify against the runtime, not the UI
+
+DSM's banners lag reality and its health status is derived. Verify the thing itself:
+
+```sh
+mount | grep /volume1                          # actually mounted, and rw or ro?
+sudo btrfs filesystem usage /volume1           # metadata headroom
+sudo dmesg | tail -100                         # kernel truth about the mount
+synopkg status <Pkg>                           # package state as JSON
+# damage survey: hours on a large share, so detach it and keep stderr
+sudo setsid nohup sh -c 'find /volume1/<share> -size +0 > /dev/null' \
+  > /root/survey.log 2>&1 < /dev/null &
+```
+
+`find <dir>` alone performs readdir only and reads no inodes, so it reports a badly damaged
+filesystem as clean. **`-type f` does not fix that**: `find` answers `-type` from the `d_type`
+that `readdir` already returned and skips the `stat` entirely. Use a predicate that needs inode
+data - `-size +0`, `-printf '%s\n'`, `-newer <ref>` - and let stderr through instead of
+discarding it, since the EIO lines are the finding.
+
+---
+
+## Recovery first moves
+
+**Establish the goal before the sequence.** With a verified backup, the goal is repair. Without
+one, the goal is **evacuation**: get the data off a read-only mount first, and treat repair as a
+later, optional problem. Buying destination disks is cheaper than a recovery lab. Ask which
+situation the user is in; do not assume.
+
+When a volume will not mount, do these in order. Details in `references/btrfs-recovery.md`;
+read `references/gotchas.md` before the first write of any kind.
+
+**The branch that decides the order:** with a verified backup, build the overlay first and run
+every mount attempt against it. Without one, take the named exception in hard refusal 3 - one
+read-only mount attempt on the bare origin, accepting the log-replay write, because evacuation
+beats purity. After that attempt, everything goes through the overlay.
+
+1. **Stop writing.** Do not repair, do not reboot repeatedly, do not let DSM auto-repair. Do not
+   update DSM on a unit with a broken volume.
+2. **Identify version and platform** (Step 1 above), and confirm the failure is above the RAID
+   layer (`references/storage-and-backup.md` section 4).
+3. **Try the cheap read-only mount options**, cheapest first, reading `dmesg` after each failure.
+   `-o ro,no_quota_tree` alone recovers a common class of Synology mount failure. Note that a
+   read-only mount still replays the log tree, which is a write - the reference explains when
+   that forces the overlay first.
+4. **If a read-only mount succeeds and there is no backup, evacuate now.** Repair decisions get
+   easier once the data is elsewhere.
+5. **Build a dm-snapshot overlay and fingerprint the origin** before any write attempt. The
+   overlay and a mounted origin are mutually exclusive, so this is a branch point, not a step
+   that stacks on top of step 3.
+6. **Read the GPL kernel source** for the nearest published release family when the cheap options
+   fail (the archive carries families such as `7.3-86009`, `7.2-72806`, `7.1.1-42962`, not every
+   build; 7.4 has no drop yet):
+   `https://archive.synology.com/download/ToolChain/Synology%20NAS%20GPL%20Source/<VER>-<BUILD>/`
+   Extract `fs/btrfs/` and read `ctree.h`, `disk-io.c`, `super.c`, `usrquota.c`. It converts a
+   black box into a documented system, and twenty minutes there beats hours of probing.
+7. **Only then** consider offline tools, and only a patched btrfs-progs build, against the overlay.
+
+---
+
+## Packages and services
+
+```sh
+synopkg list --name                  # installed packages (no --started on 7.1)
+synopkg status <Pkg>                 # JSON status
+synopkg stop|start <Pkg>
+synopkg enable|disable <Pkg>         # autostart marker in /var/packages/<Pkg>/enabled
+systemctl stop pkgctl-<Pkg>.service  # the underlying unit
+```
+
+**Package dependencies resurrect packages.** `synopkg disable` is not enough if another
+installed package declares the target in `install_dep_packages`:
+
+```sh
+grep -h install_dep_packages /var/packages/*/INFO
+```
+
+Synology Drive declares SynoFinder, so SynoFinder restarts within a minute of being disabled.
+When the goal is "stop indexing this share", use the indexer's own control tool rather than
+fighting the package manager - see `references/dsm-cli.md`.
+
+---
+
+## Security
+
+- Keep Telnet disabled (CVE-2026-32746, CVSS 9.8, unauthenticated RCE in DSM's telnetd)
+- Disable the default `admin` account; use a named admin with 2FA
+- Move SSH off 22 only as noise reduction, not as a control; restrict by firewall rule instead
+- Do not expose DSM's web UI directly to the internet. QuickConnect and DDNS both widen exposure;
+  prefer a VPN into the LAN
+- Patch level matters more than version line: 7.3 LTS with current patches is a supported
+  posture, 7.2.1 without them is not
+- Snapshots are not backups until they are replicated off the unit. Immutable (WORM) snapshots,
+  introduced in DSM 7.2, resist an admin-account compromise; ordinary snapshots do not
+- Package exposure is the real attack surface: MailPlus, Photos, and Drive carry most advisories.
+  Uninstall what is unused
+
+## Performance
+
+- Check `btrfs filesystem usage` metadata headroom before blaming disks. A metadata-full btrfs
+  behaves like a failing filesystem while every disk is healthy
+- Indexing (`synoindexd`, `synoelasticd`) and Photos face-recognition dominate CPU on small units;
+  pause per share rather than disabling packages
+- `synoindexd` and snapshot deletion both spike I/O; do not benchmark during either
+- SHR/RAID5 resync and btrfs balance are both throughput killers - check `/proc/mdstat` before
+  investigating "slow NAS" complaints
+
+---
+
+## Reference Files
+
+- `references/dsm-cli.md` - DSM command surface: packages, services, shares, users, network,
+  indexing, logs, notifications, SMART, DSM API. Read for any routine administration task.
+- `references/storage-and-backup.md` - SHR and the RAID/LVM/btrfs stack, disk replacement,
+  drive compatibility database, snapshots, Hyper Backup, restore verification. Read when the
+  task touches disks, pools, snapshots, or backups.
+- `references/btrfs-recovery.md` - Synology's btrfs divergences (private root flags, private
+  trees, private mount options, the usrquota mount trap), dm-snapshot overlay procedure, mount
+  escalation ladder, tool matrix, btrfs-progs bugs, subvolume flag ioctls. Read when a volume
+  will not mount or when stock tools report corruption.
+- `references/gotchas.md` - footguns, diagnostic hygiene, ash shell traps, behavior of a
+  damaged volume. Read before any repair attempt.
+
+## Output Contract
+
+See `references/output-contract.md` for the full contract.
+
+- **Skill name:** SYNOLOGY-DSM
+- **Deliverable bucket:** `audits`
+- **Mode:** conditional. When invoked to **analyze, review, audit, or improve** an existing
+  system (health review, recovery post-mortem, hardening audit), emit the full contract and
+  write the deliverable to `docs/local/audits/synology-dsm/<YYYY-MM-DD>-<slug>.md`. When invoked
+  to answer a question, run a routine command, or explain behavior, respond freely.
+- **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
+
+## Related Skills
+
+- **docker** - Container Manager on DSM is stock Docker plus a GUI. That skill owns the compose
+  file and image; this one owns `/volume1` paths, DSM permissions, and package lifecycle.
+- **networking** - DNS, VPN, reverse proxy, and VLAN work around the NAS. This skill stops at
+  the appliance's own interfaces.
+- **debug-triage** - localizes an unknown failing layer during a live incident. Use it first when
+  "the NAS is down" could be network, power, or storage; this skill takes over once it is DSM.
+- **debian-ubuntu** - DSM 7 is Debian-derived, so some package intuitions carry over, but DSM's
+  own package manager and config regeneration do not behave like apt.
+- **security-audit** - reviews application code and dependencies. This skill covers appliance
+  hardening and DSM-specific exposure.
+- **virtualization** - Virtual Machine Manager on DSM runs QEMU/KVM underneath; that skill covers
+  the guest and hypervisor concepts, this one the DSM package around them.
+
+## Rules
+
+1. **Identify the DSM version and platform before advising anything.** Behavior differs across
+   DSM 6, 7.1, 7.2, and 7.4.
+2. **No repair without an overlay.** Any operation that can write to a damaged volume runs
+   against a dm-snapshot overlay first.
+3. **Never `--init-extent-tree`, never `clear_cache` on a damaged volume.** Both destroy volumes,
+   and the `clear_cache` ban is unconditional.
+4. **Read Synology's GPL kernel source for the exact build before deep recovery work.** It is
+   authoritative documentation of the on-disk format and nothing else is.
+5. **Treat mainline-tool corruption reports as unverified.** Synology's private root flags and
+   trees are rejected by mainline's tree-checker. Confirm damage against the DSM kernel's own
+   behavior before acting on a stock-tool verdict.
+6. **Damage surveys need an inode-reading predicate.** `find` bare or with `-type f` reads no
+   inodes and reports a corrupt volume as clean. Use `-size +0` or `-printf '%s\n'`.
+7. **Confirm before destructive or outward-facing actions**: RAID repair, volume delete, disk
+   removal, package uninstall, DSM update, reboot of a production unit.
+8. **Detach long-running jobs.** `setsid nohup ... < /dev/null &`, with the logic in a script
+   file so `pkill -f` patterns cannot match your own command line.
+9. **Suspect the diagnostic first when it returns nothing.** Empty output on a damaged system is
+   usually a broken check, not a clean result.
+10. **Snapshots are not backups.** Verify a restore path off the unit before touching storage.

--- a/skills/synology-dsm/references/btrfs-recovery.md
+++ b/skills/synology-dsm/references/btrfs-recovery.md
@@ -1,0 +1,445 @@
+# Synology btrfs: Divergences and Recovery
+
+Everything here was verified on hardware during a real recovery (DS415+, DSM 7.1.1-42962,
+avoton platform, btrfs on mdraid5). Where something is inferred rather than observed, it says so.
+Kernel line references are to Synology's published GPL source for that build.
+
+Read this when a Synology volume will not mount, has gone read-only, or when stock btrfs tools
+report corruption on a volume that otherwise behaves.
+
+**Build sensitivity.** The mechanisms here (usrquota walking every subvolume, private trees being
+derived data, mainline's tree-checker rejecting private flags) hold across Synology builds. The
+exact numbers do not necessarily: flag bit positions, tree objectids, the set of accepted mount
+options, and the userspace `btrfs` version were read from one build's GPL source
+(DSM 7.1.1-42962, avoton, 3.10 kernel). Newer platforms ship a 4.4 kernel line. Before acting on
+a specific constant, confirm it in the GPL source for the target build (section 8) - that is
+cheap and it is the whole reason to download the source.
+
+## Contents
+
+1. Why stock tools lie
+2. Private root flags
+3. Private trees
+4. Private mount options
+5. The usrquota mount trap
+6. Free space tree
+7. Superblock
+8. GPL source: the highest-value move
+9. The dm-snapshot overlay
+10. Mount escalation ladder
+11. Tool matrix and patched builds
+12. btrfs-progs bugs on damaged filesystems
+13. Setting Synology subvolume flags from userspace
+14. Damage surveying
+
+---
+
+## 1. Why stock tools lie
+
+Synology's on-disk format is **newer than their own userspace tools** and diverges from
+mainline's version of the same features. That single sentence explains nearly every tool failure:
+
+- DSM's `/sbin/btrfs` (v4.0 on DSM 7.1) refuses to open the filesystem read-write:
+  `unsupported option features (3)`
+- Mainline btrfs-progs opens it read-write but its tree-checker rejects Synology's private root
+  flags as corruption, so a healthy volume is reported as damaged
+
+Neither verdict is trustworthy on its own. Confirm against the DSM kernel's own behavior.
+
+## 2. Private root flags (`btrfs_root_item.flags`)
+
+```
+BTRFS_ROOT_SUBVOL_RDONLY            (1ULL << 0)
+BTRFS_ROOT_SUBVOL_HIDE              (1ULL << 32)   0x100000000
+BTRFS_ROOT_SUBVOL_NOLOAD_USRQUOTA   (1ULL << 33)   0x200000000
+BTRFS_ROOT_SUBVOL_CMPR_RATIO        (1ULL << 34)   0x400000000
+BTRFS_ROOT_SUBVOL_DISABLE_QUOTA     (1ULL << 35)   0x800000000
+BTRFS_ROOT_SUBVOL_DEAD              (1ULL << 48)
+```
+
+Mainline's tree-checker (Linux 5.4+ and matching btrfs-progs) rejects these as corruption. A
+volume carrying them is reported as damaged by stock tools even when perfectly healthy.
+
+Patch for offline tools:
+
+```c
+// kernel-shared/tree-checker.c
+const u64 valid_root_flags = ... | BTRFS_ROOT_SUBVOL_DEAD | 0xFFFFFFF00000000ULL;
+```
+
+Userspace-visible equivalents live in `include/uapi/linux/btrfs.h` at the same bit positions:
+`BTRFS_SUBVOL_HIDE`, `BTRFS_SUBVOL_NOLOAD_USRQUOTA`, `BTRFS_SUBVOL_CMPR_RATIO`,
+`BTRFS_SUBVOL_DISABLE_QUOTA`.
+
+## 3. Private trees
+
+```
+ 200  BTRFS_USRQUOTA_TREE_OBJECTID
+ 201  BTRFS_QUOTA_TREE_OBJECTID
+ 202  BTRFS_BLOCK_GROUP_HINT_TREE_OBJECTID
+ 203  BTRFS_BLOCK_GROUP_CACHE_TREE_OBJECTID
+ 205  BTRFS_SYNO_USAGE_TREE_OBJECTID
+ 206  BTRFS_SYNO_EXTENT_USAGE_TREE_OBJECTID
+-206  BTRFS_SYNO_SUBVOL_USAGE_OBJECTID
+key type 165 = SYNO_BTRFS_EXTENT_USAGE_KEY
+```
+
+**202, 203, 205, and 206 hold derived data** - caches and usage accounting, all reconstructible.
+Damage there is not authoritative data loss. Mainline tools emit
+`Invalid key type(BLOCK_GROUP_ITEM) found in root(203)` and `ignoring invalid key`; that is
+correct, harmless behavior, not a symptom of the real problem.
+
+A broken tree 203 is explicitly non-fatal at mount (`disk-io.c`):
+
+```c
+ret = btrfs_check_syno_block_group_cache_tree(fs_info);
+if (ret) { fs_info->block_group_cache_tree_broken = 1; WARN_ON_ONCE(1); }
+```
+
+## 4. Private mount options (`fs/btrfs/super.c`)
+
+```
+no_quota_tree                    forces quota_root/usrquota_root to -ENOENT
+block_group_cache_tree
+clear_block_group_cache_tree
+no_block_group_hint
+syno_allocator / clear_syno_allocator
+synoacl, synoumounthang=%d
+```
+
+`no_quota_tree` cannot be applied on remount, only on a fresh mount.
+
+**`no_quota_tree` is the single most useful recovery option on Synology btrfs.** See section 5
+for why.
+
+## 5. The usrquota mount trap
+
+`usrquota_subtree_load_one()` in `fs/btrfs/usrquota.c` walks **every** subvolume at `open_ctree`
+time to build accounting. For each subvolume it enumerates `ROOT_REF` children and calls
+`btrfs_read_fs_root_no_name()` on each.
+
+If **any single subvolume root node is unreadable**, that call fails, the error propagates, and
+`open_ctree` fails. **The entire filesystem becomes unmountable because of one damaged
+subvolume.** The kernel tries to degrade (`usrquota disabled due to faield to load tree` - the
+typo is upstream) but still fails the mount.
+
+The control flow detail that matters: the per-subvolume skip flag is checked when a subvolume is
+*dequeued*:
+
+```c
+update_queue:
+    if (btrfs_root_noload_usrquota(subvol_root))
+        goto out;
+```
+
+but a child's root is read inside the **parent's** enumeration loop, before anything checks the
+child's flags. Therefore:
+
+- Setting `NOLOAD_USRQUOTA` on the damaged subvolume does **not** help
+- Setting it on the **parent** does, because the parent returns before enumerating children
+
+On DSM the top-level container is subvolume **256** (`@syno`), and DSM mounts it as the volume
+root. So `/volume1` is subvolume 256's root and is a valid target for the ioctl in section 13.
+
+Cost: usrquota accounting is disabled for everything beneath, so per-share quotas and DSM usage
+reporting stop working. Reversible.
+
+## 6. Free space tree
+
+`compat_ro_flags` bit 0 = `FREE_SPACE_TREE`, bit 1 = `FREE_SPACE_TREE_VALID`, so a normal
+Synology volume shows `0x3`.
+
+Mount-time behavior:
+
+```c
+if (CLEAR_CACHE && compat_ro(FREE_SPACE_TREE))        clear_free_space_tree = 1;
+else if (compat_ro(FREE_SPACE_TREE) && !compat_ro(FREE_SPACE_TREE_VALID)) {
+    btrfs_warn("free space tree is invalid");         clear_free_space_tree = 1;
+}
+```
+
+Note the second branch: the kernel self-heals an *invalid* free space tree with no mount option
+at all. If `FREE_SPACE_TREE_VALID` is set, it trusts the tree.
+
+**Clearing the valid bit is not a safe alternative to `clear_cache`.** Both branches set the same
+`clear_free_space_tree = 1` and converge on one call to `btrfs_clear_free_space_tree()`, so
+clearing the bit reaches the exact code path that hard refusal 2 bans, with the same failure mode
+(freeing the tree's own blocks through the damage). Treat it as covered by that refusal. The
+useful part of this section is diagnostic: `compat_ro_flags` tells you whether the kernel already
+considers the tree invalid and is trying to rebuild it on its own.
+
+## 7. Superblock
+
+Standard btrfs layout. Field offsets used in practice:
+
+```
+0    csum[32]        (crc32c, little-endian, in the first 4 bytes)
+64   magic  "_BHRfS_M" (0x4D5F53665248425F)
+180  compat_ro_flags
+188  incompat_flags
+196  csum_type
+```
+
+Primary at 0x10000 (64 KiB); mirrors at 0x4000000 (64 MiB) and 0x4000000000 (256 GiB), and only
+those that fall within the device - btrfs keeps at most three copies (`BTRFS_SUPER_MIRROR_MAX`).
+Checksum is CRC32C (Castagnoli, poly 0x82F63B78, init 0xFFFFFFFF, final xor 0xFFFFFFFF) over
+bytes `[32:4096]`.
+
+Any tool that rewrites a superblock should first **recompute the existing checksum and confirm it
+matches on-disk** before trusting itself to write a new one. Cheap, and it catches an incorrect
+implementation immediately.
+
+## 8. GPL source: the highest-value move
+
+Synology publishes occasional `<version>-<build>` source drops, not one per build. The whole
+archive is nine entries: `7.3-86009`, `7.2-72806`, `7.2-64570`, `7.1.1-42962`, `7.0-41890`,
+`6.2-25556`, `6.1-15284`, `6.1-15152`, `1.3-9346` - and as of July 2026 there is no 7.4 drop. If the target build has no matching entry, read the closest
+lower family and treat every constant taken from it as provisional (see the build-sensitivity
+note at the top of this file).
+
+```
+https://archive.synology.com/download/ToolChain/Synology%20NAS%20GPL%20Source/<VER>-<BUILD>/
+https://global.synologydownload.com/download/ToolChain/Synology%20NAS%20GPL%20Source/<VER>-<BUILD>/<platform>/linux-3.10.x.txz
+```
+
+Find version and platform:
+
+```sh
+cat /etc.defaults/VERSION                       # productversion, buildnumber
+grep unique /etc.defaults/synoinfo.conf         # e.g. synology_avoton_415+
+```
+
+The kernel driver is the authoritative documentation of the on-disk format. `btrfs-progs` source
+is absent from the older drops (7.1.1-42962, 7.2-72806); newer drops may carry a
+`btrfs-progs-*.txz` alongside the kernel, which would be a better base for a format-aware build
+than patched mainline. List the platform directory before assuming you have to patch. Extract
+only what is needed:
+
+```sh
+tar xf linux-3.10.x.txz --wildcards '*/fs/btrfs/*'
+tar xf linux-3.10.x.txz --wildcards '*/include/uapi/linux/btrfs.h'
+```
+
+Reading `fs/btrfs/{ctree.h,disk-io.c,super.c,usrquota.c}` for twenty minutes produced more than
+hours of black-box probing. **Do this early, not late.**
+
+Newer platforms ship a 4.4.x kernel rather than 3.10.x; the archive path lists what exists for
+that build. Verify the kernel line with `uname -r` before guessing the filename.
+
+## 9. The dm-snapshot overlay
+
+Always work on an overlay. Reads pass through to the origin, writes divert to a COW file.
+
+Confirm the device first - `cachedev_0` is volume 1 on a single-volume unit, not a universal
+name. Check `lvs` and `btrfs filesystem show` before substituting it into anything.
+
+Unmounting the origin is a prerequisite and it is not a one-liner:
+
+```sh
+cd /                                    # your shell sits in /volume1/homes/<user>
+synopkg list --name                     # stop every running package first
+sudo synopkg stop <Pkg>                 # one by one; no syno_poweroff_task on DSM 7
+sudo systemctl stop nfs-server nfs-mountd synoindexd synoelasticd   # then services holding it
+sudo ls -l /proc/*/cwd /proc/*/root /proc/*/fd/* 2>&1 | grep volume1   # who holds it (no lsof)
+sudo umount /volume1
+```
+
+The COW file must live somewhere that is not the volume being recovered, on a filesystem that
+supports sparse files and large files. A USB volume (`/volumeUSB1/usbshare`) is the usual choice
+but DSM commonly mounts those as exFAT or FAT32, where FAT32 caps a file at 4 GiB and neither
+gives you sparseness - `truncate -s 300G` then fails or preallocates. Check first:
+
+```sh
+df -T /volumeUSB1/usbshare                     # ext4 or btrfs, not vfat/exfat
+truncate -s 300G /volumeUSB1/usbshare/overlay.img
+du -h --apparent-size /volumeUSB1/usbshare/overlay.img   # 300G apparent
+du -h /volumeUSB1/usbshare/overlay.img                   # ~0 if truly sparse
+```
+
+A second internal volume works. An NFS or iSCSI target is possible but adds a failure mode
+mid-repair. There is no valid option that stores the COW file on the origin.
+
+```sh
+ORIGIN=/dev/mapper/cachedev_0           # verify this name first
+LOOP=$(sudo losetup -f --show /volumeUSB1/usbshare/overlay.img)
+sudo dmsetup create ovl --table "0 $(sudo blockdev --getsz $ORIGIN) snapshot $ORIGIN $LOOP P 8"
+```
+
+Tear down with `umount`, then `dmsetup remove ovl`, then `losetup -d "$LOOP"`.
+
+Pair it with an origin fingerprint taken before any work and re-verified after:
+
+```sh
+for off in 0 67108864 1073741824 274877906944; do          # byte offsets: 0, 64 MiB, 1 GiB, 256 GiB
+  sz=$(sudo blockdev --getsize64 "$ORIGIN")
+  [ "$off" -lt "$sz" ] || { echo "skip $off: past end of device"; continue; }
+  sudo dd if="$ORIGIN" iflag=skip_bytes,count_bytes skip=$off count=8388608 | md5sum
+done
+```
+
+Use byte offsets with `skip_bytes`, not `bs=1M skip=N` - with a 1 MiB block size, `skip=10485760`
+means 10 TiB, and on any smaller device `dd` reads nothing, prints the md5 of empty input, and
+still exits 0. Never send that `dd` to `2>/dev/null`: a short read is exactly the failure this
+check exists to catch.
+
+Constraints:
+
+- The origin must not be mounted; dm-snapshot needs to open it. The overlay and a mounted
+  `/volume1` are mutually exclusive
+- The overlay carries the same fsid as the array, so never mount both at once - btrfs identifies
+  filesystems by UUID
+- COW usage shows in `dmsetup status ovl` as `used/total`. Watch it to confirm whether a tool is
+  actually writing
+- Size the COW file for the worst case, not the expected case. A repair that rewrites metadata
+  can consume far more than intuition suggests, and a full COW device fails the overlay
+
+In the recovery this document comes from, the overlay absorbed three separate
+filesystem-destroying outcomes. It is not optional.
+
+## 10. Mount escalation ladder
+
+**A read-only mount is not a read-free mount.** btrfs replays the log tree even with `-o ro`, and
+performs delayed transactions during mount. Suppressing that needs an explicit option, and on
+DSM you probably do not have one: the `rescue=nologreplay` namespace and its `norecovery` alias
+are modern mainline, while DSM ships 3.10 and 4.4 kernels that predate them. Worse, those
+kernels do accept `recovery`, which means *use the backup root* (later renamed `usebackuproot`)
+and does not skip log replay. An unrecognized btrfs option fails the mount outright rather than
+being ignored, so testing is cheap and unambiguous - try it, read `dmesg`, and plan on the
+baseline that log replay cannot be suppressed.
+
+Consequence: on a damaged volume, run the ladder against the overlay unless the kernel accepts a
+log-replay-suppressing option. Rung 1 on the bare origin is a write.
+
+Set the target once, and mount somewhere neutral so DSM does not act on the result:
+
+```sh
+TARGET=/dev/mapper/ovl          # the overlay. Only ever the origin under the named exception
+mkdir -p /mnt/vol1              # not /volume1
+```
+
+Then try in order, cheapest and least invasive first, reading `dmesg` after each failure:
+
+```sh
+mount -o ro                                                  $TARGET /mnt/vol1   # rung 1
+mount -o ro,no_quota_tree                                    $TARGET /mnt/vol1   # rung 2
+mount -o ro,no_quota_tree,no_block_group_hint                $TARGET /mnt/vol1   # rung 3
+mount -o rw,no_quota_tree,clear_block_group_cache_tree       $TARGET /mnt/vol1   # rung 4
+```
+
+Rung 2 fixes the usrquota trap in section 5 and is the one that recovers a common class of
+Synology mount failure. Rung 4 is **an unconditional write**: overlay mandatory, no exemption -
+the log-replay discussion above applies only to the read-only rungs.
+
+Rung 5 does not exist. `clear_cache` is on the hard-refusal list unconditionally, because
+establishing that the free space tree is *not* the damaged structure is exactly what a damaged
+filesystem prevents you from doing. If the ladder ends at rung 4, the next step is offline tools
+against the overlay, not a fifth mount option.
+
+Always read `dmesg` after a failed mount. Capture it by diffing full snapshots rather than
+tracking line offsets, because the ring buffer wraps.
+
+Stopping DSM services is a prerequisite for unmounting `/volume1`. `syno_poweroff_task` does not
+exist on DSM 7.1+, so stop packages and services individually, and `cd /` first.
+
+## 11. Tool matrix and patched builds
+
+| Tool | Opens RW? | Synology-aware? | Verdict |
+|---|---|---|---|
+| DSM `/sbin/btrfs` v4.0 | No (`unsupported option features (3)`) | Yes | read-only inspection, `restore`, `subvolume list` |
+| mainline btrfs-progs | Yes | No, rejects root flags | unusable unpatched |
+| mainline + root-flag patch | Yes | Partially | best available offline tool |
+
+Build guidance for the patched binary:
+
+- Static, `--disable-backtrace`, `--with-crypto=builtin`
+- Build on a glibc-based image (Debian stable). Alpine's static libblkid pulls libeconf, which
+  has no static package
+- Build **unstripped with `-g`** so a fault address resolves via `addr2line`. A stripped binary
+  turns every crash into a dead end
+- Deploy to `/root/`, not `/tmp` (`noexec`)
+
+## 12. btrfs-progs bugs on damaged filesystems
+
+Observed on v6.15 (June 2025; current is v7.x, so line numbers have drifted - grep the function
+name, not the line). All are only reachable on a damaged filesystem, and all are worth guarding
+in any recovery build:
+
+1. `kernel-shared/extent-tree.c:2062` - `btrfs_print_leaf(path->nodes[0])` on a path that was
+   never populated. NULL dereference **while reporting an error**.
+2. `check/main.c:6394` - `calc_extent_flag()` dereferences `ri`, but `run_next_block()` is called
+   with `ri = NULL` (line 8781). Only unconditional under `--init-extent-tree`. The naive fix
+   (`if (!ri) return -ENOENT;`) is **harmful**: the caller responds to an error by setting
+   `BTRFS_BLOCK_FLAG_FULL_BACKREF`, silently poisoning the rebuilt tree. The correct fix skips
+   only the `ri`-dependent shortcuts.
+3. `check/main.c:7527` - `delete_duplicate_records()` calls `abort()` on overlapping **metadata**
+   extents. It cannot simply proceed, because the key it built is wrong: with `SKINNY_METADATA`
+   the item is keyed `(start, METADATA_ITEM_KEY, info_level)`, not `(start, EXTENT_ITEM_KEY, nr)`.
+
+Also: `btrfs check --repair` prompts
+`repair mode will force to clear out log tree, are you sure? [y/N]` and blocks forever with no
+stdin. Pipe `yes` into it or it will look like a hang.
+
+## 13. Setting Synology subvolume flags from userspace
+
+```
+BTRFS_IOCTL_MAGIC          0x94
+BTRFS_IOC_SUBVOL_GETFLAGS  _IOR(0x94, 25, __u64)   = 0x80089419
+BTRFS_IOC_SUBVOL_SETFLAGS  _IOW(0x94, 26, __u64)   = 0x4008941A
+```
+
+The fd must be a subvolume root (`btrfs_ino == BTRFS_FIRST_FREE_OBJECTID`), otherwise the ioctl
+returns `-EINVAL`.
+
+**This needs a writable mount, so it is not the thing that gets you mounted.** `SETFLAGS` takes
+write access and returns `-EROFS` on a read-only mount. Two legitimate uses: as a prophylactic on
+a healthy volume, or as the permanent replacement for the mount option once
+`-o rw,no_quota_tree` has the volume up. The mount option is what recovers a volume; the flag is
+what keeps it mounting without the option afterwards.
+
+The kernel handler is a **read-modify-write across all the private flags**, so always GET, OR in
+the desired bit, then SET. A blind SET clears `HIDE`, `CMPR_RATIO`, and `DISABLE_QUOTA`.
+
+Python is enough (`fcntl.ioctl`, `struct.pack("=Q", ...)`) and DSM ships python3, so no compiled
+helper is needed:
+
+```python
+import fcntl, os, struct
+GET, SET = 0x80089419, 0x4008941A
+NOLOAD_USRQUOTA = 1 << 33
+fd = os.open("/volume1", os.O_RDONLY)             # subvolume 256 root on DSM; open(), not open("rb")
+cur = struct.unpack("=Q", fcntl.ioctl(fd, GET, struct.pack("=Q", 0)))[0]
+fcntl.ioctl(fd, SET, struct.pack("=Q", cur | NOLOAD_USRQUOTA))
+```
+
+Read the flags back and confirm before relying on the change.
+
+## 14. Damage surveying
+
+```sh
+find <dir> -size +0         # stats every entry, surfaces EIO
+find <dir> -printf '%s\n'   # same effect, prints the size it had to stat for
+find <dir> -type f          # NO stat: -type is answered from readdir's d_type
+find <dir>                  # readdir only, reads NO inodes
+```
+
+**A survey without an inode-reading predicate reports a corrupt filesystem as clean.** That
+mistake produced a false "0.00% damaged" result across 44 TB. Precisely: bare `find` still has to
+`opendir` each directory, so it does surface unreadable *directories*; the blind spot is
+unreadable *file* inodes. Note also that `-size +0` stats every file but does not print zero-byte
+ones, so do not compute a damage percentage from its stdout - use `-printf '%s\n'` for that. `-type f` looks like it should
+help and does not: `find` uses the `d_type` field `readdir` already returned and skips the
+`stat` call, so the inode is never touched. Predicates that need inode data (`-size`, `-printf
+'%s'`, `-newer`, `-perm`) are the ones that surface EIO.
+
+Distinguish two classes of damage:
+
+- unreadable **files**: the inode is unreadable, the name is still listed
+- unreadable **directories**: contents cannot be enumerated at all, so what is inside is unknown
+  and uncountable
+
+Prefer re-detecting damage in-process (`os.lstat`, catch `EIO`) over replaying a recorded path
+list. `find` stderr contains shell-escaped names, and media trees are full of spaces, quotes,
+and unicode.
+
+For extracting data off a filesystem that will not mount read-write, DSM's own `btrfs restore`
+works read-only and understands the Synology format, which mainline `restore` may not.

--- a/skills/synology-dsm/references/dsm-cli.md
+++ b/skills/synology-dsm/references/dsm-cli.md
@@ -1,0 +1,313 @@
+# DSM Command Surface
+
+Command reference for administering DSM over SSH. Two confidence tiers are marked throughout:
+
+- **Verified**: observed on a DSM 7.1 unit (DS415+, avoton) during hands-on work
+- **Documented**: from Synology's CLI Administrator Guide or DSM's own help output. Confirm with
+  `<tool> --help` on the target unit before scripting it - flags differ across DSM versions and
+  models, and several `syno*` tools have no stable interface contract
+
+The CLI guide is the last one Synology published (copyright 2015-2021, 20 pages) and its examples
+are DSM 5-era: the service names it lists and its eth0/eth1 assumptions are stale. Treat it as
+normative for argument order and semantics, not for what exists on a DSM 7 unit. Where it prints
+argument names with spaces (`full name`, `adv privilege`, `[--dont restart service]`), this file
+uses underscores for readability - the guide's own spacing is inconsistent and its
+`{--del]` bracket is a typo in the source.
+
+Source:
+`https://global.download.synology.com/download/Document/Software/DeveloperGuide/Firmware/DSM/All/enu/Synology_DiskStation_Administration_CLI_Guide.pdf`
+
+## Contents
+
+1. Shell access and elevation
+2. Identity and platform
+3. Packages
+4. Services
+5. Shares, users, groups
+6. Storage and disks
+7. Indexing
+8. Logs and notifications
+9. Network
+10. DSM Web API
+11. Extra tooling (Entware, community scripts)
+
+---
+
+## 1. Shell access and elevation
+
+Enable SSH in Control Panel > Terminal & SNMP > Terminal. Keep Telnet off (CVE-2026-32746).
+
+```sh
+ssh admin@nas                  # DSM 7 disallows direct root SSH login
+sudo -i                        # root shell
+```
+
+Working facts (**verified**):
+
+- `/bin/sh` is ash. No bashisms, no process substitution. `bash` exists but scripts invoked by
+  DSM run under ash
+- `/tmp` is mounted `noexec`. Deploy binaries to `/root/` or a package directory
+- `scp` needs `-O` (legacy protocol) because the sftp subsystem is disabled
+- Sessions land in `/volume1/homes/<user>`, which pins the volume. `cd /` before unmount work
+- `lsof`, `fuser`, `mountpoint`, and `modinfo` are absent. Use `/proc` directly:
+
+```sh
+sudo ls -l /proc/*/cwd /proc/*/root /proc/*/fd/* 2>&1 | grep volume1   # who holds the mount
+```
+
+Detach anything long-running (**verified** failure mode: an SSH drop kills the job):
+
+```sh
+setsid nohup /root/job.sh > /root/job.log 2>&1 < /dev/null &
+```
+
+Put the logic in a script file so a later `pkill -f <pattern>` cannot match your own command line.
+
+## 2. Identity and platform
+
+```sh
+cat /etc.defaults/VERSION                  # productversion, buildnumber, majorversion  (verified)
+grep unique /etc.defaults/synoinfo.conf    # platform id, e.g. synology_avoton_415+     (verified)
+uname -a                                   # kernel line (3.10.x or 4.4.x)              (verified)
+```
+
+`/etc.defaults/` holds shipped defaults; `/etc/` holds the live copy that DSM regenerates. Edits
+in `/etc.defaults/` survive routine updates more often, but a major DSM upgrade can overwrite
+either. Treat both as regenerated state, not as configuration you own.
+
+`/etc/fstab` is rewritten at boot (`synocfgen` is among the writers). A volume line looks like:
+
+```
+/dev/mapper/cachedev_0 /volume1 btrfs auto_reclaim_space,ssd,synoacl,relatime,nodev 0 0
+```
+
+## 3. Packages
+
+```sh
+synopkg list --name                  # installed packages            (verified)
+synopkg status <Pkg>                 # JSON status                   (verified)
+synopkg stop <Pkg> ; synopkg start <Pkg>                            # (verified)
+synopkg enable <Pkg> ; synopkg disable <Pkg>   # autostart marker in /var/packages/<Pkg>/enabled
+systemctl stop pkgctl-<Pkg>.service  # the unit behind the package   (verified)
+```
+
+`synopkg list --started` does not exist on DSM 7.1 (**verified**). Use `synopkg status`.
+
+**Dependencies resurrect packages** (**verified**): `synopkg disable` does not hold if another
+installed package declares the target in `install_dep_packages`.
+
+```sh
+grep -h install_dep_packages /var/packages/*/INFO
+```
+
+Observed: `SynologyDrive` depends on `SynoFinder`, so SynoFinder restarts within a minute of
+being disabled. When the real goal is narrower (stop indexing one share), use the indexer's own
+control tool in section 7 instead of fighting the package manager.
+
+Package layout: `/var/packages/<Pkg>/` holds `INFO`, `enabled`, `target/` (the install tree,
+usually a symlink into `/volume1/@appstore/<Pkg>`), and `etc/`.
+
+## 4. Services
+
+```sh
+systemctl list-units --type=service --state=running     # (verified)
+systemctl status <unit>
+```
+
+Guide-documented `synoservice` syntax (**documented**, from the CLI Administrator Guide):
+
+```
+synoservice {--help}
+synoservice {--list} [running]
+synoservice {--enable | --disable} service...
+synoservice {--start | --stop | --restart} service...
+synoservice {--keyon | --keyoff} service...
+synoservice {--detail} service...
+```
+
+`--enable`/`--disable` persist the setting **and** start or stop the service immediately.
+`--start`/`--stop`/`--restart` do not modify settings. The guide says a start "will check if the
+service has been enabled" but does not state what happens when it has not, so do not promise the
+user a specific failure mode.
+
+`--hard-disable`, `--hard-stop`, `--hard-enable`, and `--hard-start` appear in some DSM builds'
+own `--help` output but are not in the guide. Run `synoservice --help` on the unit before using
+them.
+
+Core services worth knowing (**verified** present on DSM 7.1): `pgsql`, `pgsql-adapter`,
+`s2s_daemon`, `synologand`, `nfs-server`, `nfs-mountd`, `synoindexd`, `synoelasticd`.
+
+To free `/volume1` on DSM 7 there is no `syno_poweroff_task` (**verified** absent on 7.1). Stop
+packages, then the services that hold the volume, then unmount - after `cd /`.
+
+## 5. Shares, users, groups
+
+Guide-documented syntax (**documented**, from the CLI Administrator Guide):
+
+```
+synouser  {--help} | {--add} username passwd "full name" expired email app_privilege
+synouser  {--del} username... | {--rename} old new | {--modify} username passwd "full name" expired email
+synogroup {--help} | {--add} groupname username... | {--del} groupname...
+synogroup {--rename} old_groupname new_groupname | {--member} groupname username...
+synoshare {--help}
+synoshare {--add} sharename share_desc share_path user_list_na user_list_rw user_list_ro share_browsable adv_privilege
+synoshare {--del} {TRUE | FALSE} sharename...
+synoshare {--rename} old_sharename new_sharename
+synoshare {--setuser} sharename {NA | RO | RW} {+ | - | =} user_list
+```
+
+`synoshare --del` takes a boolean **first**: `TRUE` deletes configuration and data, `FALSE`
+deletes only the configuration and leaves the directory, which DSM will then restore as a share
+with default privileges on the next restart. Both are destructive in different ways; confirm
+which one the user means before running either. It cannot delete Hybrid Share folders.
+
+Listing flags (`--enum`, `--get`, `--list`) exist on real units for several of these tools but
+are **not in the guide**, and `synouser --setpw` appears only in the guide's examples, not its
+synopsis. Run `<tool> --help` on the unit rather than scripting against a flag
+recalled from a forum post.
+
+Share data lives at `/volume1/<share>`. ACLs are Synology ACLs (`synoacl` mount option), so
+`getfacl`/`setfacl` do not tell the whole story. DSM ships `synoacltool` for Synology ACLs, but it
+is not in the CLI guide and its interface is not contractual - run it with no arguments to get
+its usage before relying on it. The guide covers only `synouser`, `synogroup`, `synoshare`,
+`synonet`, `synoservice`, and `synowin`; everything else in this file is `--help`-derived or
+observed, and marked accordingly.
+
+## 6. Storage and disks
+
+```sh
+cat /proc/mdstat                          # arrays, degradation, resync progress   (verified)
+sudo mdadm --detail /dev/md2              # array detail                           (verified)
+sudo vgs ; sudo lvs ; sudo pvs            # LVM layer                              (verified)
+sudo btrfs filesystem show                                                       # (verified)
+sudo btrfs filesystem usage /volume1      # data vs metadata allocation            (verified)
+sudo btrfs subvolume list /volume1                                                # (verified)
+sudo smartctl -a /dev/sda                 # SMART, present on DSM                  (verified)
+sudo dmesg | tail -100                                                            # (verified)
+```
+
+Device stack (**verified**):
+
+```
+/dev/sdX3  ->  mdN (RAID, data)  ->  vgN/volume_N  ->  cachedev_N (flashcache shim)  ->  btrfs
+```
+
+`md0` (system, ~8 GB) and `md1` (swap, ~2 GB) are RAID1 across **all** disks. They are commonly
+found degraded and ignored for months. Check them on every engagement.
+
+See `storage-and-backup.md` for repair, replacement, and the compatibility database.
+
+## 7. Indexing
+
+**Identify which indexer is running hot before pausing anything.** Three separate subsystems
+produce the same "the NAS is hammering the disks" complaint and they take different levers:
+
+| Process | Belongs to | Lever |
+|---|---|---|
+| `synoelasticd`, `synotifyd` | SynoFinder / Universal Search | the `fileindex` tool below |
+| `synoindexd` | media indexing for Photos, Video Station, Audio Station | the indexed-folder list in DSM's Indexing Service settings - `fileindex` does not control it |
+| Photos face and subject recognition | Synology Photos | unshare the folder from Photos, or disable recognition in the Photos settings |
+
+```sh
+top -b -n 1 | head -20
+ps w | grep -E 'synoindex|synoelastic|synotifyd'
+```
+
+Pausing SynoFinder's indexing when `synoindexd` is the busy process changes nothing. This is the
+most common misdiagnosis on a media share.
+
+The SynoFinder watch list is `/usr/syno/etc/synotifyd/fileindex`, JSON, one entry per indexed
+share (**verified**). Read it, do not hand-edit it - DSM regenerates this class of config and a
+package restart rewrites it. Change it through the tool so the daemon sees the change:
+
+```sh
+sudo /var/packages/SynoFinder/target/tool/fileindex -a share_pause  -n <sharename>   # (verified)
+sudo /var/packages/SynoFinder/target/tool/fileindex -a share_resume -n <sharename>   # (verified)
+sudo /var/packages/SynoFinder/target/tool/fileindex -a is_idle                       # (documented)
+```
+
+Other actions seen in its help (**documented** - confirm with `--help` on the unit): `reindex`,
+`share_rebuild`, `volume_pause`, `volume_resume`. `-n <name>` is required; `-p <path>` alone
+fails with `name is required` (**verified**).
+
+Two things the tool does not tell you and that are not established: whether a pause survives a
+reboot or a SynoFinder restart, and whether `-n` is case-sensitive. Copy the share name exactly
+as `synoshare` reports it, and re-check the pause with `is_idle` after a restart rather than
+assuming persistence.
+
+This is the correct lever for excluding a share from SynoFinder indexing - far better than
+fighting package dependencies.
+
+## 8. Logs and notifications
+
+```sh
+sudo dmesg                                  # kernel ring buffer, wraps           (verified)
+ls /var/log/                                # syslog-style logs
+ls /var/log/synolog/                        # DSM Log Center databases
+```
+
+DSM's Log Center stores structured logs in SQLite databases under `/var/log/synolog/`, not plain
+text. Read them with `sqlite3` if present, or export from the Log Center UI. Do not assume a
+plain-text grep covers DSM events.
+
+`dmesg` wraps. When a flood of one message is running, a full-snapshot diff is the only reliable
+way to see what else happened:
+
+```sh
+sudo dmesg > /root/dmesg.before
+# ... action ...
+sudo dmesg > /root/dmesg.after
+diff /root/dmesg.before /root/dmesg.after | head -50
+```
+
+## 9. Network
+
+```sh
+ip a ; ip r                                 # standard iproute2 present          (verified)
+cat /etc/hosts ; cat /etc/resolv.conf
+```
+
+Guide-documented `synonet` syntax (**documented**). All of these change live networking and can
+cut your own session:
+
+```
+synonet {--help}
+synonet {--dhcp} iface
+synonet {--manual} iface ip mask [--dont_restart_service]
+synonet {--set_gateway} gateway
+synonet {--set_dns} dns
+synonet {--set_mtu} iface MTU
+synonet {--set_hostname} hostname [--dont_restart_service]
+```
+
+DSM's firewall is configured through Control Panel and enforced with its own ruleset. Editing
+iptables directly does not persist and can be reverted by DSM at any time; use the UI or the
+firewall's own config path.
+
+## 10. DSM Web API
+
+DSM exposes an HTTP API at `/webapi/` used by the web UI itself. Entry points: `query.cgi` for
+API discovery, `auth.cgi` / `entry.cgi` with `SYNO.API.Auth` for session login, then per-package
+API namespaces (`SYNO.Core.*`, `SYNO.FileStation.*`, `SYNO.Backup.*`).
+
+Use it for automation instead of screen-scraping the UI. Two rules:
+
+- Never pass the password on the command line. Use a curl config file with mode 0600, an
+  environment variable, or stdin - process listings are readable by other users
+- API sets and versions differ per DSM release; call `query.cgi` on the target unit rather than
+  hardcoding a version from documentation
+
+Synology's "DSM Login Web API Guide" is the reference. Community clients exist (for example the
+`synology-dsm` Python client used by Home Assistant) if a maintained wrapper is preferable to
+raw calls.
+
+## 11. Extra tooling
+
+- **Entware** adds an `opkg` package manager for tools DSM omits. It installs outside DSM's
+  package system, so DSM updates can break it and it is unsupported by Synology. Reach for it
+  only when a needed tool genuinely does not exist; prefer `python3`, which ships with DSM
+- **Community scripts** (for example 007revad's collection for the drive compatibility database)
+  patch DSM state directly. Read any such script before running it, pin the version, and expect
+  a DSM update to revert its effects
+- Compiling on the NAS is not worth it. Cross-build static binaries elsewhere and copy them to
+  `/root/` (see the build guidance in `btrfs-recovery.md`)

--- a/skills/synology-dsm/references/gotchas.md
+++ b/skills/synology-dsm/references/gotchas.md
@@ -1,0 +1,102 @@
+# DSM Footguns and Diagnostic Hygiene
+
+Read before any repair attempt or any change to a production unit. Most entries here come from a
+real recovery; the rest are DSM behaviors that reliably mislead.
+
+## Never do these on a damaged Synology btrfs volume
+
+- **`btrfs check --repair --init-extent-tree`.** Observed: completes a full scan, then writes a
+  zero-entry node into the **chunk tree**, hits `BUG_ON` in `btrfs_try_chunk_alloc`, and leaves
+  the filesystem permanently unmountable (`open_ctree failed`). This destroys the volume.
+- **`mount -o clear_cache`, unconditionally.** Establishing that the free space tree is not the
+  damaged structure is exactly what a damaged filesystem prevents. Clearing the tree
+  requires freeing its own blocks, which requires the damaged block. The transaction aborts
+  *during mount*, after which the filesystem fails `open_ctree` entirely. Strictly worse than
+  before.
+- **Any repair at all without a dm-snapshot overlay in place.**
+- **`mdadm --assemble --force` or `--create` as an opening move.** Event counts diverge on a
+  broken array; force-assembly picks a generation silently, and `--create` overwrites superblocks.
+
+## The circularity, stated once
+
+Every "remove the damaged derived tree" operation must **free the blocks that tree occupies**,
+and freeing extents requires reading extent-tree and free-space metadata. If the damage sits in
+that path, every removal route fails through the damage.
+
+Approaches that *ignore* the damaged structure - feature bits, mount options, skip flags - can
+succeed where approaches that *remove* it cannot. Reach for the ignoring lever first.
+
+## Diagnostic hygiene
+
+- **When a diagnostic returns nothing, suspect the diagnostic first.** Empty output on a system
+  you know is broken is a broken check far more often than a clean result.
+- **`dmesg` ring buffers wrap.** A flood of one message hides everything else. Diff full
+  snapshots rather than tracking line offsets.
+- **Grepping one error pattern that has stopped does not mean the problem stopped.** Grep the
+  actual failing message, not the one you first noticed.
+- **A cascade of identical errors is usually one root cause plus N consequences.** Find the first
+  occurrence and read what preceded it.
+- **A survey without an inode-reading predicate reports a corrupt filesystem as clean.**
+  `find <dir>` does readdir only and reads no inodes, and `find <dir> -type f` does not help -
+  `-type` is answered from `readdir`'s `d_type` with no `stat`. Use `-size +0` or
+  `-printf '%s\n'`. That mistake produced a false "0.00% damaged" result across 44 TB.
+- **DSM's health banners are derived state.** Verify the mount, the array, and the filesystem
+  directly rather than trusting the UI's summary.
+- **Distinguish "unreachable" from "not present".** A permission error, a stopped service, and a
+  missing resource all look alike if stderr is discarded. Never `2>/dev/null` a diagnostic whose
+  failure reason matters.
+
+## Shell traps on DSM
+
+- `/bin/sh` is ash. No process substitution `<(...)`, no bash arrays, no `[[ ]]` in scripts DSM
+  invokes.
+- `sh -euxc '...'` is terminated by any apostrophe inside it, including one in an English
+  comment. Match text with a regex (`Shouldn.t`) or avoid the word.
+- Redirections in `sudo cmd 2>file` are performed by the *calling* shell, so a root-owned
+  leftover file makes the whole command fail before `sudo` even runs. Wrap it: `sudo sh -c '...'`.
+- `grep -c pattern file || echo 0` emits `0` twice when there are no matches.
+- `/tmp` is `noexec`. A copied binary fails with "Permission denied" that looks like an
+  ownership problem.
+- `scp` without `-O` fails with `subsystem request failed` because the sftp subsystem is disabled.
+- Never `pkill -f <pattern>` where the pattern appears in your own command line. Put the logic in
+  a script file so the pattern is not in a live cmdline.
+- SSH sessions land in `/volume1/homes/<user>`, so `umount /volume1` reports "target is busy"
+  against your own shell. `cd /` first.
+
+## Behavior of a damaged volume
+
+- **`remount,rw` is refused once btrfs has forced read-only.** A full unmount and fresh mount is
+  required, which means stopping packages and services.
+- **btrfs forcing read-only is protective**, not additional damage. Treat it as the filesystem
+  doing its job.
+- **Ordinary create/fsync/delete and idle time are safe** even with `auto_reclaim_space` enabled;
+  only touching the damaged inodes aborts. Verify such hypotheses before recommending them -
+  `auto_reclaim_space` was a plausible culprit in the source recovery and was innocent.
+- **Stock-tool corruption reports are not evidence.** Mainline's tree-checker rejects Synology's
+  private root flags, and mainline `check` complains about private trees 202/203/205/206, which
+  hold reconstructible derived data. Both are expected noise on a healthy Synology volume.
+
+## DSM behaviors that mislead
+
+- **`/etc/fstab` is regenerated at boot.** Hand-edited mount options vanish silently.
+- **`syno_poweroff_task` exists on DSM 6 but not DSM 7.1+.** Scripts and forum posts that use it
+  fail confusingly on modern DSM.
+- **Package dependencies resurrect disabled packages.** `grep -h install_dep_packages
+  /var/packages/*/INFO` before assuming a `synopkg disable` held.
+- **DSM 7 disallows direct root SSH.** Guides written for DSM 6 fail at the first step; use
+  `sudo -i`.
+- **Home directories live on the data volume.** When `/volume1` is down, key-based SSH auth
+  breaks because `authorized_keys` is unreadable. Have a password-capable admin account and, on
+  a unit you may need to recover, console or serial access.
+- **DSM's firewall and network config are owned by DSM.** Direct iptables edits do not persist.
+- **`btrfs check --repair` prompts for confirmation and blocks forever with no stdin.** It looks
+  like a hang. Pipe `yes` into it if you have already decided to run it.
+
+## Remote work discipline
+
+- Detach anything long-running: `setsid nohup <cmd> > log 2>&1 < /dev/null &`. An SSH drop kills
+  an attached job, and a 40-minute repair interrupted halfway is worse than one not started.
+- Take the origin fingerprint before starting and re-verify it after (see the overlay procedure
+  in `btrfs-recovery.md`). It is the only proof the origin was untouched.
+- Log to a file on persistent storage, not to the terminal. The terminal is the least durable
+  place the output can live.

--- a/skills/synology-dsm/references/output-contract.md
+++ b/skills/synology-dsm/references/output-contract.md
@@ -1,0 +1,218 @@
+# Output Contract
+
+How a skill reports its findings: an inline surface in the transcript and a written deliverable file. The two shapes below are intentionally different.
+
+## Two surfaces
+
+The contract has two intentionally divergent shapes:
+
+- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+
+## Inline format
+
+### Header box
+
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+
+Minimum form (3 lines):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Extended form (when surfacing mode/target/started):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW                                                                 ║
+║  Mode: audit  ·  Target: src/auth/  ·  Started: 2026-05-03T14:22Z            ║
+║  Deliverable: docs/local/audits/code-review/2026-05-03-auth-review.md        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Conclusion header (same shape, name suffixed `· CONCLUSION`):
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  CODE-REVIEW · CONCLUSION                                                    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+
+### Conclusion table
+
+All-double Unicode box-drawing, fixed 80 chars wide, fixed 5 columns:
+
+```
+╔════╦══════════╦══════════╦══════════════════════════════════════╦════════════╗
+║ #  ║ Type     ║ Priority ║ Summary                              ║ Action     ║
+╠════╬══════════╬══════════╬══════════════════════════════════════╬════════════╣
+║ 1  ║ found    ║ P0       ║ Missing CSRF check on /api/posts     ║ recommend  ║
+║ 2  ║ found    ║ P0       ║ SQL injection via search param       ║ recommend  ║
+║ 3  ║ found    ║ P1       ║ Race condition in worker pool        ║ recommend  ║
+║ 4  ║ rec      ║ P2       ║ Extract repeated auth helper         ║ proposed   ║
+║ 5  ║ rec      ║ info     ║ Naming convention drift in /utils    ║ proposed   ║
+╚════╩══════════╩══════════╩══════════════════════════════════════╩════════════╝
+```
+
+Column widths (cell content + 1 char padding either side):
+
+| Column   | Width | Allowed values                                          |
+|----------|-------|---------------------------------------------------------|
+| #        | 4     | numeric, padded                                         |
+| Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
+| Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
+| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
+
+Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
+
+## File format (deliverable)
+
+Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
+
+```markdown
+# CODE-REVIEW — src/auth/ — 2026-05-03
+
+- **Skill:** code-review
+- **Mode:** audit
+- **Target:** `src/auth/`
+- **Started:** 2026-05-03T14:22Z
+- **Findings:** 5 (P0:2, P1:1, P2:1, info:1)
+
+---
+
+## P0 — Must fix
+
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  - **File:** `src/auth/routes.ts:42`
+  - **Description:** Handler accepts state-changing requests without verifying CSRF token. Any logged-in user on a malicious page can trigger posts on behalf of the victim.
+  - **Suggested action:** Add `requireCsrf()` middleware before the route handler.
+  - **Fix applied:** _to be filled by implementer_
+
+- [ ] **#2 SQL injection via search param**
+  - **File:** `src/auth/search.ts:88`
+  - **Description:** `q` parameter is concatenated into the query string without parameterization.
+  - **Suggested action:** Switch to prepared statement with `$1` binding.
+  - **Fix applied:** _to be filled by implementer_
+
+## P1 — Should fix
+
+- [ ] **#3 Race condition in worker pool reconnect path**
+  - **File:** `src/worker/pool.go:142`
+  - **Description:** When N connections exceed pool_max during a reconnect storm, the gate releases before the new conn registers, allowing duplicates.
+  - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
+  - **Fix applied:** _to be filled by implementer_
+
+## P2 — Nice to fix
+
+- [ ] **#4 Extract repeated auth helper**
+  - **File:** `src/auth/helpers.ts:12,55,89`
+  - **Description:** Same 8-line cookie-decode block appears in three handlers.
+  - **Suggested action:** Extract to `decodeAuthCookie()` in `src/auth/cookie.ts`.
+  - **Fix applied:** _to be filled by implementer_
+
+## Info
+
+- [ ] **#5 Naming convention drift in /utils**
+  - **File:** `src/utils/`
+  - **Description:** Mix of `camelCase` and `snake_case` filenames; repo convention is `kebab-case`.
+  - **Suggested action:** Rename in a follow-up PR.
+  - **Fix applied:** _to be filled by implementer_
+
+---
+
+## Conclusion
+
+| #  | Type   | Priority | Summary                                | Action     |
+|----|--------|----------|----------------------------------------|------------|
+| 1  | found  | P0       | Missing CSRF check on /api/posts       | recommend  |
+| 2  | found  | P0       | SQL injection via search param         | recommend  |
+| 3  | found  | P1       | Race condition in worker pool reconnect| recommend  |
+| 4  | rec    | P2       | Extract repeated auth helper           | proposed   |
+| 5  | rec    | info     | Naming convention drift in /utils      | proposed   |
+```
+
+Notes:
+
+- Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
+- Findings grouped by priority section. Sections with zero findings are omitted.
+- Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
+- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+
+### Deliverable filename
+
+`docs/local/<bucket>/<skill-name>/<YYYY-MM-DD>-<slug>.md`
+
+If the same skill writes twice in one day, append `-2`, `-3`, etc. to the slug.
+
+## Severity / priority scale
+
+One scale, used in both inline and file:
+
+| Label  | Meaning                                              | File section heading       |
+|--------|------------------------------------------------------|----------------------------|
+| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
+| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
+| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
+| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
+| `info` | Informational — no action required                   | `## Info`                  |
+
+Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+
+## Storage layout
+
+```
+docs/local/
+  prompts/         # prompt-generator outputs
+  audits/          # audit / review / scan reports (the checkbox-style files)
+  plans/           # reserved for upstream skills (e.g. superpowers:writing-plans)
+  specs/           # reserved for upstream skills (e.g. superpowers:brainstorming)
+  deliverables/    # catch-all (sketches, generated docs, ad-hoc artifacts)
+```
+
+`plans/` and `specs/` are reserved for upstream skills. Repo-owned skills MUST NOT default to those buckets unless they genuinely produce a plan or spec artifact.
+
+## Mode detection
+
+Each skill declares one of two modes in its `## Output Contract` section:
+
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+
+- **Conditional:** the agent applies this rule per invocation:
+
+  > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+## Fix protocol
+
+**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+
+Example, before:
+
+```markdown
+- [ ] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** _to be filled by implementer_
+```
+
+After:
+
+```markdown
+- [x] **#1 Missing CSRF check on POST /api/posts**
+  ...
+  - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
+```
+
+**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+
+1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
+2. Iterates findings in priority order (P0 first).
+3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
+
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.

--- a/skills/synology-dsm/references/storage-and-backup.md
+++ b/skills/synology-dsm/references/storage-and-backup.md
@@ -1,0 +1,193 @@
+# Storage, Disks, Snapshots, Backups
+
+Read this when the task touches disks, storage pools, RAID repair, snapshots, or backups.
+Recovery of an unmountable volume is a different document: `btrfs-recovery.md`.
+
+## Contents
+
+1. The layer stack, and why it matters
+2. SHR
+3. Reading array health
+4. "Volume Crashed" triage
+5. Disk replacement and repair
+6. Drive compatibility database
+7. btrfs metadata headroom
+8. Snapshots
+9. Backups
+10. Migration between units
+
+---
+
+## 1. The layer stack
+
+```
+/dev/sdX3  ->  mdN (RAID)  ->  vgN/volume_N (LVM)  ->  cachedev_N (flashcache shim)  ->  btrfs
+```
+
+Four layers, four independent failure modes. DSM's UI collapses them into one health indicator,
+which is why its warnings are ambiguous. Diagnose bottom-up: disks, then array, then LVM, then
+filesystem. A filesystem symptom with a healthy array is a filesystem problem; a filesystem
+symptom with a degraded array is usually the array.
+
+`md0` (system, ~8 GB) and `md1` (swap, ~2 GB) are RAID1 across **all** disks in the unit, not
+just the pool members. They degrade quietly and stay degraded for months because DSM does not
+surface them the way it surfaces data volumes. Check them every time.
+
+## 2. SHR
+
+Synology Hybrid RAID is not a distinct RAID level. It is md arrays layered so that mixed-size
+disks contribute their full capacity: the disks are partitioned into matched chunks and each
+chunk group becomes its own md array, joined by LVM. SHR-1 tolerates one disk failure, SHR-2
+tolerates two.
+
+Consequences:
+
+- A single unit can show several `mdN` devices for one apparent volume. Read all of `/proc/mdstat`,
+  not just the first array
+- Capacity expansion only materializes when enough disks are large enough for a new chunk group.
+  Replacing one disk in a mixed set often adds nothing until the second one is replaced
+- Not every model supports SHR; some enterprise models ship with it disabled
+
+## 3. Reading array health
+
+```sh
+cat /proc/mdstat
+sudo mdadm --detail /dev/md2
+sudo mdadm --examine /dev/sda3        # per-device superblock, event count
+```
+
+What to look at:
+
+- `[UUU_]` style maps: an underscore is a missing member
+- `recovery`/`resync` lines with a percentage and speed: the array is rebuilding. Do not
+  benchmark, do not power down, do not start a second repair
+- Event counts across members in `--examine`. Divergent counts are why force-assembly is
+  dangerous: it picks a generation for you, silently
+
+## 4. "Volume Crashed" triage
+
+DSM's banner does not say which layer failed. It can mean the md array went inactive, or that
+btrfs went read-only after metadata trouble. Establish the layer before touching anything:
+
+```sh
+cat /proc/mdstat                       # array active and complete?
+sudo lvs                               # LV present?
+mount | grep volume                    # mounted, and rw or ro?
+sudo dmesg | grep -iE 'btrfs|md/raid|I/O error' | tail -40
+```
+
+Then:
+
+| Finding | Layer | Next step |
+|---|---|---|
+| Array inactive or missing members | mdadm | Identify the failed disks first. Do not force-assemble |
+| Array clean, LV present, btrfs mounted read-only | btrfs | `btrfs-recovery.md` |
+| Array clean, mount fails with `open_ctree failed` | btrfs | `btrfs-recovery.md`, mount ladder |
+| I/O errors on one disk in `dmesg` | disk | Replace the disk, then repair the array |
+
+Do not click "Repair" in DSM before this triage. Repair at the wrong layer writes to every disk
+in the pool and can turn a recoverable filesystem problem into a data-loss event.
+
+btrfs forcing itself read-only is **protective**, not additional damage. `remount,rw` is refused
+once that has happened; a full unmount and fresh mount is required, which means stopping services.
+
+## 5. Disk replacement and repair
+
+Order of operations:
+
+1. Confirm which physical bay maps to the failed device (`smartctl -a`, DSM's Storage Manager
+   bay view, drive serial numbers). Pulling the wrong disk from a degraded array destroys it
+2. Verify the backup is current and restorable **before** starting a rebuild. A rebuild reads
+   every sector of every surviving disk, which is exactly when a second marginal disk fails
+3. Replace, then let DSM repair the pool, or `mdadm --add` for the system/swap arrays
+4. Watch `/proc/mdstat` to completion. Expect hours to days for large data arrays; RAID1 on the
+   8 GB system array finishes in under a minute
+
+One disk at a time. Never remove a second disk from a degraded SHR-1 or RAID5 pool.
+
+## 6. Drive compatibility database
+
+DSM keeps a local compatible-drive database (files under `/var/lib/disk-compatibility/`) and
+gates warnings, and on some 2025 models gated functionality, on it.
+
+Policy timeline worth knowing, because it determines what a user's unit does:
+
+- April 2025: Synology announced that 2025 Plus-series models would require Synology-branded
+  drives for full functionality
+- October 2025, with DSM 7.3: Synology reversed it. Third-party 3.5" HDDs and 2.5" SATA SSDs are
+  supported again on 2025 Plus units. M.2 SSDs remained restricted at that point
+
+`support_disk_compatibility` in `/etc.defaults/synoinfo.conf` toggles the check. Changing it, or
+running a community script that injects drive models into the local database, silences warnings
+but also silences a real signal and can be reverted by any DSM update. Treat it as the user's
+decision, state the tradeoff, and never apply it unprompted.
+
+## 7. btrfs metadata headroom
+
+```sh
+sudo btrfs filesystem usage /volume1
+```
+
+A btrfs filesystem with free data space but exhausted metadata behaves like failing hardware:
+writes fail, the volume may go read-only, and every disk reports healthy. Check metadata before
+investigating disks. Small-file-heavy shares and long snapshot chains are the usual causes.
+
+DSM does not expose `btrfs balance` in the UI for this. Handle it deliberately: free space by
+deleting old snapshots first, since snapshot deletion returns metadata, and treat any manual
+balance as a change with a stated blast radius (heavy I/O, long duration, interruptible but not
+free to interrupt).
+
+## 8. Snapshots
+
+Snapshot Replication requires btrfs volumes. Snapshots are per shared folder (and per LUN), stored
+in a hidden system directory on the same volume (`/volume1/@sharesnap/...` on units observed;
+confirm the path on the target unit before scripting against it).
+
+Facts that change decisions:
+
+- A snapshot on the same volume protects against deletion and ransomware encryption of files,
+  not against volume loss. It is not a backup
+- **Immutable snapshots (WORM)**, introduced in DSM 7.2 alongside WriteOnce shared folders,
+  cannot be deleted by anyone, including
+  an administrator or a compromised admin account, until the protection period expires. Enabling
+  immutability requires it set on both the replication task and the snapshot schedule
+- A protection period of 7 to 14 days is the common recommendation. Longer periods consume space
+  that cannot be reclaimed early, by design
+- Long snapshot chains consume metadata (section 7). Retention policy is a storage decision, not
+  only a recovery one
+- Restore paths: whole-share restore from Snapshot Replication, or per-file browse of the
+  read-only snapshot directory
+
+## 9. Backups
+
+| Tool | Covers | Restore requirement |
+|---|---|---|
+| Hyper Backup | NAS data and DSM config to another NAS, USB, rsync target, or cloud | Hyper Backup Explorer or a Hyper Backup Vault on the target |
+| Snapshot Replication | Shared folders and LUNs to a second Synology | A second Synology with a compatible DSM |
+| Active Backup for Business | Endpoints, servers, VMs, Microsoft 365 backing up **to** the NAS | The NAS itself must be alive |
+| USB Copy / rsync | Ad-hoc file-level copies | Any host |
+
+Hyper Backup writes a proprietary `.hbk` container. Plain file copies are not what it produces,
+so restoring without a Synology or Hyper Backup Explorer is not a five-minute job. Test it.
+
+Verification rules:
+
+- A backup job reporting success is not a verified backup. Restore something, at a defined
+  interval, and record when it was last done
+- Keep at least one copy off the unit and one copy that the NAS's own admin credentials cannot
+  delete. Active Backup for Business stores its data on the NAS, which means it protects
+  endpoints, not the NAS
+- Check backup integrity before any storage repair, not after. The repair is when you find out
+
+## 10. Migration between units
+
+DSM supports moving a disk set into another Synology and preserving data (Synology calls this
+disk migration), subject to model family and DSM version constraints. Two properties matter:
+
+- Reinstalling DSM does not by itself wipe data volumes; DSM lives on the `md0` system partition
+  replicated across all disks, separately from the data pool
+- Migration compatibility depends on the target model's platform and DSM version. Check
+  Synology's migration compatibility table for the specific source and target models rather than
+  assuming
+
+Before any migration, take a full backup. Migration touches the system partition on every disk.


### PR DESCRIPTION
Adds a `synology-dsm` skill for administering Synology NAS appliances over SSH and recovering btrfs volumes that will not mount.

The core problem it addresses: DSM's btrfs on-disk format is newer than the btrfs-progs DSM ships and diverges from mainline, so stock tools report healthy volumes as corrupt, and several widely-repeated forum remedies destroy volumes outright.

## Contents

- `SKILL.md` (367 lines) - target versions and advisories, hard refusals, environment facts, symptom routing, recovery first moves, packages/services, security, performance
- `references/dsm-cli.md` - command surface with explicit verified/documented confidence tiers
- `references/storage-and-backup.md` - SHR, layer triage for "Volume Crashed", disk replacement, drive compatibility database, snapshots, backup matrix
- `references/btrfs-recovery.md` - private root flags/trees/mount options, the usrquota mount trap, dm-snapshot overlay, mount escalation ladder, tool matrix, subvolume flag ioctls
- `references/gotchas.md` - footguns, diagnostic hygiene, ash shell traps

## Validation

Three forward tests (routine indexing task, dangerous-command request, unmountable volume) plus two independent review passes. Defects found and fixed include:

- `find -type f` does not force a stat (answered from `readdir`'s `d_type`), so the documented damage survey reported a corrupt filesystem as clean
- the origin fingerprint used `bs=1M skip=10485760`, which is 10 TiB, and hashed empty input on any smaller device with `2>/dev/null` hiding the error
- clearing `FREE_SPACE_TREE_VALID` reaches the same kernel path as the banned `clear_cache`
- the recommended patch floor omitted the fix for the CVSS 9.8 telnetd RCE
- a read-only mount still replays the log tree, which conflicts with the overlay-before-write rule

Gates: `lint-skills.sh` 0/0, `validate-spec.sh` 0 violations, contract sync, freshness, private-leak, deep-audit coverage, markdownlint all pass.