### PR TITLE
docs(skills): fix first body paragraph as marketplace storefront copy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Check version receipts
         run: ./scripts/check-version-receipts.sh
 
+      - name: Check first-paragraph storefront copy
+        run: ./scripts/check-first-paragraph.sh
+
       - name: Check deep-audit skill coverage
         run: ./scripts/check-deep-audit-coverage.sh
 

--- a/docs/skill-authoring.md
+++ b/docs/skill-authoring.md
@@ -1,0 +1,76 @@
+# Skill authoring: the first body paragraph is storefront copy
+
+This collection is published at `https://skills.sh/iuliandita/skills`. On a
+skill's page there, the rendered summary comes from the **first paragraph of
+the SKILL.md body** - not from the YAML `description` frontmatter. That
+paragraph is the only copy a stranger reads before deciding whether to
+install.
+
+## Constraints
+
+The first paragraph after the `# Title: Subtitle` H1 must:
+
+- be a single paragraph, 110-350 characters
+- not start with a bold block (`**...**`) - version tables, warnings, and
+  other bold-led content go below it, never above it
+- not contain a version number (`\d+\.\d+\.\d+`)
+- not end in a colon (a truncated preview of an unfinished sentence reads as
+  broken copy, even when the colon correctly introduces a bullet list below)
+
+`scripts/check-first-paragraph.sh` enforces these mechanically and runs in CI.
+
+## Exemplar
+
+`skills/code-review/SKILL.md`:
+
+```markdown
+# Code Review: Deep Correctness Audit
+
+Find bugs that actually break things. Not style, not slop - correctness, reliability, and logic errors that will bite in production.
+```
+
+One sentence. Says what it does, who it is for, what it is not. 132
+characters.
+
+## Fixing a paragraph that fails the check
+
+`scripts/check-first-paragraph.sh` is a proxy for the goal, not the goal
+itself. Passing its character window by prepending a sentence that restates
+the paragraph right below it makes the page worse, not better - a reader
+hits the same claim twice. Apply these moves in order, and stop at the first
+one that works:
+
+1. **Split at a sentence boundary.** If the paragraph is too long but its
+   existing first sentence already summarizes the skill, break the paragraph
+   after that sentence: paragraph one is the existing sentence, the rest
+   becomes paragraph two. Zero new words. If paragraph one then lands under
+   110 characters, pull the next existing sentence up instead of writing new
+   copy. This is the correct fix for most TOO-LONG cases -
+   `debian-ubuntu`, `handoff`, `nixos-btw`, `rhel-fedora`, `routine-writer`,
+   and `observability` are all plain sentence-boundary splits.
+2. **Reorder.** If a bold block (version pins, warnings) sits above the
+   prose, move the prose above it without editing either block's content.
+   `localize` is this case. A variant applies when no split lands inside the
+   110-350 window: `kali-linux` moved an existing later sentence to open the
+   paragraph instead, again with no words added or removed.
+3. **Write new copy - last resort.** Only when the paragraph is genuinely
+   too short or ends in a colon with nothing reusable above it. The new
+   sentence must state something the paragraph below it does not, must name
+   its subject rather than opening with an unbound pronoun like "it", and
+   must avoid the `X rather than Y` / `instead of` contrast construction -
+   a documented AI tell that `skills/anti-ai-prose/SKILL.md` audits for.
+   Allow at most one contrast construction across the whole collection's
+   leads; prefer none.
+
+Rewriting existing prose outright is not one of these moves. If none of the
+three apply, treat that as a judgment call worth flagging to a reviewer, not
+something to default into.
+
+## Not the same thing as the frontmatter `description`
+
+The YAML `description` field serves a different job: agent trigger matching,
+governed by the middle-dot prefix rule in `scripts/lint-skills.sh`. It is
+read by agents deciding whether to invoke a skill, not by humans browsing
+skills.sh.
+Fixing the first body paragraph never means editing `description`, and vice
+versa.

--- a/scripts/check-first-paragraph.sh
+++ b/scripts/check-first-paragraph.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+set +e
+output="$(python3 - "$ROOT" <<'PY'
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+flagged = 0
+for p in sorted((root / "skills").glob("*/SKILL.md")):
+    body = p.read_text().split("---", 2)[2]
+    m = re.search(r"^# .+?\n+(.+?)(?:\n\n|\n\*\*)", body, re.S | re.M)
+    para = " ".join(m.group(1).split()) if m else "(none)"
+    flags = []
+    if para.startswith("**"):
+        flags.append("STARTS-WITH-BOLD-BLOCK")
+    if len(para) > 350:
+        flags.append("TOO-LONG")
+    if len(para) < 110:
+        flags.append("TOO-SHORT")
+    if para.rstrip().endswith(":"):
+        flags.append("ENDS-IN-COLON")
+    if re.search(r"\d+\.\d+\.\d+", para):
+        flags.append("CONTAINS-VERSION")
+    if flags:
+        flagged += 1
+        print(f"{p.parent.name} {len(para)} {','.join(flags)}")
+        print(f"    {para[:160]}")
+
+sys.exit(1 if flagged else 0)
+PY
+)"
+status=$?
+set -e
+
+if [[ -n "$output" ]]; then
+  printf '[!] first-paragraph check failed for the following skills:\n' >&2
+  printf '%s\n' "$output" >&2
+fi
+
+if (( status != 0 )); then
+  exit 1
+fi
+
+printf 'All skill first paragraphs pass the storefront-copy check.\n'

--- a/skills/debian-ubuntu/SKILL.md
+++ b/skills/debian-ubuntu/SKILL.md
@@ -15,9 +15,11 @@ metadata:
 
 Administer Debian, Ubuntu, Linux Mint, Pop!_OS, Devuan, and other Debian-derived systems,
 with partial coverage for Kali when the question is about base OS administration rather than
-security-distro workflow. Focus on Debian stable and Ubuntu LTS first, then layer in
-derivative-specific behavior, PPA workflows, snap confinement, Ubuntu HWE, and explicit checks
-for derivatives that diverge on init, packaging defaults, or intended use.
+security-distro workflow.
+
+Focus on Debian stable and Ubuntu LTS first, then layer in derivative-specific behavior, PPA
+workflows, snap confinement, Ubuntu HWE, and explicit checks for derivatives that diverge on
+init, packaging defaults, or intended use.
 
 **Versions worth pinning** (verified July 2026):
 

--- a/skills/deep-grill/SKILL.md
+++ b/skills/deep-grill/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # Deep Grill: Two-Phase Plan Interrogator
 
+Deep-grill ends with a written decision record, so a resolved requirement stays settled instead of getting relitigated in a later session.
+
 Most build failures are not the model failing to write code - they are requirements that were
 never specified. Deep-grill kills that failure before anything exists, in two phases:
 

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # Dev Cycle: Start-to-Finish Workflow
 
+Dev Cycle gets invoked once to start a task and again later to ship it, keeping git, testing, and review calls out of a single freeform session.
+
 Orchestrates a unit of work from branch creation to merge and release. Runs in
 two modes that typically span different sessions:
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -17,8 +17,10 @@ metadata:
 
 Compress the current session into a small markdown document another agent session can continue
 from. A handoff is a one-way, lossy carry: whatever the next session needs has to be written
-down explicitly, because everything else is gone. The point is to keep each session focused and
-inside its high-attention context window instead of dragging one bloated thread forward.
+down explicitly, because everything else is gone.
+
+The point is to keep each session focused and inside its high-attention context window
+instead of dragging one bloated thread forward.
 
 Inspired by Matt Pocock's `/handoff` skill. The failure mode it exists to prevent is
 **relitigation**: the next session reopens a decision the current one had already settled,

--- a/skills/jekyll-hyde/SKILL.md
+++ b/skills/jekyll-hyde/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # Jekyll-Hyde: Dual-Lens Decision Advisor
 
+Jekyll-Hyde applies to any decision before it ships, from a one-line copy change to a company-wide policy call, letting both advisors weigh in before either one wins.
+
 Review product, engineering, design, and business decisions through two opposing advisor modes:
 
 - **Dr Jekyll** turns ambition into durable usefulness, trust, changeability, and clear next steps.

--- a/skills/kali-linux/SKILL.md
+++ b/skills/kali-linux/SKILL.md
@@ -13,13 +13,14 @@ metadata:
 
 # Kali Linux: Kali Administration, Tooling, and Lab Workflow
 
+Kali is Debian-shaped, but the places where it goes wrong are usually Kali-specific: branch
+mixing, metapackage sprawl, stale images, persistence mistakes, hardware edge cases, or people
+using the wrong tool family for the job.
+
 Administer Kali Linux without flattening it into plain Debian or into a bag of offensive tools.
 Start by identifying which Kali lane you are actually on - rolling install, last-snapshot,
 live USB, VM image, Purple image, NetHunter, or a throwaway lab box - then separate base OS
 health from tool-selection questions, branch hygiene, hardware support, and engagement scope.
-Kali is Debian-shaped, but the places where it goes wrong are usually Kali-specific: branch
-mixing, metapackage sprawl, stale images, persistence mistakes, hardware edge cases, or people
-using the wrong tool family for the job.
 
 **Target versions** (verified July 2026):
 

--- a/skills/localize/SKILL.md
+++ b/skills/localize/SKILL.md
@@ -13,15 +13,16 @@ metadata:
 
 # Localize: App Internationalization Workflow
 
+Systematic approach to internationalizing applications. Covers two scenarios: adding
+multilingual support from scratch and auditing existing i18n for gaps.
+
+Built from real production pain - the hardest part of i18n is not translation but finding
+every string that needs it, and making sure translations read naturally in context rather
+than as mechanical word-by-word output.
+
 **Target versions (July 2026):** react-i18next 17.0.10, vue-i18n 11.4.7, next-intl 4.13.3,
 i18next 26.3.6. For missing-key persistence, require i18next-http-middleware 3.9.7+ and
 i18next-fs-backend 2.6.6+ to fix critical prototype pollution (CVE-2026-48714).
-
-Systematic approach to internationalizing applications. Covers two scenarios: adding
-multilingual support from scratch and auditing existing i18n for gaps. Built from real
-production pain - the hardest part of i18n is not translation but finding every string
-that needs it, and making sure translations read naturally in context rather than as
-mechanical word-by-word output.
 
 ## When to use
 

--- a/skills/nixos-btw/SKILL.md
+++ b/skills/nixos-btw/SKILL.md
@@ -16,9 +16,11 @@ metadata:
 Administer NixOS without falling back into imperative distro muscle memory. NixOS is
 declarative, functional, and atomic: the system is a value computed from a configuration,
 every change becomes a new immutable generation in `/nix/store`, and rollbacks are a
-bootloader entry away. This skill keeps that model intact, then layers in the practical
-stack: channels vs flakes, `nixos-rebuild` vs `nix` CLI, home-manager, nix-darwin, store
-hygiene, overlays, module writing, secrets, and the Determinate Nix and Lix lanes.
+bootloader entry away.
+
+This skill keeps that model intact, then layers in the practical stack: channels vs
+flakes, `nixos-rebuild` vs `nix` CLI, home-manager, nix-darwin, store hygiene, overlays,
+module writing, secrets, and the Determinate Nix and Lix lanes.
 
 The places NixOS breaks are NixOS-shaped: channel drift, flake input staleness, garbage
 collection that nukes a needed derivation, overlays fighting, `nix-env -i` poisoning the

--- a/skills/observability/SKILL.md
+++ b/skills/observability/SKILL.md
@@ -18,8 +18,10 @@ metadata:
 Design and audit the signals a running system emits so failures are visible before users report
 them. This skill builds the standing pipeline - instrumentation, metrics, traces, structured
 logs, alert rules, SLOs, and dashboards-as-code - and audits a repo for the gaps that leave a
-service blind. It produces config (exporters, recording/alerting rules, OTLP pipelines,
-dashboard JSON), so the AI Self-Check applies.
+service blind.
+
+It produces config (exporters, recording/alerting rules, OTLP pipelines, dashboard JSON), so
+the AI Self-Check applies.
 
 **Target versions**: see `references/versions.md` (verified per the receipt date
 in that file). Do not restate version numbers here.

--- a/skills/rhel-fedora/SKILL.md
+++ b/skills/rhel-fedora/SKILL.md
@@ -14,10 +14,12 @@ metadata:
 # RHEL-Fedora: Fedora and RHEL-Family Administration
 
 Administer Fedora, RHEL, Rocky Linux, AlmaLinux, Oracle Linux, Amazon Linux, and nearby
-RPM-family systems without flattening their important differences. Start by separating the
-fast-moving Fedora lane from the conservative enterprise lane, then account for vendor quirks
-such as subscription-manager, CentOS Stream drift, Oracle UEK, Amazon's cloud-first defaults,
-and SELinux or firewalld behavior that people love to blame on the wrong layer.
+RPM-family systems without flattening their important differences.
+
+Start by separating the fast-moving Fedora lane from the conservative enterprise lane, then
+account for vendor quirks such as subscription-manager, CentOS Stream drift, Oracle UEK,
+Amazon's cloud-first defaults, and SELinux or firewalld behavior that people love to blame on
+the wrong layer.
 
 **Versions worth pinning** (verified July 2026):
 

--- a/skills/routine-writer/SKILL.md
+++ b/skills/routine-writer/SKILL.md
@@ -13,7 +13,9 @@ metadata:
 
 # Routine Writer
 
-Turn an unattended, repeatable task into a Claude Code routine: a saved prompt plus repositories, connectors, and triggers that runs on Anthropic cloud infrastructure without needing a local machine. Output is a self-contained prompt plus the artifacts to wire it up (a `/schedule` CLI command when available, a `curl` template for the `/fire` endpoint, or a web-UI walkthrough).
+Turn an unattended, repeatable task into a Claude Code routine: a saved prompt plus repositories, connectors, and triggers that runs on Anthropic cloud infrastructure without needing a local machine.
+
+Output is a self-contained prompt plus the artifacts to wire it up (a `/schedule` CLI command when available, a `curl` template for the `/fire` endpoint, or a web-UI walkthrough).
 
 **Why routines differ from chat prompts.** A routine runs as a full autonomous Claude Code cloud session. There is no permission-mode picker, no approval prompts, and no human to answer clarifying questions mid-run. A prompt that works fine in a conversation can stall or misfire silently inside a routine because the model has no one to ask. Every routine prompt must be self-contained, state its success criteria, and declare where output goes.
 


### PR DESCRIPTION
## What

skills.sh renders the **first paragraph of the SKILL.md body** as a skill's public
summary, not the YAML `description` frontmatter. Eleven skills had a first paragraph
that was unusable as that summary: too long, too short, colon-terminated, or led by a
bold version block.

Worst case was `localize`, whose page opened with a version list and a CVE number.

## How

Eight of the eleven were fixed without writing a single new word:

- **Sentence-boundary splits** (zero new words): `debian-ubuntu`, `handoff`,
  `nixos-btw`, `rhel-fedora`, `routine-writer`, `observability`
- **Reorder** (prose above the bold version block, content untouched): `localize`;
  `kali-linux` moves an existing later sentence up, since no split fits the
  110-350 window
- **New copy** (genuinely too short or colon-terminated): `deep-grill`, `dev-cycle`,
  `jekyll-hyde`

`localize` and `kali-linux` were verified as pure reorders by sorted word-multiset
comparison against `main` - every version pin and CVE-2026-48714 survives byte-for-byte.
No YAML `description` field was touched.

## Guardrail

`scripts/check-first-paragraph.sh` enforces the constraints (single paragraph,
110-350 chars, no leading bold block, no version number, no trailing colon) and runs
in the `collection` job of the lint workflow, so new skills cannot regress it.

`docs/skill-authoring.md` documents the rule and the fix priority: split, then
reorder, then new copy as a last resort. It warns that the script is a proxy for the
goal - passing the character window by prepending a sentence that restates the
paragraph below it makes the page worse.

## Verification

- `./scripts/check-first-paragraph.sh` - exit 0, zero flagged
- `./scripts/lint-skills.sh` - PASSED, 47 skills, 0 errors, 0 warnings
- `./scripts/validate-spec.sh` - PASSED
- `./scripts/check-freshness-dates.sh` - exit 0
- `shellcheck scripts/check-first-paragraph.sh` - exit 0
- `markdownlint-cli2` - 0 errors
- No frontmatter `description` lines changed
