### PR TITLE
refactor(skills): drop injected generic self-check items, cap regrowth

### DIFF
--- a/scripts/check-contract-sync.sh
+++ b/scripts/check-contract-sync.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Guard the self-contained output contract:
-#   1. Every public skill ships references/output-contract.md identical to the
-#      source of truth (skills/_shared/output-contract.md). No drift.
+# Guard the self-contained shared references:
+#   1. Every public skill ships a references/<name>.md identical to the
+#      source of truth (skills/_shared/<name>.md) for each file in
+#      SHARED_FILE_NAMES (contract-lib.sh). No drift.
 #   2. No SKILL.md or references/*.md carries a runtime skills/_shared/ link
 #      (it would be a dead reference on standalone installs).
 #
@@ -12,44 +13,53 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=./scripts/contract-lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/contract-lib.sh"
-TARGET_NAME="output-contract.md"
 
 fail=0
-
-if [[ ! -f "$CONTRACT_SRC" ]]; then
-  printf '[!] Source contract missing: %s\n' "$CONTRACT_SRC" >&2
-  exit 1
-fi
-
-# Expected shipped contract (portable portion of the source).
-expected="$(render_shipped_contract)"
+exempt_pattern=""
+for n in "${SHARED_FILE_NAMES[@]}"; do
+  esc="${n//./\\.}"
+  if [[ -z "$exempt_pattern" ]]; then
+    exempt_pattern="/references/${esc}:"
+  else
+    exempt_pattern="${exempt_pattern}|/references/${esc}:"
+  fi
+done
 
 # ── 1. Drift check ─────────────────────────────────────────────────────
-for dir in "$ROOT"/skills/*/; do
-  name="$(basename "$dir")"
-  [[ "$name" == _* ]] && continue
-  [[ -f "$dir/SKILL.md" ]] || continue
-  copy="$dir/references/$TARGET_NAME"
-  if [[ ! -f "$copy" ]]; then
-    printf '[!] %s: missing references/%s (run scripts/gen-contract-refs.sh)\n' "$name" "$TARGET_NAME" >&2
-    fail=1
-    continue
+for target_name in "${SHARED_FILE_NAMES[@]}"; do
+  src="$ROOT/skills/_shared/$target_name"
+  if [[ ! -f "$src" ]]; then
+    printf '[!] Source file missing: %s\n' "$src" >&2
+    exit 1
   fi
-  if ! printf '%s\n' "$expected" | cmp -s - "$copy"; then
-    printf '[!] %s: references/%s drifted from source (run scripts/gen-contract-refs.sh)\n' "$name" "$TARGET_NAME" >&2
-    fail=1
-  fi
+  expected="$(render_shipped_file "$src")"
+
+  for dir in "$ROOT"/skills/*/; do
+    name="$(basename "$dir")"
+    [[ "$name" == _* ]] && continue
+    [[ -f "$dir/SKILL.md" ]] || continue
+    copy="$dir/references/$target_name"
+    if [[ ! -f "$copy" ]]; then
+      printf '[!] %s: missing references/%s (run scripts/gen-contract-refs.sh)\n' "$name" "$target_name" >&2
+      fail=1
+      continue
+    fi
+    if ! printf '%s\n' "$expected" | cmp -s - "$copy"; then
+      printf '[!] %s: references/%s drifted from source (run scripts/gen-contract-refs.sh)\n' "$name" "$target_name" >&2
+      fail=1
+    fi
+  done
 done
 
 # ── 2. Ban runtime _shared references ──────────────────────────────────
 # A skill must not point at skills/_shared/ at runtime - it does not ship.
-# The generated output-contract.md copies are exempt: their content is the
-# source contract itself, governed by the drift check above, not authored
-# per skill.
+# The generated copies (references/<name>.md for each SHARED_FILE_NAMES
+# entry) are exempt: their content is the source file itself, governed by
+# the drift check above, not authored per skill.
 shared_refs="$(grep -rn 'skills/_shared/' "$ROOT"/skills/*/SKILL.md "$ROOT"/skills/*/references/*.md 2>/dev/null \
-  | grep -v '/references/output-contract\.md:' || true)"
+  | grep -vE "$exempt_pattern" || true)"
 if [[ -n "$shared_refs" ]]; then
-  printf '[!] runtime reference to skills/_shared/ (use local references/%s instead):\n' "$TARGET_NAME" >&2
+  printf '[!] runtime reference to skills/_shared/ (use local references/<name>.md instead):\n' >&2
   printf '%s\n' "$shared_refs" >&2
   fail=1
 fi
@@ -59,4 +69,4 @@ if (( fail )); then
   exit 1
 fi
 
-printf 'Contract sync OK: all skills carry an in-sync references/%s, no runtime _shared refs.\n' "$TARGET_NAME"
+printf 'Contract sync OK: all skills carry in-sync shared references, no runtime _shared refs.\n'

--- a/scripts/contract-lib.sh
+++ b/scripts/contract-lib.sh
@@ -1,19 +1,32 @@
 #!/usr/bin/env bash
-# Shared helpers for the per-skill output contract.
+# Shared helpers for the per-skill shared references (output contract, agent
+# hygiene, ...).
 #
-# The source of truth is skills/_shared/output-contract.md. Everything above the
-# `maintainer-notes:not-shipped` marker is the portable contract that ships into
-# each skill's references/output-contract.md; the marker and everything below it
-# are maintainer/build notes that must never reach an installed skill.
+# Each source of truth lives in skills/_shared/<name>.md. Everything above the
+# `maintainer-notes:not-shipped` marker is the portable content that ships into
+# each skill's references/<name>.md; the marker and everything below it are
+# maintainer/build notes that must never reach an installed skill.
 
 CONTRACT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTRACT_ROOT="$(cd "$CONTRACT_LIB_DIR/.." && pwd)"
-CONTRACT_SRC="$CONTRACT_ROOT/skills/_shared/output-contract.md"
 CONTRACT_MARKER='<!-- maintainer-notes:not-shipped'
 
-# Emit the portable contract: every line before the marker, with trailing blank
-# lines trimmed so the shipped copy ends in exactly one newline.
-render_shipped_contract() {
+# Every shared file that gets copied into each skill's references/ dir.
+# shellcheck disable=SC2034  # consumed by scripts that source this lib
+SHARED_FILE_NAMES=(
+  "output-contract.md"
+  "agent-hygiene.md"
+)
+
+# Back-compat single-file variables, still used by callers that only care
+# about the output contract.
+CONTRACT_SRC="$CONTRACT_ROOT/skills/_shared/output-contract.md"
+
+# Emit the portable content of a shared file: every line before the marker,
+# with trailing blank lines trimmed so the shipped copy ends in exactly one
+# newline. Takes the source file path as $1.
+render_shipped_file() {
+  local src="$1"
   awk -v marker="$CONTRACT_MARKER" '
     index($0, marker) == 1 { exit }
     { lines[n++] = $0 }
@@ -21,5 +34,10 @@ render_shipped_contract() {
       while (n > 0 && lines[n-1] == "") n--
       for (i = 0; i < n; i++) print lines[i]
     }
-  ' "$CONTRACT_SRC"
+  ' "$src"
+}
+
+# Back-compat wrapper: render the output contract specifically.
+render_shipped_contract() {
+  render_shipped_file "$CONTRACT_SRC"
 }

--- a/scripts/contract-lib.sh
+++ b/scripts/contract-lib.sh
@@ -7,8 +7,6 @@
 # each skill's references/<name>.md; the marker and everything below it are
 # maintainer/build notes that must never reach an installed skill.
 
-CONTRACT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CONTRACT_ROOT="$(cd "$CONTRACT_LIB_DIR/.." && pwd)"
 CONTRACT_MARKER='<!-- maintainer-notes:not-shipped'
 
 # Every shared file that gets copied into each skill's references/ dir.
@@ -17,10 +15,6 @@ SHARED_FILE_NAMES=(
   "output-contract.md"
   "agent-hygiene.md"
 )
-
-# Back-compat single-file variables, still used by callers that only care
-# about the output contract.
-CONTRACT_SRC="$CONTRACT_ROOT/skills/_shared/output-contract.md"
 
 # Emit the portable content of a shared file: every line before the marker,
 # with trailing blank lines trimmed so the shipped copy ends in exactly one
@@ -35,9 +29,4 @@ render_shipped_file() {
       for (i = 0; i < n; i++) print lines[i]
     }
   ' "$src"
-}
-
-# Back-compat wrapper: render the output contract specifically.
-render_shipped_contract() {
-  render_shipped_file "$CONTRACT_SRC"
 }

--- a/scripts/gen-contract-refs.sh
+++ b/scripts/gen-contract-refs.sh
@@ -1,37 +1,42 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Generate each skill's local copy of the shared output contract.
+# Generate each skill's local copy of every shared reference file.
 #
 # Skills are installed individually (npx skills add, install.sh), so a skill may
 # not be co-located with skills/_shared/ at runtime. To stay self-contained,
-# every skill ships its own references/output-contract.md, generated from the
-# single source of truth at skills/_shared/output-contract.md.
+# every skill ships its own references/<name>.md for each file listed in
+# SHARED_FILE_NAMES (contract-lib.sh), generated from the single source of
+# truth at skills/_shared/<name>.md.
 #
-# Run this after editing the source contract. CI enforces no drift via
+# Run this after editing a source file. CI enforces no drift via
 # scripts/check-contract-sync.sh.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=./scripts/contract-lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/contract-lib.sh"
-TARGET_NAME="output-contract.md"
 
-if [[ ! -f "$CONTRACT_SRC" ]]; then
-  printf 'Source contract not found: %s\n' "$CONTRACT_SRC" >&2
-  exit 1
-fi
+total=0
+for target_name in "${SHARED_FILE_NAMES[@]}"; do
+  src="$ROOT/skills/_shared/$target_name"
+  if [[ ! -f "$src" ]]; then
+    printf 'Source file not found: %s\n' "$src" >&2
+    exit 1
+  fi
 
-# Render once: the portable contract is everything above the maintainer marker.
-shipped="$(render_shipped_contract)"
+  # Render once: the portable content is everything above the maintainer marker.
+  shipped="$(render_shipped_file "$src")"
 
-count=0
-for dir in "$ROOT"/skills/*/; do
-  name="$(basename "$dir")"
-  [[ "$name" == _* ]] && continue          # skip _shared and other build inputs
-  [[ -f "$dir/SKILL.md" ]] || continue
-  mkdir -p "$dir/references"
-  printf '%s\n' "$shipped" > "$dir/references/$TARGET_NAME"
-  count=$((count + 1))
+  count=0
+  for dir in "$ROOT"/skills/*/; do
+    name="$(basename "$dir")"
+    [[ "$name" == _* ]] && continue          # skip _shared and other build inputs
+    [[ -f "$dir/SKILL.md" ]] || continue
+    mkdir -p "$dir/references"
+    printf '%s\n' "$shipped" > "$dir/references/$target_name"
+    count=$((count + 1))
+  done
+
+  printf 'Generated %s/%s into %d skill(s).\n' "references" "$target_name" "$count"
+  total=$((total + count))
 done
-
-printf 'Generated %s/%s into %d skill(s).\n' "references" "$TARGET_NAME" "$count"

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -249,20 +249,26 @@ check_ai_self_check() {
 }
 
 # ── Generic self-check ratio check ──────────────────────────────────────
-# The five phrases below were bulk-injected by the skill-refiner scoring loop
-# into nearly every skill (see plans/008). They now live once, shared, at
+# The five items below (full canonical text, not just the bold label) were
+# bulk-injected by the skill-refiner scoring loop into nearly every skill
+# (see plans/008). They now live once, shared, at
 # skills/_shared/agent-hygiene.md. A skill's own '## AI Self-Check' section
 # should be dominated by hand-written, skill-specific checks; cap how much of
 # it can still be this generic boilerplate.
 #
+# Match on the full item text, not the bold label: an item that reuses a
+# label like "Routing overlap checked" with its own hand-written body (e.g.
+# skill-router's overlap check, or synology-dsm's DSM-specific checks) is
+# authored content, not injected filler, and must not be flagged.
+#
 # skill-refiner and skill-creator are exempt: routing overlap and spec-claim
 # verification are literally their domain, not injected filler.
-GENERIC_SELF_CHECK_PHRASES=(
-  "Current source checked"
-  "Hidden state identified"
-  "Verification is real"
-  "Routing overlap checked"
-  "Spec claims verified"
+GENERIC_SELF_CHECK_ITEMS=(
+  '- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them'
+  '- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting'
+  '- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths'
+  '- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance'
+  '- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files'
 )
 GENERIC_SELF_CHECK_EXEMPT=("skill-refiner" "skill-creator")
 GENERIC_SELF_CHECK_MAX_RATIO=10  # percent
@@ -278,14 +284,16 @@ check_generic_self_check_ratio() {
   section="$(awk '/^## AI Self-Check/{f=1; next} /^## /{f=0} f' "$file")"
   [[ -z "$section" ]] && return
 
-  local total generic phrase
+  local total generic canonical_item line
   total=$(grep -c '^- \[ \]' <<< "$section" || true)
   (( total == 0 )) && return
 
   generic=0
   while IFS= read -r line; do
-    for phrase in "${GENERIC_SELF_CHECK_PHRASES[@]}"; do
-      if [[ "$line" == *"$phrase"* ]]; then
+    # Normalize leading/trailing whitespace only - no other fuzzy matching.
+    line="$(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' <<< "$line")"
+    for canonical_item in "${GENERIC_SELF_CHECK_ITEMS[@]}"; do
+      if [[ "$line" == "$canonical_item" ]]; then
         (( generic++ )) || true
         break
       fi

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -250,11 +250,11 @@ check_ai_self_check() {
 
 # ── Generic self-check ratio check ──────────────────────────────────────
 # The five items below (full canonical text, not just the bold label) were
-# bulk-injected by the skill-refiner scoring loop into nearly every skill
-# (see plans/008). They now live once, shared, at
-# skills/_shared/agent-hygiene.md. A skill's own '## AI Self-Check' section
-# should be dominated by hand-written, skill-specific checks; cap how much of
-# it can still be this generic boilerplate.
+# bulk-injected by an automated skill-scoring pass into nearly every skill.
+# They now live once, shared, at skills/_shared/agent-hygiene.md. A skill's
+# own '## AI Self-Check' section should be dominated by hand-written,
+# skill-specific checks; cap how much of it can still be this generic
+# boilerplate.
 #
 # Match on the full item text, not the bold label: an item that reuses a
 # label like "Routing overlap checked" with its own hand-written body (e.g.

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -248,6 +248,56 @@ check_ai_self_check() {
   fi
 }
 
+# ── Generic self-check ratio check ──────────────────────────────────────
+# The five phrases below were bulk-injected by the skill-refiner scoring loop
+# into nearly every skill (see plans/008). They now live once, shared, at
+# skills/_shared/agent-hygiene.md. A skill's own '## AI Self-Check' section
+# should be dominated by hand-written, skill-specific checks; cap how much of
+# it can still be this generic boilerplate.
+#
+# skill-refiner and skill-creator are exempt: routing overlap and spec-claim
+# verification are literally their domain, not injected filler.
+GENERIC_SELF_CHECK_PHRASES=(
+  "Current source checked"
+  "Hidden state identified"
+  "Verification is real"
+  "Routing overlap checked"
+  "Spec claims verified"
+)
+GENERIC_SELF_CHECK_EXEMPT=("skill-refiner" "skill-creator")
+GENERIC_SELF_CHECK_MAX_RATIO=10  # percent
+
+check_generic_self_check_ratio() {
+  local file="$1" name="$2"
+  local exempt
+  for exempt in "${GENERIC_SELF_CHECK_EXEMPT[@]}"; do
+    [[ "$name" == "$exempt" ]] && return
+  done
+
+  local section
+  section="$(awk '/^## AI Self-Check/{f=1; next} /^## /{f=0} f' "$file")"
+  [[ -z "$section" ]] && return
+
+  local total generic phrase
+  total=$(grep -c '^- \[ \]' <<< "$section" || true)
+  (( total == 0 )) && return
+
+  generic=0
+  while IFS= read -r line; do
+    for phrase in "${GENERIC_SELF_CHECK_PHRASES[@]}"; do
+      if [[ "$line" == *"$phrase"* ]]; then
+        (( generic++ )) || true
+        break
+      fi
+    done
+  done <<< "$(grep '^- \[ \]' <<< "$section")"
+
+  local ratio=$(( generic * 100 / total ))
+  if (( ratio > GENERIC_SELF_CHECK_MAX_RATIO )); then
+    error "$name: AI Self-Check section is ${ratio}% generic boilerplate ($generic/$total items) - exceeds ${GENERIC_SELF_CHECK_MAX_RATIO}% cap, replace with skill-specific checks"
+  fi
+}
+
 # ── Collection-wide symlink check ──────────────────────────────────────
 # Reject committed symlinks under skills/. install.sh's skill_hash uses
 # `find` without -L so symlinks are no longer followed, but a committed
@@ -292,6 +342,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   check_references "$skill_file" "$name" "$skill_dir"
   check_private_refs "$skill_dir" "$name"
   check_ai_self_check "$skill_file" "$name"
+  check_generic_self_check_ratio "$skill_file" "$name"
   check_banned_words "$skill_dir" "$name"
   check_prose_double_dash "$skill_dir" "$name"
   (( skill_count++ )) || true

--- a/scripts/test-lint-skills.sh
+++ b/scripts/test-lint-skills.sh
@@ -128,19 +128,34 @@ test_real_cross_skill_reference_is_accepted() {
   trap - RETURN
 }
 
+# Full canonical item text - must match scripts/lint-skills.sh's
+# GENERIC_SELF_CHECK_ITEMS exactly, since the lint rule matches on the
+# complete item, not the bold label.
+CANONICAL_GENERIC_ITEMS=(
+  '- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them'
+  '- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting'
+  '- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths'
+  '- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance'
+  '- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files'
+)
+
+# Bold labels reused with a skill-specific, non-canonical body - must NOT be
+# flagged as generic even though the label matches.
+CUSTOM_BODY_LABELED_ITEMS=(
+  '- [ ] **Current source checked**: fixture-specific CLI flags are verified against the fixture docs'
+  '- [ ] **Hidden state identified**: fixture caches and prior fixture runs are made explicit'
+  '- [ ] **Verification is real**: fixture checks exercise the actual fixture runtime'
+  '- [ ] **Routing overlap checked**: overlap with other fixture skills is checked'
+  '- [ ] **Spec claims verified**: fixture claims are checked against the fixture spec'
+)
+
 append_self_check_section() {
   local skill_file="$1" generic_count="$2" total_count="$3"
   local i
   {
     printf '\n## AI Self-Check\n\n'
     for ((i = 1; i <= generic_count; i++)); do
-      case "$i" in
-        1) printf -- '- [ ] **Current source checked**: dated versions verified\n' ;;
-        2) printf -- '- [ ] **Hidden state identified**: local config made explicit\n' ;;
-        3) printf -- '- [ ] **Verification is real**: final checks exercise the runtime\n' ;;
-        4) printf -- '- [ ] **Routing overlap checked**: overlapping skills checked\n' ;;
-        5) printf -- '- [ ] **Spec claims verified**: claims checked against docs\n' ;;
-      esac
+      printf -- '%s\n' "${CANONICAL_GENERIC_ITEMS[$((i - 1))]}"
     done
     for ((i = generic_count + 1; i <= total_count; i++)); do
       printf -- '- [ ] Skill-specific check item %d\n' "$i"
@@ -187,6 +202,24 @@ test_generic_self_check_ratio_over_cap_fails() {
   trap - RETURN
 }
 
+test_generic_self_check_ratio_ignores_custom_body_with_generic_label() {
+  local tmp skill_dir
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  skill_dir="$tmp/skills/lint-fixture"
+  write_minimal_skill "$skill_dir" "lint-fixture"
+  {
+    printf '\n## AI Self-Check\n\n'
+    printf '%s\n' "${CUSTOM_BODY_LABELED_ITEMS[@]}"
+  } >> "$skill_dir/SKILL.md"
+
+  "$ROOT/scripts/lint-skills.sh" "$tmp/skills" >/dev/null
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
 test_generic_self_check_ratio_exempts_skill_creator() {
   local tmp skill_dir
   tmp="$(mktemp -d)"
@@ -208,5 +241,6 @@ test_unrelated_bold_does_not_mask_missing_reference
 test_real_cross_skill_reference_is_accepted
 test_generic_self_check_ratio_within_cap_passes
 test_generic_self_check_ratio_over_cap_fails
+test_generic_self_check_ratio_ignores_custom_body_with_generic_label
 test_generic_self_check_ratio_exempts_skill_creator
 printf 'lint tests passed\n'

--- a/scripts/test-lint-skills.sh
+++ b/scripts/test-lint-skills.sh
@@ -128,8 +128,85 @@ test_real_cross_skill_reference_is_accepted() {
   trap - RETURN
 }
 
+append_self_check_section() {
+  local skill_file="$1" generic_count="$2" total_count="$3"
+  local i
+  {
+    printf '\n## AI Self-Check\n\n'
+    for ((i = 1; i <= generic_count; i++)); do
+      case "$i" in
+        1) printf -- '- [ ] **Current source checked**: dated versions verified\n' ;;
+        2) printf -- '- [ ] **Hidden state identified**: local config made explicit\n' ;;
+        3) printf -- '- [ ] **Verification is real**: final checks exercise the runtime\n' ;;
+        4) printf -- '- [ ] **Routing overlap checked**: overlapping skills checked\n' ;;
+        5) printf -- '- [ ] **Spec claims verified**: claims checked against docs\n' ;;
+      esac
+    done
+    for ((i = generic_count + 1; i <= total_count; i++)); do
+      printf -- '- [ ] Skill-specific check item %d\n' "$i"
+    done
+  } >> "$skill_file"
+}
+
+test_generic_self_check_ratio_within_cap_passes() {
+  local tmp skill_dir
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  skill_dir="$tmp/skills/lint-fixture"
+  write_minimal_skill "$skill_dir" "lint-fixture"
+  append_self_check_section "$skill_dir/SKILL.md" 1 10
+
+  "$ROOT/scripts/lint-skills.sh" "$tmp/skills" >/dev/null
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_generic_self_check_ratio_over_cap_fails() {
+  local tmp skill_dir output status
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  skill_dir="$tmp/skills/lint-fixture"
+  write_minimal_skill "$skill_dir" "lint-fixture"
+  append_self_check_section "$skill_dir/SKILL.md" 5 10
+
+  status=0
+  output="$("$ROOT/scripts/lint-skills.sh" "$tmp/skills" 2>&1)" || status=$?
+  if (( status == 0 )); then
+    printf '%s\n' "$output" >&2
+    fail "lint-skills.sh passed despite a 50% generic AI Self-Check section"
+  fi
+  if [[ "$output" != *"lint-fixture"* || "$output" != *"50%"* ]]; then
+    printf '%s\n' "$output" >&2
+    fail "lint-skills.sh did not name the skill and ratio for the generic self-check overage"
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+test_generic_self_check_ratio_exempts_skill_creator() {
+  local tmp skill_dir
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  skill_dir="$tmp/skills/skill-creator"
+  write_minimal_skill "$skill_dir" "skill-creator"
+  append_self_check_section "$skill_dir/SKILL.md" 5 5
+
+  "$ROOT/scripts/lint-skills.sh" "$tmp/skills" >/dev/null
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
 test_reference_files_are_scanned
 test_reference_examples_are_ignored
 test_unrelated_bold_does_not_mask_missing_reference
 test_real_cross_skill_reference_is_accepted
+test_generic_self_check_ratio_within_cap_passes
+test_generic_self_check_ratio_over_cap_fails
+test_generic_self_check_ratio_exempts_skill_creator
 printf 'lint tests passed\n'

--- a/skills/_shared/agent-hygiene.md
+++ b/skills/_shared/agent-hygiene.md
@@ -1,0 +1,20 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
+
+<!-- maintainer-notes:not-shipped
+Everything above this marker is the portable hygiene checklist. It is the single
+source of truth and is copied verbatim into each skill's own
+references/agent-hygiene.md by scripts/gen-contract-refs.sh (drift-guarded by
+scripts/check-contract-sync.sh). This marker and everything below it are stripped
+before copying, so installed skills never see repo-internal build notes. Edit the
+checklist above, then re-run the generator.
+-->

--- a/skills/ai-ml/SKILL.md
+++ b/skills/ai-ml/SKILL.md
@@ -65,13 +65,9 @@ AI tools consistently produce the same mistakes when generating AI application c
 - [ ] No synchronous LLM calls in request handlers - always async with timeouts
 - [ ] PII stripped or masked before sending to external model APIs
 - [ ] Temperature set intentionally (0 for deterministic tasks, higher for creative)
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Provider drift checked**: Responses/Agents/SDK examples use current provider surfaces, not deprecated patterns - specifically verify no use of `openai.beta.assistants.create` (Assistants API, superseded by Responses/Agents API) or other Assistants-era surfaces
 - [ ] **RAG evidence bounded**: retrieval thresholds, citations, and empty-result behavior are defined before generation
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ## Performance
 

--- a/skills/ai-ml/references/agent-hygiene.md
+++ b/skills/ai-ml/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -76,13 +76,9 @@ AI tools consistently produce the same Ansible mistakes. **Before returning any 
 - [ ] Tags present on logical task groups for selective execution
 
 Run generated playbooks through `ansible-lint` (production profile) when available.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Collection docs checked**: module arguments and return values match the installed collection version
 - [ ] **Idempotence proven**: changed/ok behavior is verified with check mode or a second run where practical
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/ansible/references/agent-hygiene.md
+++ b/skills/ansible/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -54,15 +54,11 @@ Before returning any audit, verify:
 - [ ] **Density and short-text rule applied**: density heuristic applied before assigning severity; for text under 100 words, 2+ tells in one paragraph = P1 regardless of per-500-word threshold
 - [ ] **Audit output itself uses no AI-prose tells** (apply these rules to your own output)
 - [ ] **AI fallback names checked (fiction)**: protagonist and major-character names compared against the documented fallback set (Elara, Lyra, Aurora, Kael, Vale, Cassius, etc.) and the phonetic tell (2 soft syllables, A/L/R/N consonants, no demographic anchor); fallback-set names allowed only when the setting and population organically produce them
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Adverb stacking checked**: `-ly` adverb density scanned; passages with multiple adverb-modified speech tags or adjacent adverb clusters flagged at the same density threshold as vocabulary tells
 - [ ] **Confident filler checked**: emphasis crutches, rhetorical setups, and faux-profundity fragments flagged by pattern/density, not on isolated earned uses
 - [ ] **Overflagging avoided**: plain but valid technical prose is not labeled AI-written without concrete evidence
 - [ ] **Audience preserved**: edits keep the author's domain vocabulary, intent, and required formality
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/anti-ai-prose/references/agent-hygiene.md
+++ b/skills/anti-ai-prose/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/anti-slop/SKILL.md
+++ b/skills/anti-slop/SKILL.md
@@ -55,12 +55,8 @@ Before returning any anti-slop audit, verify:
 - [ ] **No hallucinated replacements**: verify that suggested modern alternatives actually exist in the target language version (e.g., `match` requires Python 3.10+, `LazyLock` requires Rust 1.80+)
 - [ ] **Test theater distinguished from correctness**: implementation-mirroring tests, mock-heavy ceremony, and snapshots with no semantic assertions belong here; actual failing behavior still belongs to code-review
 - [ ] **Structural duplication sweep done**: compare same-role modules/classes across sibling dirs (`providers`, `targets`, `sources`, `clients`, `registry`) and either report near-twins or note why the duplication is intentional
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **API/grounding verified**: suspicious helpers, flags, imports, config keys, and schema claims are checked against local types, generated schema, lockfiles, `--help` output, or official docs before being called hallucinations
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 ---
 
 ## Performance

--- a/skills/anti-slop/references/agent-hygiene.md
+++ b/skills/anti-slop/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/arch-btw/SKILL.md
+++ b/skills/arch-btw/SKILL.md
@@ -90,13 +90,9 @@ Before returning Arch or CachyOS commands, verify:
 - [ ] **Diagnostic errors are not silenced**: do not mask failures with `2>/dev/null` on commands whose error reason matters for triage. Use `2>&1 || true` to surface errors without aborting a gathering pass.
 - [ ] **Snapshots are not backups**: on Btrfs systems, snapshots help with rollback but do not replace real backups.
 - [ ] **Conflicting files use exact path**: `--overwrite` uses the specific file path from pacman error output, never a blanket `'*'` glob
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Mirror and repo state checked**: package advice matches current Arch/CachyOS repos and local mirror sync status
 - [ ] **AUR trust handled**: PKGBUILDs, install scripts, and maintainer changes are reviewed before build/install
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/arch-btw/references/agent-hygiene.md
+++ b/skills/arch-btw/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/backend-api/SKILL.md
+++ b/skills/backend-api/SKILL.md
@@ -75,14 +75,10 @@ Before returning API code, route design, or OpenAPI output, verify:
 - [ ] Cookie-based browser auth accounts for cookie scope and CSRF behavior instead of assuming cookies are automatically safe
 - [ ] OAuth guidance is current: authorization code + PKCE, no implicit flow, no resource owner password credentials
 - [ ] Sensitive defaults are explicit: cookie flags, token TTLs, scope boundaries, and rate limits are not hand-waved
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Framework version checked**: FastAPI, Express, NestJS, and OpenAPI examples match current APIs and migration notes
 - [ ] **Contract compatibility checked**: response codes, pagination, errors, and auth behavior preserve existing clients unless a version bump is explicit
 - [ ] **Injection in handler body flagged as contract defect**: if injection (SQL, command, header, path traversal) is found inside a route handler, flag it as a missing validation-boundary defect at the contract layer and recommend fixing it there; route to **security-audit** for a full injection audit if the pattern is widespread
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/backend-api/references/agent-hygiene.md
+++ b/skills/backend-api/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -56,13 +56,9 @@ Before returning any browsing result, verify:
 - [ ] Did not automate destructive account actions unless the user named the exact action and target
 - [ ] Re-extracted page state after any click or form submission before making decisions
 - [ ] Escalated to the next tool tier on failure rather than retrying the same tool
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Robots and terms considered**: scraping or automation respects access rules, auth boundaries, and rate limits
 - [ ] **Dynamic content verified**: browser-rendered pages are checked with the real tool when static HTML may be incomplete
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/browse/references/agent-hygiene.md
+++ b/skills/browse/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/ci-cd/SKILL.md
+++ b/skills/ci-cd/SKILL.md
@@ -81,13 +81,9 @@ every failure with file and line reference.
 - [ ] **Ignore-list entries have expiry dates**: every `.trivyignore`, `.grype.yaml`, Dependabot `ignore`, or Renovate `ignoreDeps` entry includes a comment with revisit date + owner. No dates = zombie tech debt.
 - [ ] **Lockfiles committed**: `package-lock.json`, `bun.lock`, `Cargo.lock`, `go.sum`, `uv.lock` belong in version control for applications. Manifest-only commits break reproducibility.
 - [ ] **Auto-merge gated on tests, not just lint**: Dependabot/Renovate auto-merge without test coverage of the changed area is a supply-chain shortcut.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Runner trust checked**: workflow advice distinguishes hosted, self-hosted, fork, and protected-branch execution
 - [ ] **Mutable references controlled**: actions, images, includes, and templates are pinned where supply-chain risk matters
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ## Performance
 

--- a/skills/ci-cd/references/agent-hygiene.md
+++ b/skills/ci-cd/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/cluster-health/SKILL.md
+++ b/skills/cluster-health/SKILL.md
@@ -47,15 +47,11 @@ Before running checks or reporting results, verify:
 - [ ] Time window is bounded and stated in the report
 - [ ] Protected registry contents are not printed unless the user asks for those exact details
 - [ ] Findings include evidence, impact, and next action
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Cluster target explicit**: kubeconfig context, namespace, and environment are named before any query
 - [ ] **Read-only posture kept**: health checks do not mutate resources or restart workloads unless the user explicitly escalates
 - [ ] **No improvisation**: only the read-only commands in the reference files were run; missing coverage was noted as a suggestion, not freelanced with guessed service names, paths, or flags
 - [ ] **Stderr is visible**: diagnostic commands surface their failure reason instead of masking it with `2>/dev/null`; a missing tool, permission gap, or wrong context is reported, not silently treated as a clean result
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ## Performance
 

--- a/skills/cluster-health/references/agent-hygiene.md
+++ b/skills/cluster-health/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -54,13 +54,9 @@ Before reporting any finding at >= 80% confidence, verify:
 - [ ] **Construct a failing case**: for P0 findings, describe the specific input or sequence that triggers the bug
 - [ ] **Verify API/stdlib claims**: AI code review suggestions frequently contain factual errors about framework behavior. If unsure, look it up
 - [ ] **Boundary values on numeric inputs flagged**: zero, negative, and overflow values on page numbers, sizes, counts, and indices are high-confidence findings - do not suppress with the 80% threshold
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Line references verified**: every finding points to code that exists in the reviewed diff
 - [ ] **Behavioral claim proven**: findings describe a plausible failing input, race, leak, or regression
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/code-review/references/agent-hygiene.md
+++ b/skills/code-review/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/code-slimming/SKILL.md
+++ b/skills/code-slimming/SKILL.md
@@ -123,8 +123,10 @@ Before returning a code-slimming audit, verify:
   anti-ai-prose, and load-bearing comments (why, invariants, links, license, lint pragmas) are kept
 - [ ] **Correctness and security routed**: bugs go to code-review; vulnerabilities go to security-audit
 - [ ] **Routing lane held**: generic cleanup, slop, correctness, security, test-writing,
-- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
   broad-review, and implementation work were routed instead of reported as code-slimming findings
+- [ ] **Routing overlap checked**: recommendations do not duplicate anti-slop, code-review, testing, full-review, or deep-audit responsibilities
+- [ ] **Spec claims verified**: any statement about skill behavior, output contracts, or repo conventions is checked against current skill files and scripts
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/code-slimming/SKILL.md
+++ b/skills/code-slimming/SKILL.md
@@ -123,12 +123,8 @@ Before returning a code-slimming audit, verify:
   anti-ai-prose, and load-bearing comments (why, invariants, links, license, lint pragmas) are kept
 - [ ] **Correctness and security routed**: bugs go to code-review; vulnerabilities go to security-audit
 - [ ] **Routing lane held**: generic cleanup, slop, correctness, security, test-writing,
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
   broad-review, and implementation work were routed instead of reported as code-slimming findings
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: recommendations do not duplicate anti-slop, code-review, testing, full-review, or deep-audit responsibilities
-- [ ] **Spec claims verified**: any statement about skill behavior, output contracts, or repo conventions is checked against current skill files and scripts
 
 ---
 

--- a/skills/code-slimming/references/agent-hygiene.md
+++ b/skills/code-slimming/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/command-prompt/SKILL.md
+++ b/skills/command-prompt/SKILL.md
@@ -58,13 +58,9 @@ Before returning any generated shell script or command, verify:
 - [ ] No hardcoded paths for tools (`/usr/bin/git`) - use `command -v` or bare command names
 - [ ] Temp files use `mktemp` with cleanup traps, not hardcoded `/tmp/foo`
 - [ ] No secrets in command history (use `read -s` or environment variables)
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Shell identified**: examples match POSIX sh, Bash, Zsh, or Fish semantics intentionally
 - [ ] **Quoting tested**: paths with spaces, empty variables, and glob characters behave safely
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/command-prompt/references/agent-hygiene.md
+++ b/skills/command-prompt/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/databases/SKILL.md
+++ b/skills/databases/SKILL.md
@@ -105,13 +105,9 @@ AI tools consistently produce the same database mistakes. **Before returning any
 - [ ] Connection pool settings don't exceed `max_connections` across all app instances
 - [ ] Backup strategy tested by actually restoring (backup without restore test = hope, not a strategy)
 - [ ] Secrets (passwords, connection strings) injected via env vars or secret managers, not config files
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Engine/version checked**: SQL syntax, index options, and replication advice match the named engine and major version
 - [ ] **Data-loss path gated**: migrations, deletes, reindexes, and failovers include backup, dry-run, rollback, or maintenance-window guidance
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/databases/references/agent-hygiene.md
+++ b/skills/databases/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -97,13 +97,9 @@ Before returning Debian or Ubuntu commands, verify:
 - [ ] **Diagnostic errors are not silenced**: do not mask failures with `2>/dev/null` on commands whose error reason matters. Use `2>&1 || true` to surface errors without aborting.
 - [ ] **Firmware updates are not conflated with package updates**: `fwupd` and vendor tools (e.g., `system76-firmware`) are separate from `apt upgrade`.
 - [ ] **Debian alternatives are checked**: when a command behaves oddly, verify `update-alternatives` for that binary.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Release support checked**: Debian/Ubuntu/Mint/Pop advice matches current lifecycle and enabled repositories
 - [ ] **Third-party repo risk handled**: PPAs, snaps, vendor repos, and pin priorities are explicit
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/debian-ubuntu/references/agent-hygiene.md
+++ b/skills/debian-ubuntu/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/debug-triage/references/agent-hygiene.md
+++ b/skills/debug-triage/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/deep-audit/SKILL.md
+++ b/skills/deep-audit/SKILL.md
@@ -62,13 +62,9 @@ workflow (waves + persistence + routing), not just the wave dispatch phase.
 - [ ] If LARGE and no brainstorming skill is available, execution-plan files written to `docs/local/specs/` and `docs/local/plans/` using the standard naming convention
 - [ ] When user specified a scope, all agents received that scope constraint and detection was filtered to the scoped file tree
 - [ ] Only skills from the iuliandita/skills collection were used - no built-in reviewers or platform audit modes
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Scope bounded**: audit waves match the repo type and user request, not every possible skill
 - [ ] **Evidence retained**: findings cite files, commands, outputs, or source docs instead of impressions
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ## Performance
 

--- a/skills/deep-audit/references/agent-hygiene.md
+++ b/skills/deep-audit/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/deep-grill/SKILL.md
+++ b/skills/deep-grill/SKILL.md
@@ -68,7 +68,8 @@ and fold both phases into the record. Everything else still holds.
 - [ ] **Vague answers forced concrete**: every hand-wave resolved to a decision, a sharp open question, a flagged fog patch, or a do-first prerequisite - never a silent gap.
 - [ ] **Decision record written**: resolved decisions, surviving risks, open questions, fog, prerequisites, and a next step land in the deliverable file.
 - [ ] **Domain detected and routed**: correct lens applied; if the real task is code review, security, or a repo audit, routed to the right skill instead.
-- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
+- [ ] **Hidden state identified**: existing code, config, prior decisions, and constraints are surfaced before grilling, not assumed.
+- [ ] **Routing overlap checked**: overlap with jekyll-hyde and code-review handled per "When NOT to use" before proceeding.
 
 ---
 

--- a/skills/deep-grill/SKILL.md
+++ b/skills/deep-grill/SKILL.md
@@ -68,8 +68,7 @@ and fold both phases into the record. Everything else still holds.
 - [ ] **Vague answers forced concrete**: every hand-wave resolved to a decision, a sharp open question, a flagged fog patch, or a do-first prerequisite - never a silent gap.
 - [ ] **Decision record written**: resolved decisions, surviving risks, open questions, fog, prerequisites, and a next step land in the deliverable file.
 - [ ] **Domain detected and routed**: correct lens applied; if the real task is code review, security, or a repo audit, routed to the right skill instead.
-- [ ] **Hidden state identified**: existing code, config, prior decisions, and constraints are surfaced before grilling, not assumed.
-- [ ] **Routing overlap checked**: overlap with jekyll-hyde and code-review handled per "When NOT to use" before proceeding.
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/deep-grill/references/agent-hygiene.md
+++ b/skills/deep-grill/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -84,13 +84,9 @@ Before declaring finish-mode complete:
 - [ ] CI watched to completion with forge-appropriate verification (e.g., `gh pr view --json statusCheckRollup`, `glab ci status`, manual confirmation for Bitbucket/bare) - not merged on "probably fine"
 - [ ] For releases: tag matches the bumped version; CHANGELOG has a new section dated today; release-workflow watch used forge-appropriate exit-status flag (`gh run watch --exit-status` etc.)
 - [ ] No `--no-verify`, no `--force-push`, no destructive reset - if blocked, fix the root cause
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Dirty tree protected**: unrelated user changes are identified and left intact
 - [ ] **Remote/branch target checked**: base branch, upstream, and PR target are verified before push, merge, or release
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/dev-cycle/references/agent-hygiene.md
+++ b/skills/dev-cycle/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -65,13 +65,9 @@ AI tools consistently produce the same Docker mistakes. **Before returning any g
 - [ ] Package caches cleaned in same layer: `--no-cache` (apk), `rm -rf /var/lib/apt/lists/*` (apt). For pip: use `--mount=type=cache` OR `--no-cache-dir`, not both.
 - [ ] CMD uses exec form (JSON array), not shell form: `CMD ["node", "app.js"]` not `CMD node app.js`
 - [ ] **HEALTHCHECK uses available tools**: probe command uses a binary present in the final image (wget in Alpine, curl in Debian, none in scratch/distroless - use the app's own health endpoint)
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Engine/Compose syntax checked**: Dockerfile, Compose, BuildKit, and runtime flags match the installed versions
 - [ ] **Image provenance considered**: base images, registries, tags, SBOMs, and signatures are handled where risk warrants
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ## Performance
 

--- a/skills/docker/references/agent-hygiene.md
+++ b/skills/docker/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/firewall-appliance/SKILL.md
+++ b/skills/firewall-appliance/SKILL.md
@@ -58,13 +58,9 @@ Before returning any firewall commands, verify:
   drops from the client side
 - [ ] VLAN interface assigned before adding rules - unassigned VLANs pass no traffic through
   the firewall even if the trunk is tagged correctly
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Platform/version checked**: OPNsense, pfSense, FreeBSD, pf, and plugin commands match the appliance version
 - [ ] **Lockout path prevented**: remote firewall changes preserve management access and rollback
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/firewall-appliance/references/agent-hygiene.md
+++ b/skills/firewall-appliance/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -67,13 +67,9 @@ Before returning any built UI or critique, verify:
 - [ ] **Responsive QA completed** - desktop, mobile, keyboard, dark+light, text overflow, and screenshot review checked when visual changes were made
 - [ ] **Critique mode: max 10 tickets** - P0/P1 priority. Rant is filtered, not shipped raw
 - [ ] **No AI prose tells in commentary** - apply the **anti-ai-prose** vocabulary list to the persona's own writing, not just user-facing copy. Plain English
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Framework reality checked**: React, Next, Vite, Astro, SvelteKit, and Tailwind guidance matches current docs and installed packages
 - [ ] **Visual verification done**: responsive screenshots or browser checks confirm layout, assets, and interaction states
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/frontend-design/references/agent-hygiene.md
+++ b/skills/frontend-design/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/full-review/SKILL.md
+++ b/skills/full-review/SKILL.md
@@ -57,13 +57,9 @@ Verify:
 - [ ] Preflight context block was passed to all agents
 - [ ] When user specified a scope, the `Scope:` line in every agent's context block reflects that scope (not "full codebase review")
 - [ ] Scope held in output: each agent's findings reference only files/modules within the requested scope. If any agent's output references out-of-scope paths, flag it in that report's header (see Step 3 scope verification)
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Routing explicit**: code-review, anti-slop, security-audit, and update-docs findings stay in their lanes
 - [ ] **No false coverage**: unrun tests, skipped directories, and unavailable tools are reported
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/full-review/references/agent-hygiene.md
+++ b/skills/full-review/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -86,13 +86,9 @@ verify against this list:**
 - [ ] **Force-push safety.** If force-push is needed, always use `--force-with-lease` (refuses if remote has unfetched commits). Plain `--force` requires explicit user approval and team coordination.
 - [ ] **Version info dated.** When citing tool versions, include a date so readers know when to re-check. Stale version numbers cause silent breakage.
 - [ ] **Forge-CLI subcommands verified.** Before scripting `fj`/`gh`/`glab`/`tea` commands in a runbook, hooks, or CI, confirm the subcommand and flags exist on the target version (`<cli> <cmd> --help`). These CLIs add, rename, and remove subcommands across minor versions; docs lag behind the binary.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Ref safety checked**: branch, remote, upstream, and worktree path are verified before history edits
 - [ ] **Recovery path known**: reflog, backup branch, or bundle exists before destructive history operations
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/git/references/agent-hygiene.md
+++ b/skills/git/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -62,6 +62,7 @@ Before writing or returning a handoff doc, verify:
 - [ ] **Small enough to fit**: the doc is short enough to sit in the next session's
       high-attention zone - if it is long, cut detail and lean harder on pointers
 - [ ] **Gitignored**: `.handoff/` is in .gitignore unless the user asked to commit the doc
+- [ ] **Spec claims verified**: pointers (paths, line numbers, PR numbers, branches) are confirmed to exist at write time, not assumed
 - [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -62,11 +62,7 @@ Before writing or returning a handoff doc, verify:
 - [ ] **Small enough to fit**: the doc is short enough to sit in the next session's
       high-attention zone - if it is long, cut detail and lean harder on pointers
 - [ ] **Gitignored**: `.handoff/` is in .gitignore unless the user asked to commit the doc
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: pointers (paths, line numbers, PR numbers, branches) are confirmed to exist at write time, not assumed
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/handoff/references/agent-hygiene.md
+++ b/skills/handoff/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/jekyll-hyde/SKILL.md
+++ b/skills/jekyll-hyde/SKILL.md
@@ -53,13 +53,9 @@ Before returning advice, verify:
 - [ ] **Sharp strategy separated from abuse**: do not label every strong moat, opinionated default, or growth loop as a dark pattern.
 - [ ] **Domain routed correctly**: if the user needs code bugs, security findings, UI craft, or roadmap capture, route to the adjacent skill.
 - [ ] **Final recommendation included**: even after Hyde, end with an actionable path or decision frame.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Decision scope held**: critique targets the decision, constraints, and tradeoffs, not unrelated strategy
 - [ ] **Evidence separated**: facts, assumptions, risks, and opinions are labeled distinctly
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/jekyll-hyde/references/agent-hygiene.md
+++ b/skills/jekyll-hyde/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -82,13 +82,9 @@ Before returning Kali commands or tool recommendations, verify:
 - [ ] **NetHunter is not treated like normal desktop Kali**: mobile kernels, Android host constraints, rootless vs full chroot shape, and missing systemd-style tooling can change which checks even make sense.
 - [ ] **Correct handoff chosen**: once the question becomes exploitation methodology, route to **lockpick**. Once it becomes original vulnerability discovery, route to **zero-day**.
 - [ ] **Diagnostic errors are not silenced**: do not hide useful failure output with `2>/dev/null` on commands whose error reason matters. Use `2>&1 || true` when gathering.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Channel checked**: kali-rolling, snapshots, metapackages, and NetHunter advice matches official docs
 - [ ] **Lab boundary explicit**: offensive tooling stays in authorized labs, CTFs, or owned systems
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/kali-linux/references/agent-hygiene.md
+++ b/skills/kali-linux/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -60,14 +60,10 @@ This skill runs inside an AI agent. AI tools consistently produce the same K8s s
 - [ ] Kube context verified before any kubectl/helm/argocd command
 - [ ] Requester is authorized for cluster/admin changes, especially in shared chats. If the request comes from a non-admin participant, stop and ask the authorized owner for approval before kubectl, Helm, ArgoCD, or GitOps edits.
 - [ ] No auto-sync to production without approval gate
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **API versions checked**: manifests, Helm templates, and Gateway resources match the target cluster version
 - [ ] **Cluster context verified**: namespace, context, and kubeconfig identity are shown before mutating commands
 - [ ] **kube-proxy mode checked on 1.35+ clusters**: IPVS mode is deprecated in 1.35 (removal targeted for a future release); recommend nftables mode for new clusters and flag IPVS in reviews
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 Run generated manifests through `kube-score`, `kubelinter`, or `checkov` when available.
 

--- a/skills/kubernetes/references/agent-hygiene.md
+++ b/skills/kubernetes/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -89,13 +89,9 @@ code, catalogs, or translations, verify against this list:**
   commas or unquoted keys
 - [ ] **Locale detection complete**: browser navigator.language, Accept-Language header,
   or user preference stored and respected
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Locale data checked**: ICU message syntax, plural categories, and CLDR assumptions match the target locales
 - [ ] **Fallback behavior tested**: missing keys, pseudo-locales, RTL, and long strings are exercised
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/localize/references/agent-hygiene.md
+++ b/skills/localize/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/lockpick/SKILL.md
+++ b/skills/lockpick/SKILL.md
@@ -56,11 +56,7 @@ Before executing any technique or generating exploitation commands, verify:
 - [ ] **No destructive actions**: kernel exploits tested in lab first, no `rm -rf`, no disk writes to critical paths
 - [ ] **Architecture matched**: exploit/payload matches target arch (`uname -m`). x86_64 exploits don't work on ARM, 32-bit payloads fail on 64-bit-only systems
 - [ ] **Reverse shells use authorized ports**: listener IP and port match the engagement plan
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/lockpick/references/agent-hygiene.md
+++ b/skills/lockpick/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/mcp/SKILL.md
+++ b/skills/mcp/SKILL.md
@@ -62,14 +62,10 @@ When generating or reviewing MCP server code, verify each item before presenting
 - [ ] Rate limiting on tool invocations
 - [ ] Tool annotations treated as untrusted by client-side code
 - [ ] Elicitation does not request passwords, tokens, or secrets
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Spec version checked**: transports, auth, resources, tools, and prompts match current MCP docs and SDK behavior
 - [ ] **Tool poisoning considered**: tool descriptions, dynamic metadata, and server updates cannot silently expand authority
 - [ ] **SDK methods verified**: see Common Mistakes #8 - verify every API call against actual SDK docs rather than inventing method names
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/mcp/references/agent-hygiene.md
+++ b/skills/mcp/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/networking/SKILL.md
+++ b/skills/networking/SKILL.md
@@ -95,13 +95,9 @@ Before returning any generated network configuration, verify:
 - [ ] **systemd-resolved conflict**: if deploying a local DNS server (Unbound, CoreDNS,
   dnsmasq), check whether systemd-resolved is binding port 53. Disable its stub listener
   (`DNSStubListener=no`) or bind your server to a different port
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Topology verified**: interface names, routes, DNS resolvers, namespaces, VPN state, and firewall backend are observed before changes
 - [ ] **Rollback path preserved**: remote network changes include timed rollback, console access, or an alternate path
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/networking/references/agent-hygiene.md
+++ b/skills/networking/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -112,13 +112,9 @@ Before returning NixOS or Nix commands, verify:
 - [ ] **Determinate / Lix advice scoped**: Determinate's `determinate-nixd` and Lix's CLI diverge from upstream in subtle places. Name the lane before suggesting daemon or CLI flags.
 - [ ] **Diagnostic errors are not silenced**: do not hide useful output with `2>/dev/null` when the error text is the evidence. Use `2>&1 || true` when gathering.
 - [ ] **Version pins justified**: if a pinned `system.stateVersion` is suggested, explain why; do not change `stateVersion` on an existing system casually - it controls migration semantics.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Channel/flake checked**: advice matches stable, unstable, flake, home-manager, or nix-darwin context
 - [ ] **Rollback identified**: generation rollback, boot entries, and store/cache state are understood before changes
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/nixos-btw/references/agent-hygiene.md
+++ b/skills/nixos-btw/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/observability/references/agent-hygiene.md
+++ b/skills/observability/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/prompt-generator/SKILL.md
+++ b/skills/prompt-generator/SKILL.md
@@ -51,13 +51,9 @@ Before returning any generated or modified prompt file, verify:
 - [ ] **Evaluator criteria explicit**: evaluator prompts define pass/fail criteria, required evidence, and common failure modes
 - [ ] **Delegation contract clear**: delegation prompts define ownership, scope, files, allowed edits, and expected final answer shape
 - [ ] **Model-appropriate syntax**: avoid model-specific features (assistant prefills, `\n\nHuman:` formatting) in model-agnostic prompts. XML delimiters and markdown headers are both fine for structure across models
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Injection boundary set**: untrusted source text is delimited and never treated as instructions
 - [ ] **Model lock-in avoided**: provider-specific syntax appears only when the user named that provider
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/prompt-generator/references/agent-hygiene.md
+++ b/skills/prompt-generator/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -98,13 +98,9 @@ Before returning Fedora or RHEL-family commands, verify:
 - [ ] **Upgrade path is real**: Fedora `dnf system-upgrade`, RHEL `leapp`, and clone major-version jumps have different support stories. Do not improvise an in-place major upgrade path.
 - [ ] **Diagnostic errors are not silenced**: do not hide useful failure output with `2>/dev/null` on commands whose errors matter. Use `2>&1 || true` when gathering.
 - [ ] **Version table treated as a hint, not gospel**: if the pinned table is getting old, verify distro release and key package versions live before leaning on it.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Lifecycle checked**: RHEL, Fedora, Rocky, Alma, CentOS Stream, and Amazon Linux guidance matches the target release
 - [ ] **SELinux/firewalld context preserved**: fixes do not disable enforcement permanently as a shortcut
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/rhel-fedora/references/agent-hygiene.md
+++ b/skills/rhel-fedora/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/roadmap/SKILL.md
+++ b/skills/roadmap/SKILL.md
@@ -56,13 +56,9 @@ Before writing or modifying ROADMAP.md, verify:
 - [ ] **No hallucinated competitive data**: every feature, issue count, or user demand claim
       from a competitor repo is backed by an actual link or quote - not inferred
 - [ ] **No priority inflation**: P0 items are genuine blockers, not aspirational wishes
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Evidence quality marked**: competitive intel, user feedback, and assumptions are labeled with source and confidence
 - [ ] **Backlog hygiene kept**: stale ideas are parked or deleted instead of endlessly reprioritized
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ## Roadmap Format
 

--- a/skills/roadmap/references/agent-hygiene.md
+++ b/skills/roadmap/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/routine-writer/SKILL.md
+++ b/skills/routine-writer/SKILL.md
@@ -58,13 +58,9 @@ Routines are high-stakes: they run unattended, consume daily allowance, and can 
 - [ ] **Cron interval >= 1 hour**: scheduled triggers under one hour are rejected by the platform.
 - [ ] **Beta header pinned with date**: prose mentions of `experimental-cc-routine-2026-04-01` carry the header date so future readers can scan for staleness. Inside code blocks the header string itself carries the date, so no parenthetical is needed.
 - [ ] **No tokens in output**: environment variable placeholders only. Never paste a real `sk-ant-oat01-...` value.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **API surface checked**: routine headers, beta names, schedule syntax, and event payloads match current official docs
 - [ ] **Unattended risk bounded**: permissions, spending, mutation scope, and notification paths are explicit
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/routine-writer/references/agent-hygiene.md
+++ b/skills/routine-writer/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -59,13 +59,9 @@ Before returning any security audit report, verify:
 - [ ] **Known incidents checked**: dependency audit verified against the known supply chain incidents listed in Step 3 (event-stream, ua-parser-js, colors any version, faker, polyfill.io, xz-utils, trivy 0.69.4-0.69.6, TrapDoor, Mini Shai-Hulud worm, outdated lodash), not just CVE databases
 - [ ] **Agentic risks covered** (when applicable): MCP servers, AI tool handlers, prompt injection surfaces audited if present
 - [ ] **Scope respected**: no external service probing, no DAST, repo-only analysis
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Threat model matched**: findings map to the app's actual assets, actors, trust boundaries, and deployment
 - [ ] **Exploitability stated carefully**: severity is based on reachable paths and impact, not scanner labels alone
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/security-audit/references/agent-hygiene.md
+++ b/skills/security-audit/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/skill-creator/references/agent-hygiene.md
+++ b/skills/skill-creator/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/skill-refiner/references/agent-hygiene.md
+++ b/skills/skill-refiner/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/skill-router/SKILL.md
+++ b/skills/skill-router/SKILL.md
@@ -44,6 +44,8 @@ Before returning a routing decision, verify:
 - [ ] One primary skill is selected unless the task truly spans multiple domains
 - [ ] Near misses are explained only when useful
 - [ ] The next action is clear: invoke a skill, ask a question, or proceed without a skill
+- [ ] **Routing overlap checked**: close matches are checked for trigger theft, missing exclusions, and process-skill precedence before the final route
+- [ ] **Spec claims verified**: claims about installed skills, trigger descriptions, or routing metadata are checked against the current collection
 - [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---

--- a/skills/skill-router/SKILL.md
+++ b/skills/skill-router/SKILL.md
@@ -44,11 +44,7 @@ Before returning a routing decision, verify:
 - [ ] One primary skill is selected unless the task truly spans multiple domains
 - [ ] Near misses are explained only when useful
 - [ ] The next action is clear: invoke a skill, ask a question, or proceed without a skill
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: close matches are checked for trigger theft, missing exclusions, and process-skill precedence before the final route
-- [ ] **Spec claims verified**: claims about installed skills, trigger descriptions, or routing metadata are checked against the current collection
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/skill-router/references/agent-hygiene.md
+++ b/skills/skill-router/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/synology-dsm/SKILL.md
+++ b/skills/synology-dsm/SKILL.md
@@ -80,11 +80,7 @@ in this order, rather than being skipped:
 - [ ] Tool presence checked, not assumed - `lsof`, `fuser`, `mountpoint`, `modinfo` are absent
 - [ ] Config edits target files DSM does not regenerate, or the regeneration is accounted for
 - [ ] Backup or snapshot state verified before any repair, not after
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: DSM version, model, package dependencies, mounted volumes, and prior repair attempts are made explicit before acting
-- [ ] **Verification is real**: checks exercise the actual mount, service, or filesystem rather than reading a DSM banner
-- [ ] **Routing overlap checked**: generic Linux, container, and network tasks are routed to the matching skill
-- [ ] **Spec claims verified**: claims about DSM behavior are checked against the appliance or Synology's GPL kernel source, not recalled
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/synology-dsm/SKILL.md
+++ b/skills/synology-dsm/SKILL.md
@@ -80,6 +80,10 @@ in this order, rather than being skipped:
 - [ ] Tool presence checked, not assumed - `lsof`, `fuser`, `mountpoint`, `modinfo` are absent
 - [ ] Config edits target files DSM does not regenerate, or the regeneration is accounted for
 - [ ] Backup or snapshot state verified before any repair, not after
+- [ ] **Hidden state identified**: DSM version, model, package dependencies, mounted volumes, and prior repair attempts are made explicit before acting
+- [ ] **Verification is real**: checks exercise the actual mount, service, or filesystem rather than reading a DSM banner
+- [ ] **Routing overlap checked**: generic Linux, container, and network tasks are routed to the matching skill
+- [ ] **Spec claims verified**: claims about DSM behavior are checked against the appliance or Synology's GPL kernel source, not recalled
 - [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---

--- a/skills/synology-dsm/references/agent-hygiene.md
+++ b/skills/synology-dsm/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -68,13 +68,9 @@ AI tools consistently produce the same Terraform mistakes. **Before returning an
 - [ ] `terraform fmt` and `terraform validate` pass
 
 **AI should never own `terraform apply`.** In March 2026, an AI-assisted Terraform workflow deleted production infrastructure through escalating cleanup logic. Plan output is reviewed by a human. Always.
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Provider docs checked**: resource arguments, defaults, and deprecations match pinned provider versions
 - [ ] **State impact reviewed**: imports, moves, destroys, and replacements are visible in plan output before apply
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ## Performance
 

--- a/skills/terraform/references/agent-hygiene.md
+++ b/skills/terraform/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -66,13 +66,9 @@ AI tools consistently produce the same testing mistakes. **Before returning any 
 - [ ] Coverage threshold is realistic (80% line coverage is a good default; 100% is a lie)
 - [ ] Snapshot tests have been reviewed manually before committing (blind `--update` is a bug factory)
 - [ ] E2E selectors use `data-testid`, `role`, or accessible names - not CSS classes or DOM structure
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Runner APIs current**: pytest, Vitest, Jest, Playwright, and Testing Library examples match current runner behavior
 - [ ] **Flake source identified**: retries are not used to hide nondeterminism without diagnosis
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/testing/references/agent-hygiene.md
+++ b/skills/testing/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -57,13 +57,9 @@ Before presenting documentation updates, verify:
 - [ ] All roadmap files (committed AND gitignored) checked - their stated version/date matches current HEAD or latest tag
 - [ ] `[planned]` / `[exploring]` items that actually shipped have moved to Shipped Highlights, not left in the in-progress list
 - [ ] When private and public roadmaps both exist, both are updated, with the public one carrying user-visible highlights only and the private one carrying internal detail
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Docs match code**: commands, flags, config names, screenshots, and API examples are checked against the changed implementation
 - [ ] **Audience path checked**: README, changelog, API docs, runbooks, and migration notes are updated only where users need them
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ## Core Principle
 

--- a/skills/update-docs/references/agent-hygiene.md
+++ b/skills/update-docs/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -90,13 +90,9 @@ generated VM config, Terraform HCL, or Packer template, verify against this list
   `i440fx` + `ovmf` causes boot failures. `q35` + `seabios` works but wastes q35 features.
 - [ ] VGA type matches use case: `serial0` for headless cloud images, `virtio` for GUI VMs,
   omit for PCI passthrough display GPUs (`x-vga=1` replaces the virtual display)
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **Hypervisor/version checked**: Proxmox, QEMU/KVM, libvirt, XCP-ng, vSphere, and cloud-init advice matches the target platform
 - [ ] **Storage risk gated**: disk format, snapshot, passthrough, and migration commands preserve data and rollback
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 

--- a/skills/virtualization/references/agent-hygiene.md
+++ b/skills/virtualization/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files

--- a/skills/zero-day/SKILL.md
+++ b/skills/zero-day/SKILL.md
@@ -60,12 +60,8 @@ Before reporting any vulnerability or generating exploit code, verify:
 - [ ] **Disclosure plan**: findings destined for responsible disclosure, not public dump
 - [ ] **Evidence preserved**: all analysis steps documented for reproducibility
 - [ ] **Complexity honest**: if exploitation requires unlikely conditions (specific config, race window, chained bugs), state that clearly - don't inflate impact
-- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
-- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
-- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
-- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
-- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files
 - [ ] **PoC safety reviewed**: proof code demonstrates impact without avoidable persistence, exfiltration, or wormable behavior, and stays within the authorized disclosure scope
+- [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ## Performance
 

--- a/skills/zero-day/references/agent-hygiene.md
+++ b/skills/zero-day/references/agent-hygiene.md
@@ -1,0 +1,11 @@
+# Agent Hygiene
+
+Cross-cutting discipline for any AI agent output, independent of what the skill's
+domain checks cover. These five items are not skill-specific self-checks - they
+are baseline agent hygiene, checked once here instead of duplicated per skill.
+
+- [ ] **Current source checked**: dated versions, CLI flags, API names, and support windows are verified against primary docs before repeating them
+- [ ] **Hidden state identified**: local config, credentials, caches, contexts, branches, cluster targets, or previous runs are made explicit before acting
+- [ ] **Verification is real**: final checks exercise the actual runtime, parser, service, or integration point instead of only linting prose or happy paths
+- [ ] **Routing overlap checked**: overlapping skills, trigger terms, and "When NOT to use" boundaries are checked before returning guidance
+- [ ] **Spec claims verified**: claims about tool behavior, output contracts, or repo conventions are checked against current docs, scripts, or skill files


### PR DESCRIPTION
## What

Across the 47 skills there were 937 `AI Self-Check` items. 220 of them were the same five lines pasted into nearly every skill — bulk-injected by an automated scoring pass that rewards per-skill thoroughness with no collection-level redundancy penalty. The cheapest way to satisfy that metric collection-wide is duplication.

The cost is signal dilution. `kubernetes` asked an agent writing a Deployment manifest to verify "Routing overlap checked" and "Spec claims verified" — meaningless there — sitting directly beneath the items that carry real value. Every generic item read is attention not spent on a real one.

Two skills already had zero generic items and are among the strongest in the collection.

## How

- `skills/_shared/agent-hygiene.md` holds the five items once.
- `gen-contract-refs.sh` / `check-contract-sync.sh` / `contract-lib.sh` generalized from a single hardcoded target to a `SHARED_FILE_NAMES` list, so the hygiene file ships into every skill's `references/` the same way the output contract does. Standalone installs stay self-contained.
- 201 canonical items removed across 42 skills, each replaced by one pointer line.
- `lint-skills.sh` gains a rule capping generic content at 10% of a skill's self-check section, so the block cannot creep back.

## Matching on full text, not the bold label

The rule and the removal both key on the **complete canonical item text**. An item reusing a label like "Routing overlap checked" with its own hand-written body is authored content, not injected filler.

This distinction is load-bearing: 11 items across five skills carried the generic labels with skill-specific bodies — e.g. `synology-dsm`'s "checks exercise the actual mount, service, or filesystem rather than reading a DSM banner". Label matching deleted them; they are restored here and the rule was corrected so they stay. `deep-grill` had no canonical boilerplate at all and is untouched.

`skill-refiner` and `skill-creator` are exempt by name — routing overlap and spec-claim verification are genuinely their domain.

## Verification

- byte-level diff of every skill's self-check section against `43a46b7`: exactly 201 canonical removals, 42 pointer lines, zero non-canonical removals, zero orphaned continuation lines
- `lint-skills.sh`, `validate-spec.sh` -> `PASSED`, 0 errors, 0 warnings
- `check-contract-sync.sh` -> `Contract sync OK`; regenerating produces no diff
- `test-lint-skills.sh` -> 7 cases, including one asserting that generic labels with custom bodies are *not* flagged
- `shellcheck install.sh scripts/*.sh` -> exit 0
- rule probed by re-injecting canonical items into a skill: errors at `15% generic boilerplate (2/13 items)`

Also drops `CONTRACT_SRC` and `render_shipped_contract()`, which had no callers left after the generalization.

## Follow-ups

`## Performance` (44 skills) and `## Best Practices` (43 skills) show the same homogenization signature — same method, matching on full text from the start. The upstream scorer is the root cause; until it penalizes collection-level redundancy, the lint rule is what stops regrowth.

No release; several more changes land before the next version is cut.
