### PR TITLE
feat(freshness): verify version pins by receipt age, not month label

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check freshness date markers
         run: ./scripts/check-freshness-dates.sh
 
+      - name: Check version receipts
+        run: ./scripts/check-version-receipts.sh
+
       - name: Check deep-audit skill coverage
         run: ./scripts/check-deep-audit-coverage.sh
 
@@ -87,6 +90,9 @@ jobs:
 
       - name: Test lint behavior
         run: ./scripts/test-lint-skills.sh
+
+      - name: Test version receipt behavior
+        run: ./scripts/test-version-receipts.sh
 
       - name: Shellcheck scripts
         run: shellcheck install.sh scripts/*.sh

--- a/docs/version-pins.md
+++ b/docs/version-pins.md
@@ -1,0 +1,100 @@
+# Version pin receipts
+
+Skills that pin specific tool versions ("Prometheus 3.13.1", "Helm 4.2.3") back
+that claim with a receipt file, not a month label in prose. A month label only
+proves someone ran a find-and-replace; a receipt proves someone checked a
+source and recorded when.
+
+## Mechanism
+
+- Any skill that pins tool versions carries `references/versions.md`.
+- That file has YAML frontmatter plus a human-readable table body describing
+  the same pins for humans reading the rendered skill.
+- `scripts/check-version-receipts.sh` validates every `references/versions.md`
+  it finds under `skills/*/references/`. `scripts/check-freshness-dates.sh`
+  skips its month-label check for any skill that has one (see
+  "Interaction with the label gate" below).
+
+## Frontmatter contract
+
+This is the shape `scripts/check-version-receipts.sh` parses. Keys and
+structure must match exactly.
+
+```yaml
+---
+checked_at: "2026-07-27"
+checked_by: "manual"
+pins:
+  - tool: "Prometheus"
+    version: "3.13.1"
+    source: "https://github.com/prometheus/prometheus/releases"
+  - tool: "Grafana"
+    version: "13.1.1"
+    source: "https://grafana.com/docs/grafana/latest/whatsnew/"
+---
+```
+
+- `checked_at` (required) — `YYYY-MM-DD`. The date a human or agent actually
+  confirmed the numbers below against `source`. It is a claim of work done,
+  not a release date, and not a copy of whatever the label bump script wrote
+  elsewhere.
+- `checked_by` (required) — free text, e.g. `"manual"` or an agent identifier.
+- `pins` (required) — a list of one or more entries. Each entry requires:
+  - `tool` — the pinned tool's name.
+  - `version` — the pinned version string, exactly as it should read in docs.
+  - `source` — an `https://` URL a reader can follow to verify the version.
+    `http://` is rejected.
+
+## Staleness budget
+
+**120 days.** If `checked_at` is more than 120 days before the date CI runs,
+`scripts/check-version-receipts.sh` fails for that skill. Re-verify every pin
+against its `source` and bump `checked_at`, or remove pins that are no longer
+worth tracking. Override the budget locally with
+`SKILLS_PIN_MAX_AGE_DAYS` (days) if you need to test a different threshold.
+
+## SKILL.md bodies must not restate version numbers
+
+Once a skill has `references/versions.md`, its `SKILL.md` must not carry the
+version numbers directly — that reintroduces exactly the drift this mechanism
+exists to prevent (two places to update, only one of them checked). Point at
+the receipt file instead:
+
+```markdown
+**Target versions**: see `references/versions.md` (verified per the receipt date
+in that file). Do not restate version numbers here.
+```
+
+## Interaction with the label gate
+
+`scripts/check-freshness-dates.sh` still enforces the `**Target versions**
+(Month Year):` label convention for any skill that has *not* migrated to a
+receipt file — that is still most of the collection. The moment a skill grows
+`references/versions.md`, the label check is skipped for that skill (it prints
+a `note:` line saying so) because the receipt file's `checked_at` field is now
+the source of truth for that skill's freshness.
+
+`skills/cluster-health/protected/` stays excluded from both checks, as it
+already was from the label gate.
+
+## Adding receipts to a new skill
+
+1. Create `skills/<name>/references/versions.md` with the frontmatter shape
+   above, one `pins` entry per tracked tool.
+2. Verify each `version` against its `source` right now, not from memory.
+   Set `checked_at` to today's date.
+3. Add a human-readable table body below the frontmatter listing the same
+   pins, for readers of the rendered file.
+4. Replace any inline version numbers in `SKILL.md` with a pointer to
+   `references/versions.md`.
+5. Run `./scripts/check-version-receipts.sh` and
+   `./scripts/check-freshness-dates.sh` — both must exit 0, and the second
+   must print the `note:` line for your skill.
+
+## Current status
+
+Only `observability` uses this mechanism so far (see plan 007). Migrating the
+remaining skills is tracked as a follow-up (plan 013+), done in batches by
+category so each batch's receipts can be verified in one research pass. Once
+every skill that pins versions has a receipt, `scripts/check-freshness-dates.sh`
+should be deleted outright rather than kept as a vestigial gate.

--- a/scripts/check-freshness-dates.sh
+++ b/scripts/check-freshness-dates.sh
@@ -15,9 +15,38 @@ errors=0
 stale_claim_re='(as of|verified|recheck|snapshot|current as of|Pinned to|Reviewed|Updated for|Research preview context|Key facts \(|Skill Inventory \(|Target versions|Versions worth pinning)'
 freshness_line_re='(^\*\*Target versions|^\*\*Versions worth pinning|^#+ .*Target versions|^#+ .*Versions worth pinning|Reviewed [A-Z][a-z]+ 20[0-9]{2}|Updated for .*[A-Z][a-z]+ 20[0-9]{2}|Research preview context|Key facts \([A-Z][a-z]+ 20[0-9]{2}\)|Skill Inventory \([A-Z][a-z]+ 20[0-9]{2}\)|current as of|as of [A-Z][a-z]+ 20[0-9]{2}|verified [A-Z][a-z]+ 20[0-9]{2}|[A-Z][a-z]+ 20[0-9]{2} recheck|[A-Z][a-z]+ 20[0-9]{2} snapshot|Pinned to [A-Z][a-z]+ 20[0-9]{2})'
 
+# A skill that has migrated to a version-receipt file (references/versions.md,
+# see docs/version-pins.md) is verified by scripts/check-version-receipts.sh
+# instead. Its month-label marker, if any is still present in prose, is no
+# longer the freshness signal for that skill - skip it here rather than
+# demanding both mechanisms agree.
+skill_of() {
+  local file="$1"
+  if [[ "$file" =~ ^skills/([^/]+)/ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  fi
+}
+
+has_version_receipt() {
+  local skill="$1"
+  [[ -n "$skill" && -s "$ROOT/skills/$skill/references/versions.md" ]]
+}
+
+declare -A noted_skills
+
 for file in "${files[@]}"; do
   path="$ROOT/$file"
   [[ -f "$path" ]] || continue
+
+  skill="$(skill_of "$file")"
+  if has_version_receipt "$skill"; then
+    if [[ -z "${noted_skills[$skill]:-}" ]]; then
+      printf 'note: %s uses version receipts; label check skipped\n' "$skill"
+      noted_skills[$skill]=1
+    fi
+    continue
+  fi
+
   line_no=0
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_no=$((line_no + 1))

--- a/scripts/check-version-receipts.sh
+++ b/scripts/check-version-receipts.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify version-pin receipts: skills/*/references/versions.md.
+#
+# Each file carries YAML frontmatter (checked_at, checked_by, pins: [...]).
+# This script fails a skill's receipt if:
+#   - checked_at is missing or not YYYY-MM-DD
+#   - checked_at is older than the staleness budget (default 120 days)
+#   - any pins: entry is missing tool, version, or source
+#   - any pins: entry's source is not an https:// URL
+#
+# See docs/version-pins.md for the contract. Nothing to check (no
+# versions.md anywhere) is success, not an error.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILLS_ROOT="${SKILLS_ROOT:-$ROOT/skills}"
+MAX_AGE_DAYS="${SKILLS_PIN_MAX_AGE_DAYS:-120}"
+
+fail=0
+
+# Parse frontmatter of a versions.md file into machine-readable lines:
+#   CHECKED_AT=<value>
+#   CHECKED_BY=<value>
+#   PIN<n>_TOOL=<value>
+#   PIN<n>_VERSION=<value>
+#   PIN<n>_SOURCE=<value>
+# Values have surrounding quotes stripped. Malformed frontmatter (no closing
+# fence) yields no output, which the caller treats as a validation failure.
+parse_frontmatter() {
+  awk '
+    function strip(v) {
+      gsub(/^[ \t]+|[ \t]+$/, "", v)
+      if (v ~ /^".*"$/) { v = substr(v, 2, length(v) - 2) }
+      return v
+    }
+    function shquote(v) {
+      gsub(/\\/, "\\\\", v)
+      gsub(/"/, "\\\"", v)
+      gsub(/\$/, "\\$", v)
+      gsub(/`/, "\\`", v)
+      return "\"" v "\""
+    }
+    function emit(key, v) { print key "=" shquote(strip(v)) }
+    BEGIN { fence = 0; in_pins = 0; pin_i = 0 }
+    NR == 1 && $0 == "---" { fence = 1; next }
+    fence == 1 && $0 == "---" { fence = 2; next }
+    fence != 1 { next }
+    /^checked_at:[ \t]*/ {
+      v = $0; sub(/^checked_at:[ \t]*/, "", v)
+      emit("CHECKED_AT", v)
+      in_pins = 0
+      next
+    }
+    /^checked_by:[ \t]*/ {
+      v = $0; sub(/^checked_by:[ \t]*/, "", v)
+      emit("CHECKED_BY", v)
+      in_pins = 0
+      next
+    }
+    /^pins:[ \t]*$/ { in_pins = 1; next }
+    in_pins && /^[a-zA-Z_]+:/ { in_pins = 0 }
+    in_pins && /^[ \t]*-[ \t]*tool:[ \t]*/ {
+      pin_i++
+      v = $0; sub(/^[ \t]*-[ \t]*tool:[ \t]*/, "", v)
+      emit("PIN" pin_i "_TOOL", v)
+      next
+    }
+    in_pins && /^[ \t]+version:[ \t]*/ {
+      v = $0; sub(/^[ \t]+version:[ \t]*/, "", v)
+      emit("PIN" pin_i "_VERSION", v)
+      next
+    }
+    in_pins && /^[ \t]+source:[ \t]*/ {
+      v = $0; sub(/^[ \t]+source:[ \t]*/, "", v)
+      emit("PIN" pin_i "_SOURCE", v)
+      next
+    }
+    END { print "PIN_COUNT=" pin_i }
+  ' "$1"
+}
+
+# Portable day count from a YYYY-MM-DD date to now. Tries GNU date first
+# (the CI runner, ubuntu-24.04, has it), falls back to BSD date for local
+# macOS use.
+days_since() {
+  local date_str="$1" then_epoch now_epoch
+  now_epoch="$(date -u +%s)"
+  if then_epoch="$(date -u -d "$date_str" +%s 2>/dev/null)"; then
+    :
+  elif then_epoch="$(date -u -j -f '%Y-%m-%d' "$date_str" +%s 2>/dev/null)"; then
+    :
+  else
+    return 1
+  fi
+  echo $(( (now_epoch - then_epoch) / 86400 ))
+}
+
+mapfile -t receipt_files < <(find "$SKILLS_ROOT" -type f -path '*/references/versions.md' 2>/dev/null | sort)
+
+if (( ${#receipt_files[@]} == 0 )); then
+  printf 'Version receipts OK: no skills carry references/versions.md yet.\n'
+  exit 0
+fi
+
+skill_count=0
+oldest_date=""
+
+for file in "${receipt_files[@]}"; do
+  rel="${file#"$SKILLS_ROOT"/}"
+  skill="${rel%%/references/versions.md}"
+
+  eval "$(parse_frontmatter "$file")"
+
+  if [[ -z "${CHECKED_AT:-}" ]]; then
+    printf '[!] %s: missing checked_at in frontmatter\n' "$skill" >&2
+    fail=1
+    continue
+  fi
+
+  if [[ ! "$CHECKED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    printf '[!] %s: checked_at %q is not YYYY-MM-DD\n' "$skill" "$CHECKED_AT" >&2
+    fail=1
+    continue
+  fi
+
+  age_days="$(days_since "$CHECKED_AT")" || {
+    printf '[!] %s: could not parse checked_at date %q\n' "$skill" "$CHECKED_AT" >&2
+    fail=1
+    continue
+  }
+
+  if (( age_days > MAX_AGE_DAYS )); then
+    printf '[!] %s: checked_at %s is %d days old (budget %d days) - re-verify pins or remove them\n' \
+      "$skill" "$CHECKED_AT" "$age_days" "$MAX_AGE_DAYS" >&2
+    fail=1
+  fi
+
+  pin_count="${PIN_COUNT:-0}"
+  if (( pin_count == 0 )); then
+    printf '[!] %s: pins: has no entries\n' "$skill" >&2
+    fail=1
+  fi
+
+  for (( i = 1; i <= pin_count; i++ )); do
+    tool_var="PIN${i}_TOOL"
+    version_var="PIN${i}_VERSION"
+    source_var="PIN${i}_SOURCE"
+    tool="${!tool_var:-}"
+    version="${!version_var:-}"
+    source="${!source_var:-}"
+
+    if [[ -z "$tool" || -z "$version" || -z "$source" ]]; then
+      printf '[!] %s: pins[%d] is missing tool, version, or source\n' "$skill" "$i" >&2
+      fail=1
+      continue
+    fi
+
+    if [[ "$source" != https://* ]]; then
+      printf '[!] %s: pins[%d] (%s) source %q is not an https:// URL\n' "$skill" "$i" "$tool" "$source" >&2
+      fail=1
+    fi
+  done
+
+  skill_count=$((skill_count + 1))
+  if [[ -z "$oldest_date" || "$CHECKED_AT" < "$oldest_date" ]]; then
+    oldest_date="$CHECKED_AT"
+  fi
+
+  unset CHECKED_AT CHECKED_BY PIN_COUNT
+  for (( i = 1; i <= pin_count; i++ )); do
+    unset "PIN${i}_TOOL" "PIN${i}_VERSION" "PIN${i}_SOURCE"
+  done
+done
+
+if (( fail )); then
+  printf '\nVersion receipt check failed.\n' >&2
+  exit 1
+fi
+
+printf 'Version receipts OK: %d skill(s), oldest check %s.\n' "$skill_count" "$oldest_date"

--- a/scripts/test-version-receipts.sh
+++ b/scripts/test-version-receipts.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+write_receipt() {
+  local file="$1" body="$2"
+  mkdir -p "$(dirname "$file")"
+  printf '%s' "$body" > "$file"
+}
+
+run_checker() {
+  local skills_root="$1"
+  SKILLS_ROOT="$skills_root" "$ROOT/scripts/check-version-receipts.sh"
+}
+
+test_valid_recent_receipt_passes() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  write_receipt "$tmp/skills/fixture/references/versions.md" '---
+checked_at: "2026-07-27"
+checked_by: "manual"
+pins:
+  - tool: "X"
+    version: "1.0.0"
+    source: "https://example.com"
+---
+'
+
+  run_checker "$tmp/skills" >/dev/null
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_stale_checked_at_fails() {
+  local tmp output status
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  write_receipt "$tmp/skills/fixture/references/versions.md" '---
+checked_at: "2020-01-01"
+checked_by: "manual"
+pins:
+  - tool: "X"
+    version: "1.0.0"
+    source: "https://example.com"
+---
+'
+
+  status=0
+  output="$(run_checker "$tmp/skills" 2>&1)" || status=$?
+  if (( status == 0 )); then
+    printf '%s\n' "$output" >&2
+    fail "checker passed despite a checked_at older than the budget"
+  fi
+  if [[ "$output" != *"fixture"* || "$output" != *"2020-01-01"* ]]; then
+    printf '%s\n' "$output" >&2
+    fail "checker did not name the skill and stale date"
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_missing_checked_at_fails() {
+  local tmp output status
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  write_receipt "$tmp/skills/fixture/references/versions.md" '---
+checked_by: "manual"
+pins:
+  - tool: "X"
+    version: "1.0.0"
+    source: "https://example.com"
+---
+'
+
+  status=0
+  output="$(run_checker "$tmp/skills" 2>&1)" || status=$?
+  if (( status == 0 )); then
+    printf '%s\n' "$output" >&2
+    fail "checker passed despite a missing checked_at"
+  fi
+  if [[ "$output" != *"missing checked_at"* ]]; then
+    printf '%s\n' "$output" >&2
+    fail "checker did not report the missing checked_at"
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_pin_missing_source_fails() {
+  local tmp output status
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  write_receipt "$tmp/skills/fixture/references/versions.md" '---
+checked_at: "2026-07-27"
+checked_by: "manual"
+pins:
+  - tool: "X"
+    version: "1.0.0"
+---
+'
+
+  status=0
+  output="$(run_checker "$tmp/skills" 2>&1)" || status=$?
+  if (( status == 0 )); then
+    printf '%s\n' "$output" >&2
+    fail "checker passed despite a pin missing source"
+  fi
+  if [[ "$output" != *"missing tool, version, or source"* ]]; then
+    printf '%s\n' "$output" >&2
+    fail "checker did not report the pin missing source"
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_http_source_fails() {
+  local tmp output status
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  write_receipt "$tmp/skills/fixture/references/versions.md" '---
+checked_at: "2026-07-27"
+checked_by: "manual"
+pins:
+  - tool: "X"
+    version: "1.0.0"
+    source: "http://example.com"
+---
+'
+
+  status=0
+  output="$(run_checker "$tmp/skills" 2>&1)" || status=$?
+  if (( status == 0 )); then
+    printf '%s\n' "$output" >&2
+    fail "checker passed despite an http:// (non-https) source"
+  fi
+  if [[ "$output" != *"not an https:// URL"* ]]; then
+    printf '%s\n' "$output" >&2
+    fail "checker did not report the non-https source"
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_no_versions_md_anywhere_passes() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  mkdir -p "$tmp/skills/fixture"
+  printf 'no receipts here\n' > "$tmp/skills/fixture/SKILL.md"
+
+  run_checker "$tmp/skills" >/dev/null
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_valid_recent_receipt_passes
+test_stale_checked_at_fails
+test_missing_checked_at_fails
+test_pin_missing_source_fails
+test_http_source_fails
+test_no_versions_md_anywhere_passes
+printf 'version receipt tests passed (6 cases)\n'

--- a/skills/observability/SKILL.md
+++ b/skills/observability/SKILL.md
@@ -21,13 +21,8 @@ logs, alert rules, SLOs, and dashboards-as-code - and audits a repo for the gaps
 service blind. It produces config (exporters, recording/alerting rules, OTLP pipelines,
 dashboard JSON), so the AI Self-Check applies.
 
-**Target versions** (July 2026):
-- Prometheus: 3.13.1
-- OpenTelemetry Collector: v0.156.0
-- Grafana: 13.1.1
-- Grafana Loki: 3.7.3
-- Grafana Tempo: 3.0.2
-- Alertmanager: 0.33.1
+**Target versions**: see `references/versions.md` (verified per the receipt date
+in that file). Do not restate version numbers here.
 
 ## When to use
 

--- a/skills/observability/references/versions.md
+++ b/skills/observability/references/versions.md
@@ -1,0 +1,37 @@
+---
+checked_at: "2026-07-27"
+checked_by: "manual"
+pins:
+  - tool: "Prometheus"
+    version: "3.13.1"
+    source: "https://github.com/prometheus/prometheus/releases"
+  - tool: "OpenTelemetry Collector"
+    version: "v0.156.0"
+    source: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases"
+  - tool: "Grafana"
+    version: "13.1.1"
+    source: "https://github.com/grafana/grafana/releases"
+  - tool: "Grafana Loki"
+    version: "3.7.3"
+    source: "https://github.com/grafana/loki/releases"
+  - tool: "Grafana Tempo"
+    version: "3.0.2"
+    source: "https://github.com/grafana/tempo/releases"
+  - tool: "Alertmanager"
+    version: "0.33.1"
+    source: "https://github.com/prometheus/alertmanager/releases"
+---
+
+# Observability target versions
+
+Pins referenced by `../SKILL.md`. See `docs/version-pins.md` for the receipt
+contract and staleness budget (120 days).
+
+| Tool | Version | Source |
+|---|---|---|
+| Prometheus | 3.13.1 | <https://github.com/prometheus/prometheus/releases> |
+| OpenTelemetry Collector | v0.156.0 | <https://github.com/open-telemetry/opentelemetry-collector-releases/releases> |
+| Grafana | 13.1.1 | <https://github.com/grafana/grafana/releases> |
+| Grafana Loki | 3.7.3 | <https://github.com/grafana/loki/releases> |
+| Grafana Tempo | 3.0.2 | <https://github.com/grafana/tempo/releases> |
+| Alertmanager | 0.33.1 | <https://github.com/prometheus/alertmanager/releases> |


### PR DESCRIPTION
## What

The freshness gate asserted a month-label string, not the versions the label stands for. `scripts/check-freshness-dates.sh` checked that markers read `July 2026` and nothing else — so a bulk label bump made untouched content *assert* currency it did not have, and CI went green.

This replaces the label check with per-pin receipts: what was checked, where the answer came from, and when. The gate now fails on age of verification.

## How

- `skills/<name>/references/versions.md` carries YAML frontmatter: `checked_at`, `checked_by`, and a `pins:` list of `tool` / `version` / `source`.
- `scripts/check-version-receipts.sh` validates the shape and fails any receipt older than `SKILLS_PIN_MAX_AGE_DAYS` (default 120).
- `scripts/check-freshness-dates.sh` skips the label check for any skill carrying a non-empty `references/versions.md` and keeps its existing behavior for every other skill.
- `docs/version-pins.md` documents the contract and the staleness budget.
- `observability` is migrated as the pilot. Its six version numbers are copied verbatim; none were researched or changed.

## Scope

Deliberately one skill. The remaining 46 migrate in a follow-up, in batches by category, so a broken mechanism does not have to be unwound across 47 files. Once all are migrated, `check-freshness-dates.sh` should be deleted outright rather than kept as a vestigial gate.

## Verification

- `check-version-receipts.sh` -> `Version receipts OK: 1 skill(s), oldest check 2026-07-27.`
- `test-version-receipts.sh` -> 6 cases (valid, stale, missing `checked_at`, missing `source`, non-https `source`, no receipts anywhere)
- `check-freshness-dates.sh` -> exit 0, skips `observability`, unchanged for the rest
- `lint-skills.sh`, `validate-spec.sh` -> `PASSED`, 0 warnings
- `shellcheck install.sh scripts/*.sh` -> exit 0
- Verified no version number in the diff differs from `43a46b7`.

The checker `eval`s values parsed from repo frontmatter; the awk `shquote()` helper escapes `\`, `"`, `$`, and backtick. Probed with a fixture embedding `$(...)` and backtick substitution in a `tool:` value — neither executed.

No release; several more changes land before the next version is cut.
