### PR TITLE
feat(anti-ai-prose): add inline mode and fold in unslop rules

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -15,5 +15,7 @@ exclude = [
   "^https?://internal\\.example\\.com",
   "^https?://claude\\.ai",
   "^https://git\\.lix\\.systems/",
+  # Serves the anti-ai-prose Elara citation; reachable in a browser, times out from CI runners.
+  "^https://namerology\\.com/",
   "^https://github\\.com/iuliandita/skills/compare/v[0-9]+\\.[0-9]+\\.[0-9]+\\.\\.\\.v[0-9]+\\.[0-9]+\\.[0-9]+$"
 ]

--- a/skills/.refiner-runs.json
+++ b/skills/.refiner-runs.json
@@ -341,11 +341,15 @@
     },
     "scoring_note": "Model changed since the prior run (opus-4-8 -> opus-5), so this is a new baseline, not a comparable delta. Baseline was taken after the unslop merge landed. A = fresh-context skill-creator Mode 2 review (checklist pass rate). B = 6 behavioral runs as fresh-context subagents on hand-written test cases plus 2 harder generated ones (docstring scope, 520-word mixed doc). X = codex round-4 residual flag count, not re-measured after the final fix round; it is the most conservative component and is labeled an estimate. Composite uses gate/A40/B55/X5.",
     "changes": "iter1 (skill-creator Mode 2): SKILL.md 588 -> 496 lines via vocabulary regrouping and two reference extractions, clearing the repo's only lint warning; inline-mode scope corrected; dead cross-collection pointer removed. iter2: P0/info defined for prose; audit-mode template reconciled with the output contract; density scope reconciled across files; self-check rescoped to both modes. iter3: single authoritative gated/not-gated density list; worked-example taxonomy and counts fixed; docstring-vs-code scope disambiguated; short-text rule vs formatting-nit cap resolved. iter4: findings numbered in priority order for deliverable monotonicity; '+1' removed from generator residue (false positive); counter-example term-of-art overclaim corrected; '(or cut)' convention applied consistently.",
-    "deferred": [
-      "skills/_shared/output-contract.md uses em dashes and Unicode arrows in prose; generated verbatim into all skills, so it is a collection-wide decision, not an anti-ai-prose defect. Notable because this skill's job is flagging em dashes.",
-      "skill-refiner/references/test-cases.md anti-ai-prose expected signals omit 'robust' from the vocabulary cluster and expect 'serves as' inside it rather than as a separate copula finding. Left unedited on purpose: changing evaluation fixtures mid-run to match the artifact would invalidate the scoring. Phase-2 item.",
-      "fiction-tells.md carries three high-specificity external statistics that could not be verified offline this run."
-    ],
-    "phase2": "not run - single-skill scope, no meta-improvement to skill-creator or skill-refiner"
+    "deferred": [],
+    "phase2": "not run - single-skill scope, no meta-improvement to skill-creator or skill-refiner",
+    "deferred_resolved": {
+      "date": "2026-08-19",
+      "items": [
+        "_shared/output-contract.md converted to ASCII (em dashes, en dash, Unicode arrows, ellipsis) in both prose and the emitted heading spec; this aligns it with README.md, which already documented the ASCII form. Regenerated into all 47 skills; box art still exactly 80 columns. Collection-wide non-ASCII sweep now returns zero.",
+        "skill-refiner/references/test-cases.md anti-ai-prose Test 1 corrected: added the missing 'robust' and 'commitment to' to the vocabulary cluster, stated it should be one clustered finding rather than ten, and added a priority-order numbering signal. Edited post-run, not mid-run.",
+        "fiction-tells.md statistics verified against primary sources with web access. Namerology/Elara confirmed exactly. Laforge confirmed (Kaggle sci-fi dataset ~10,000 books; 'Dr Thorne' in 26 book descriptions, 204 appearances) - wording corrected from '26 books' to '26 book descriptions'. ChuckMcSneed claim was WRONG and is now fixed: it compared 77% of top-10 names against 4% of top pick, and omitted base Qwen2.5 at 28%. All three sources now carry URLs and a verification date."
+      ]
+    }
   }
 ]

--- a/skills/.refiner-runs.json
+++ b/skills/.refiner-runs.json
@@ -225,24 +225,127 @@
     "spec_status": "PASSED 0/0"
   },
   {
-  "run_id": "2026-06-25-antiaiprose",
-  "branch": "skill-creator/2026-06-25-antiaiprose",
-  "date": "2026-06-25",
-  "primary": {"harness": "claude-code", "model": "claude-opus-4-8", "effort": "high"},
-  "secondary": {"harness": "none", "note": "same-model fresh-context review (subagents), weighted 3%"},
-  "config": {"iterations": 4, "threshold": 99, "mode": "single-skill", "plateau": 2},
-  "pool_size": 1,
-  "pool": ["anti-ai-prose"],
-  "excluded": ["skill-creator", "skill-refiner"],
-  "terminated": "target-reached",
-  "iterations_completed": 4,
-  "cross_model_flags": {"minor": 1, "major": 0, "contested": 0, "note": "minor verified+fixed in iter2"},
-  "scores": {
-   "before": {"anti-ai-prose": {"G": "pass", "A": 96, "B": 97, "X": 100, "composite": 96.7}},
-   "after": {"anti-ai-prose": {"G": "pass", "A": 99, "B": 99.5, "X": 100, "composite": 99.3}}
+    "run_id": "2026-06-25-antiaiprose",
+    "branch": "skill-creator/2026-06-25-antiaiprose",
+    "date": "2026-06-25",
+    "primary": {
+      "harness": "claude-code",
+      "model": "claude-opus-4-8",
+      "effort": "high"
+    },
+    "secondary": {
+      "harness": "none",
+      "note": "same-model fresh-context review (subagents), weighted 3%"
+    },
+    "config": {
+      "iterations": 4,
+      "threshold": 99,
+      "mode": "single-skill",
+      "plateau": 2
+    },
+    "pool_size": 1,
+    "pool": [
+      "anti-ai-prose"
+    ],
+    "excluded": [
+      "skill-creator",
+      "skill-refiner"
+    ],
+    "terminated": "target-reached",
+    "iterations_completed": 4,
+    "cross_model_flags": {
+      "minor": 1,
+      "major": 0,
+      "contested": 0,
+      "note": "minor verified+fixed in iter2"
+    },
+    "scores": {
+      "before": {
+        "anti-ai-prose": {
+          "G": "pass",
+          "A": 96,
+          "B": 97,
+          "X": 100,
+          "composite": 96.7
+        }
+      },
+      "after": {
+        "anti-ai-prose": {
+          "G": "pass",
+          "A": 99,
+          "B": 99.5,
+          "X": 100,
+          "composite": 99.3
+        }
+      }
+    },
+    "scoring_note": "Targeted manual rubric (A42/B58 renormalized, fresh self-review X at 3%); behavioral run as fresh-context subagents on hand-written + 2 generated tests. Labeled estimates, not full automated sweep.",
+    "changes": "iter2: precise stop-slop attribution + count-once cross-ref (fixes README double-flag 13>11). iter3: broaden faux-profundity Detect to fragment family. iter4: reconcile confident-filler exception with short-text density rule (fixes false P1 on earned rhetorical question).",
+    "phase2": "not entered (single-skill scope; meta-improvement requires explicit human approval)"
   },
-  "scoring_note": "Targeted manual rubric (A42/B58 renormalized, fresh self-review X at 3%); behavioral run as fresh-context subagents on hand-written + 2 generated tests. Labeled estimates, not full automated sweep.",
-  "changes": "iter2: precise stop-slop attribution + count-once cross-ref (fixes README double-flag 13>11). iter3: broaden faux-profundity Detect to fragment family. iter4: reconcile confident-filler exception with short-text density rule (fixes false P1 on earned rhetorical question).",
-  "phase2": "not entered (single-skill scope; meta-improvement requires explicit human approval)"
- }
+  {
+    "run_id": "2026-08-19-antiaiprose-postmerge",
+    "branch": "feat/anti-ai-prose-unslop-merge",
+    "date": "2026-08-19",
+    "primary": {
+      "harness": "claude-code",
+      "model": "claude-opus-5[1m]",
+      "effort": "high"
+    },
+    "secondary": {
+      "harness": "codex",
+      "model": "codex-exec",
+      "note": "true cross-model peer review, 4 rounds, weighted 5%"
+    },
+    "config": {
+      "iterations": 4,
+      "threshold": 99,
+      "mode": "single-skill",
+      "plateau": 2
+    },
+    "pool_size": 1,
+    "pool": [
+      "anti-ai-prose"
+    ],
+    "excluded": [
+      "skill-creator",
+      "skill-refiner"
+    ],
+    "terminated": "plateau",
+    "iterations_completed": 4,
+    "cross_model_flags": {
+      "major": 8,
+      "minor": 10,
+      "contested": 0,
+      "note": "all verified real and fixed across rounds 2-4; zero contested. Round-4 majors were the last substantive set."
+    },
+    "scores": {
+      "before": {
+        "anti-ai-prose": {
+          "G": "pass-with-warning",
+          "A": 77.8,
+          "B": 98.0,
+          "X": 40,
+          "composite": 87.0
+        }
+      },
+      "after": {
+        "anti-ai-prose": {
+          "G": "pass",
+          "A": 94.7,
+          "B": 99.6,
+          "X": 70,
+          "composite": 96.0
+        }
+      }
+    },
+    "scoring_note": "Model changed since the prior run (opus-4-8 -> opus-5), so this is a new baseline, not a comparable delta. Baseline was taken after the unslop merge landed. A = fresh-context skill-creator Mode 2 review (checklist pass rate). B = 6 behavioral runs as fresh-context subagents on hand-written test cases plus 2 harder generated ones (docstring scope, 520-word mixed doc). X = codex round-4 residual flag count, not re-measured after the final fix round; it is the most conservative component and is labeled an estimate. Composite uses gate/A40/B55/X5.",
+    "changes": "iter1 (skill-creator Mode 2): SKILL.md 588 -> 496 lines via vocabulary regrouping and two reference extractions, clearing the repo's only lint warning; inline-mode scope corrected; dead cross-collection pointer removed. iter2: P0/info defined for prose; audit-mode template reconciled with the output contract; density scope reconciled across files; self-check rescoped to both modes. iter3: single authoritative gated/not-gated density list; worked-example taxonomy and counts fixed; docstring-vs-code scope disambiguated; short-text rule vs formatting-nit cap resolved. iter4: findings numbered in priority order for deliverable monotonicity; '+1' removed from generator residue (false positive); counter-example term-of-art overclaim corrected; '(or cut)' convention applied consistently.",
+    "deferred": [
+      "skills/_shared/output-contract.md uses em dashes and Unicode arrows in prose; generated verbatim into all skills, so it is a collection-wide decision, not an anti-ai-prose defect. Notable because this skill's job is flagging em dashes.",
+      "skill-refiner/references/test-cases.md anti-ai-prose expected signals omit 'robust' from the vocabulary cluster and expect 'serves as' inside it rather than as a separate copula finding. Left unedited on purpose: changing evaluation fixtures mid-run to match the artifact would invalidate the scoring. Phase-2 item.",
+      "fiction-tells.md carries three high-specificity external statistics that could not be verified offline this run."
+    ],
+    "phase2": "not run - single-skill scope, no meta-improvement to skill-creator or skill-refiner"
+  }
 ]

--- a/skills/_shared/output-contract.md
+++ b/skills/_shared/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/_shared/output-contract.md
+++ b/skills/_shared/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,14 +213,14 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.
 
 <!-- maintainer-notes:not-shipped
 Everything above this marker is the portable output contract. It is the single source

--- a/skills/ai-ml/references/output-contract.md
+++ b/skills/ai-ml/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/ai-ml/references/output-contract.md
+++ b/skills/ai-ml/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/ansible/references/output-contract.md
+++ b/skills/ansible/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/ansible/references/output-contract.md
+++ b/skills/ansible/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: anti-ai-prose
 description: >
-  · Audit prose for AI tells in docs, PRs, emails, slides, docstrings. Triggers: 'ai writing', 'sounds like chatgpt', 'ai slop prose', 'llm voice', 'sound human'. Not for code (use anti-slop).
+  · Strip AI tells from prose in docs, PRs, emails, and your own replies. Apply to every response by default; full audit on request. Triggers: 'unslop', 'ai writing', 'sounds like chatgpt', 'llm voice'. Not for code (use anti-slop).
 license: MIT
 compatibility: "None - works on any prose or text input"
 metadata:
@@ -17,7 +17,7 @@ Detect and fix the linguistic tells that make written English read as machine-ge
 
 This skill applies to any text: **documentation**, **READMEs**, **wikis** (Confluence, Notion, internal), **pull request descriptions**, **commit messages**, **release notes**, **blog posts**, **emails**, **slide copy**, **creative writing**, and **code comments / docstrings**. The vocabulary, syntax, tone, and formatting checks are language-domain, not platform-domain.
 
-Based in part on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) - a field guide compiled by editors who have read enormous volumes of LLM-generated text and know what it actually looks like - and on [stop-slop](https://github.com/hardikpandya/stop-slop) (MIT), which contributed the confident-filler check: emphasis crutches, rhetorical setups, and the faux-profundity fragment.
+Based in part on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) - a field guide compiled by editors who have read enormous volumes of LLM-generated text and know what it actually looks like - on [stop-slop](https://github.com/hardikpandya/stop-slop) (MIT), which contributed the confident-filler check: emphasis crutches, rhetorical setups, and the faux-profundity fragment - and on [poteto/plugins](https://github.com/poteto/plugins) `pstack/skills/unslop` (MIT), which contributed the plain-speech checks, the abstract-metaphor-noun list, chat artifacts, and the voice-restoration guidance.
 
 ## When to use
 
@@ -28,6 +28,7 @@ Based in part on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/
 - Reviewing docstrings and code comments for the same prose patterns
 - Any time someone says "this sounds like ChatGPT wrote it"
 - Self-check after a heavy LLM-drafting session
+- Filtering your own replies, explanations, and drafts as you write them (inline mode, see below)
 
 ## When NOT to use
 
@@ -37,6 +38,44 @@ Based in part on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/
 - Correctness bugs, logic errors, edge cases - use **code-review**
 - Security review of auth, secrets, or attack surface - use **security-audit**
 - Full multi-dimensional repo audit - use **full-review**
+
+---
+
+## Two modes
+
+This skill runs in one of two modes. Pick the mode from the trigger, not from the content.
+
+### Inline mode (default, always on)
+
+Applies to your own conversational output: chat replies, explanations, summaries, commit bodies,
+PR descriptions, and any prose you draft for the user. Runs on every response without being asked.
+
+- Apply the pattern rules silently while writing. This filters drafting, it does not review a
+  finished draft.
+- Emit **no report, no findings, no severity ratings, no deliverable file**, and no note that the
+  skill ran.
+- Do not restructure the user's own words when quoting them back.
+- Density thresholds do not apply. Fix every tell you catch in your own output.
+- Ask before sending: "what in this reply reads as machine generated?" Fix what that surfaces.
+
+### Audit mode (explicit)
+
+Applies to text the user hands over: a file, a paste, a diff, a directory. Triggered by an
+explicit request ("audit this", "does this sound like AI", "unslop this doc") or by invoking the
+skill against a target. Run the full Workflow below, emit the full output contract, and apply the
+density thresholds so isolated instances in long documents are not flagged.
+
+### Precedence
+
+When rules conflict, later entries lose:
+
+1. The user's explicit instruction in this conversation
+2. Project instruction files (`CLAUDE.md`, `AGENTS.md`, repo style guide)
+3. Genre convention of the text being written (see "What NOT to Flag")
+4. This skill's pattern rules
+
+A house style that mandates em dashes, title-case headings, or a formal register is not a finding.
+Inline mode adapts to it rather than overriding it.
 
 ---
 
@@ -56,6 +95,11 @@ Before returning any audit, verify:
 - [ ] **AI fallback names checked (fiction)**: protagonist and major-character names compared against the documented fallback set (Elara, Lyra, Aurora, Kael, Vale, Cassius, etc.) and the phonetic tell (2 soft syllables, A/L/R/N consonants, no demographic anchor); fallback-set names allowed only when the setting and population organically produce them
 - [ ] **Adverb stacking checked**: `-ly` adverb density scanned; passages with multiple adverb-modified speech tags or adjacent adverb clusters flagged at the same density threshold as vocabulary tells
 - [ ] **Confident filler checked**: emphasis crutches, rhetorical setups, and faux-profundity fragments flagged by pattern/density, not on isolated earned uses
+- [ ] **Mode picked correctly**: inline mode emitted no report, no findings list, and no deliverable file; audit mode emitted the full contract. The two were not mixed in one response
+- [ ] **House style respected**: project instruction files and explicit user instructions took precedence over this skill's pattern rules; a mandated em dash or title-case convention was not reported as a finding
+- [ ] **Plain-speech checks run**: participle tails, false ranges, unnamed-actor passives, dense sentence stacking, and feeling-instead-of-mechanism scanned alongside the vocabulary tells
+- [ ] **Chat artifacts cleared**: no `Great question!`, `I hope this helps!`, `Certainly!`, or cutoff disclaimer survived into the output, in either mode
+- [ ] **Voice restored, not imposed**: rewrites carry a position, varied rhythm, and specifics; voice suggestions are marked `Consider`, never `Fix`
 - [ ] **Overflagging avoided**: plain but valid technical prose is not labeled AI-written without concrete evidence
 - [ ] **Audience preserved**: edits keep the author's domain vocabulary, intent, and required formality
 - [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
@@ -78,68 +122,21 @@ Before returning any audit, verify:
 
 ## Workflow
 
-### Step 1: Scope the audit
+Audit mode only. Full detail in `references/audit-mode.md`: scoping rules, the text-kind table,
+the density heuristic, the action and severity scales, and the report template with a worked
+example.
 
-Default scope based on context:
-- If invoked on a specific file or paste - audit that text
-- If invoked with no target and there are uncommitted changes to `.md` / `.txt` / doc files - audit those
-- If invoked in a code repo with recent commits - audit the docstrings and comments in changed files
-- Otherwise - ask the user for a target
-
-Available scopes:
-- **Single file** - one doc, README, draft, or source file
-- **Directory** - all `.md` / `.rst` / `.txt` under a path
-- **Pasted text** - inline block the user supplies
-- **Recent changes** - git diff against a base
-- **Comments and docstrings only** - scan code files but audit only prose regions
-
-### Step 2: Detect text kind
-
-Different text types have different conventions. Before flagging, identify which applies:
-- **Technical docs** - formal is OK, but vocabulary bans still apply
-- **README / PR / commit** - concise is expected, significance padding is especially jarring
-- **Marketing / product copy** - tonal tells (`boast`, `showcase`) may be intentional but still weaken the writing
-- **Creative fiction** - many tells (tricolons, elegant variation) are legitimate devices; flag only when they read as mechanical
-- **Wiki article** - neutral voice required, promotional language is always a finding
-- **Email** - conversational is expected, formality inflation is a tell
-- **Slides / presentation** - fragments are fine, but vocabulary and tonal tells still apply
-
-### Step 3: Scan for patterns
-
-Apply the four categories (see below). For each match, read the surrounding context - a single instance of an AI word in a 5000-word document is probably noise, but three instances in three paragraphs is a pattern.
-
-**Density heuristic** (rough guide, not a hard rule):
-- **Under 1 flagged item per 500 words** - noise, usually do not flag
-- **2-3 per 500 words** - a pattern, flag the cluster as P2
-- **4+ per 500 words** - dominant voice, P1 severity, recommend structural rewrite
-
-**Short text scaling:** for text under 100 words, any 2+ tells in a single paragraph is P1 severity regardless of the per-500-words threshold. A single sentence crammed with AI vocabulary is worse than a long doc with scattered instances.
-
-Density only applies to vocabulary and syntax tells. A single travel-guide paragraph is enough to flag on its own. One fabricated citation is always P1.
-
-Classify each finding by category, action, and severity:
-
-**Action:**
-- **Fix** - clearly a tell, should change
-- **Consider** - judgment call, present it and let the user decide
-- **Fine** - matches the pattern but is justified (note why, move on)
-
-**Severity:**
-- **P1** - cluster of tells that makes the piece sound unmistakably AI-written; vague attribution passing opinion as fact; fabricated citations or broken references
-- **P2** - vocabulary or syntax tells that dull the voice without breaking trust; formulaic structures ("Despite its X, faces challenges..."); travel-guide voice in non-travel writing
-- **P3** - single instances of banned vocabulary; formatting nits (em-dash usage, unnecessary bold); tricolon overuse
-
-### Step 4: Report and fix
-
-Present findings grouped by category. For each Fix-level item, show the concrete rewrite. Rewrites should be **shorter** or **more specific** - never longer.
-
-**Plan first, apply that plan only.** Produce the audit report as the improvement plan before any
-rewrites are merged. If the user then asks for the fixes to be applied, change only what the plan
-flagged. Do not freelance edits outside the plan, do not "while we're here" rewrite adjacent
-prose, and do not chain a second pass of new fixes on top of the applied ones in the same step.
-This keeps the work auditable and prevents a cheap model from re-drafting the piece worse than
-the original. If new findings emerge while applying, surface them as a second audit, not as
-silent edits.
+1. **Scope.** Audit the file or paste given. With no target, fall back to uncommitted doc changes,
+   then to docstrings in changed files, then ask.
+2. **Detect text kind.** Technical docs, README/PR/commit, marketing, fiction, wiki, email, and
+   slides each carry conventions that change what counts as a tell.
+3. **Scan.** Apply the four categories below. Read surrounding context before flagging: one AI word
+   in 5000 words is noise, three in three paragraphs is a pattern. Density sets severity, and text
+   under 100 words with 2+ tells in a paragraph is P1 regardless.
+4. **Report and fix.** Group by category, show the concrete rewrite, keep every rewrite shorter or
+   more specific than the original. **Plan first, apply that plan only:** when the user asks for
+   fixes, change only what the report flagged. New findings during application become a second
+   audit, never silent edits.
 
 ---
 
@@ -186,6 +183,12 @@ Specific words that LLMs overuse far beyond their natural English frequency.
 | commence | start, begin |
 | journey toward | work toward, move toward, aim for (or drop) |
 | moving forward | from now on, next, going forward (or drop) |
+| additionally | also, and (or start the sentence with the content) |
+| enhance | improve, speed up, extend (or name the change) |
+| interplay | how X and Y interact (or drop) |
+| intricate | detailed, complex (or drop - usually padding) |
+| numerous | many |
+| ensure | make sure, guarantee (or name the mechanism) |
 
 **Detect:**
 - Multiple flagged words in the same paragraph
@@ -201,6 +204,19 @@ See "What NOT to Flag" below for domain exceptions (horticulture `landscape`, ch
 Generated fiction often converges on soft, no-baggage names such as `Elara`, `Kael`, or
 `Voss`. If a prose audit includes invented character names, read
 `references/fiction-name-tells.md` for the fallback-name pattern, exceptions, and fix guidance.
+
+#### Abstract metaphor nouns
+
+Nouns that read as technical but stand in for a plainer word: `substrate`, `wedge`, `vector`,
+`locus`, `vantage`, `nexus`, `primitive` (as noun), `harness` (as metaphor), `surface` (as in
+"API surface"), `bedrock`, `scaffolding` (as metaphor), `modality`, `paradigm`, `gold-plating`.
+
+**Detect:** the noun carries no measurement, no referent, and no consequence.
+
+**Fix:** name the concrete thing. `substrate` -> `base`, `wedge in` -> `add`, `vector` -> `way`.
+
+**Exception:** each is a term of art somewhere (`vector` in linear algebra, `locus` in
+genetics). Full table and per-term exceptions in `references/plain-speech.md`.
 
 ### 2. Syntax Tells (Noise + Soul)
 
@@ -263,6 +279,47 @@ LLMs avoid repeating a noun within a paragraph, substituting increasingly strain
 - Different technical terms for the same concept within one document
 
 **Fix:** Use the name, or a pronoun. Repetition is fine. Forced variation is worse than repetition.
+
+#### Superficial participle tails
+
+A sentence ending in a comma plus an `-ing` clause that restates what the sentence already
+said. Implies consequence without asserting one.
+
+**Detect:** `..., highlighting the need for X`, `..., ensuring reliability`, `..., reflecting
+a broader shift`, `..., showcasing the team's expertise`, `..., underscoring its importance`.
+Test: cut the clause. If nothing is lost, it was decoration.
+
+**Fix:** Delete the tail. If the consequence is real, promote it to its own sentence with a
+stated mechanism: `..., ensuring reliability` -> `Retries cover the transient failures.`
+
+#### False ranges
+
+`from X to Y` where X and Y do not sit on a shared scale, used to imply comprehensive coverage
+of what is really two examples.
+
+**Detect:** `everything from authentication to deployment`, `from startups to enterprises` with
+no middle named. Test for a meaningful midpoint: `from 10ms to 2s` is a real range, `from CI to
+observability` is not.
+
+**Fix:** List the items directly. `covers authentication and deployment`.
+
+#### Passive voice with an unnamed actor
+
+`is/are/was/were + past participle` that drops the actor: `queries are validated`, `errors are
+logged`. Ask who does it; if the answer is in the document but not the sentence, name it.
+
+**Fix:** Promote the actor to subject. `the compiler validates queries`.
+
+**Exception:** correct when the actor is unknown, irrelevant, or withheld on purpose (incident
+writeups, scientific method sections). See `references/plain-speech.md`.
+
+#### Dense sentence stacking
+
+Three or more clauses chained with commas, `and`, `which`, and `while`. Length is not the tell,
+backtracking is: flag sentences needing a second pass to locate the verb.
+
+**Fix:** Split at the clause boundary, or drop the clause carrying the least. One idea per
+sentence. Worked before/after in `references/plain-speech.md`.
 
 ### 3. Tonal Tells (Soul)
 
@@ -333,6 +390,7 @@ Phrases that wrap around the actual content without adding information. LLMs lea
 - `here's the thing:` / `the fact is:` / `the truth is:`
 - `at the end of the day` / `when all is said and done`
 - `as we've seen` / `as mentioned earlier` / `as previously discussed` (when the reader just read it)
+- Wordy connectives with a one-word equivalent: `in order to` -> `to`, `due to the fact that` -> `because`, `in the event that` -> `if`, `for the purpose of` -> `to`, `with regard to` -> `about`, `a large number of` -> `many`, `at this point in time` -> `now`
 
 **Fix:** Cut the wrapper and keep the content. `It's worth noting that X` becomes `X`. `In this article, we'll explore Y` becomes a first sentence that is about Y.
 
@@ -355,12 +413,51 @@ LLMs reach for a formula when asked to describe any organization or project: pos
 
 **Fix:** Reorganize around the actual story. If there is no story, the piece probably should not exist.
 
+#### Chat artifacts and sycophancy
+
+Assistant-voice residue that survives a copy-paste out of a chat window into a doc, PR, or
+email. Also the highest-value check in inline mode, where it applies to the reply itself.
+
+**Detect:** openers (`Great question!`, `Certainly!`, `You're absolutely right!`), closers
+(`I hope this helps!`, `Let me know if you have any questions`), progress theater (`Found the
+smoking gun!`, `Perfect!` as a standalone reaction), and restating the request before answering it.
+
+**Fix:** Delete. Open with the answer, close when the answer ends. In inline mode this is a hard
+rule with no density threshold: one `Great question!` is one too many.
+
+#### Cutoff and knowledge disclaimers
+
+Hedges about the model's own limits, left in text a human is supposed to have written:
+`While specific details are limited`, `As of my last update`, `I don't have access to
+real-time data`, `Based on available information`.
+
+**Fix:** Find the fact and state it, or cut the sentence. If the uncertainty is real, name what
+is unknown and why: `The 2026 figures are not published yet`.
+
+#### Feeling instead of mechanism
+
+Prose naming an impression rather than a fact the reader can act on. Ask what the sentence tells
+the reader to do or know: `the database stays close at hand`, `SQL you can read`, `types that
+follow your schema` all fail that test.
+
+**Fix:** Replace with the mechanism, a number, or an instruction. `.toSQL() returns the exact
+string sent to the database.` If no concrete restatement exists, cut the sentence. Table and
+exceptions in `references/plain-speech.md`.
+
+#### Generic forward-looking conclusions
+
+A closing paragraph gesturing at the future without committing: `The future looks bright`,
+`Only time will tell`, `As the space continues to evolve`, `The possibilities are endless`.
+
+**Fix:** State a specific plan, date, or fact, or end on the last real point. A piece does not
+need a conclusion paragraph to be finished.
+
 ### 4. Formatting Tells (Noise)
 
 Layout and punctuation patterns that LLMs default to.
 
 **Detect:**
-- **Em dashes** (Unicode U+2014, or the `--` double-dash substitute) used as sentence breaks. LLMs overuse them to imitate journalistic cadence. Replace with single `-` or restructure the sentence.
+- **Em dashes** (Unicode U+2014, or the `--` double-dash substitute) used as sentence breaks. LLMs overuse them to imitate journalistic cadence. Replace with single `-` or restructure the sentence. Do not swap in parentheses or en dashes instead: that trades one tell for another. If the thought needs separation, end the sentence or use a comma.
 - **Title Case in section headings** (`Understanding the Core Concepts` vs `Understanding the core concepts`). AI defaults to title case even in sentence-case conventions. Match the project's style.
 - **Excessive bold** - every third noun bolded for no reason. Bold earns its use by signaling a term or path.
 - **Bullet salad** - prose turned into bullets when a paragraph would read better. Lists are for enumerations, not for every idea.
@@ -372,6 +469,39 @@ Layout and punctuation patterns that LLMs default to.
 - **LLM output bugs** - `turn0search0`, `contentReference`, `oaicite`, `+1`, `attached_file`, hallucinated wiki-style shortcuts
 
 **Fix:** Match the surrounding project's conventions. If there is no convention, default to plain ASCII, sentence case, minimal bold, paragraph prose.
+
+#### Colon as a mid-sentence connector
+
+A colon whose right side is a full clause that would read the same as its own sentence, adding
+a beat of false setup: `If you're coming from traditional automation: instead of registering
+event handlers, you describe conditions.`
+
+**Fix:** End the sentence, or rewrite so the point stands without the comparison framing.
+
+**Exception:** colons before lists, definitions, quotes, and code blocks are correct, as is one
+introducing a real specification (`One rule: never force-push shared branches`).
+
+#### Inline-header lists that restate themselves
+
+A bold label followed by a colon whose text repeats the label:
+`**Performance:** Performance improved by 12%.`
+
+**Fix:** Convert to prose, or drop the label. `Performance improved by 12%.`
+
+**Exception:** a bold lead-in ending in a period that names the item and is followed by new
+detail is a definition list, not a tell: `**Schema in TypeScript.** Tables live in one file.`
+
+---
+
+## Restoring Voice
+
+Removing tells is half the work. Prose stripped of every pattern and given nothing back reads as
+sterile, which is its own tell. Rewrites should carry a position, varied rhythm, acknowledged
+complexity, first person where it fits, and specifics. Long form in `references/plain-speech.md`.
+
+In **audit mode**, voice notes are `Consider`-level, never `Fix`. Voice belongs to the author.
+Never rewrite a piece into your own voice under the banner of removing AI tells. In **inline
+mode**, apply this to your own drafting rather than reporting on it.
 
 ---
 
@@ -389,6 +519,12 @@ These look like AI tells but are not:
 - **Lists that are actually lists** - a three-item list is only suspicious if the items are padded. An enumeration of three real things is fine
 - **Bold where it signals a term or path** - bolding a defined term on first use is standard
 - **Em dashes in publications that require them** - some style guides (Chicago, AP) allow or require em dashes. The rule applies to your project's conventions
+- **Deliberate passive voice** - when the actor is unknown, irrelevant, or withheld on purpose. Incident writeups keep blame off individuals by design. Scientific method sections use passive by convention
+- **Colons before lists, definitions, quotes, or code blocks** - that is what colons are for. Only the mid-sentence clause joint is a tell
+- **Definition-list bold lead-ins** - `**Term.** New detail follows.` is a real pattern. The tell is only the label that restates itself: `**Performance:** Performance improved...`
+- **Real ranges** - `from 10ms to 2s`, `from v1 to v4` sit on a shared scale. Only ranges with no meaningful midpoint are false ranges
+- **Long sentences that parse on first read** - length is not the tell, backtracking is
+- **Terms of art among the abstract metaphor nouns** - `vector` in linear algebra, `primitive` in cryptography, `locus` in genetics, `harness` in test tooling
 - **A genuine rhetorical question or single hard fragment** - one "What if X?" that the piece actually answers, or one deliberate "That's it." landing a point, is voice. Flag the pattern (stacked setups, repeated faux-profundity fragments), not the isolated use. An earned single use is not a tell, so it does not count toward the short-text density threshold or escalate to P1 on its own - it is the stacking that carries the severity.
 
 ### Counter-example (prose that looks AI but is fine)
@@ -401,67 +537,21 @@ Looks flagged at a glance: `nestled`, `landscape`, `robust`, `underscores`, `piv
 
 ## Output Format
 
-````markdown
-## Anti-AI-Prose Audit: [scope]
+Audit mode only. See `references/audit-mode.md` for the report template, the rules for the
+report itself, and a worked example anchoring the format.
 
-### Findings
+Inline mode has no output format: the cleaned prose is the output.
 
-#### [Category Name] ([count] items)
+## Reference Files
 
-**[action]** ([severity]) `path/to/file:line` - [description]
-
-> before: [quoted text from the source]
-
-> after: [suggested rewrite]
-
-### Summary
-- X findings across Y files / sections
-- [overall read: does the piece sound human?]
-- [top-level observation: e.g., "vocabulary is mostly fine but the structure is formulaic"]
-````
-
-Rules for the report itself:
-- **Omit empty categories.** If there are no formatting tells, do not write an empty "Formatting Tells (0 items)" heading
-- **Order within a category** P1 > P2 > P3
-- **Deletion fixes have no "after"** - write `> after: (cut)` or just state the delete in the description
-- **Apply these rules to your own audit.** Run the Self-Check on the report before returning it - an audit written in AI-slop voice is not credible
-
-Keep it concise. Show the before/after pair. Do not lecture about why AI writing is bad - the user already knows.
-
-### Worked example (anchor the format)
-
-Input (README snippet, 48 words):
-
-> In today's fast-paced world, our platform empowers developers to seamlessly navigate the complex landscape of modern APIs. Built with a commitment to excellence, it boasts robust features and fosters innovation. Whether you're a beginner or expert, this tool serves as a pivotal resource for your journey toward better software.
-
-Report:
-
-```
-## Anti-AI-Prose Audit: README snippet (48 words)
-
-### Findings
-
-#### Vocabulary Tells (9 items)
-
-**Fix** (P1) line 1 - cluster of 9 flagged words in 48 words: far above 4/500 threshold
-> before: empowers / seamlessly / navigate / landscape / commitment to / boasts / fosters / pivotal / journey toward
-> after: (rewrite, see below)
-
-#### Tonal Tells (2 items)
-
-**Fix** (P1) line 1 - scaffolding padding and significance padding
-> before: "In today's fast-paced world"
-> after: (cut)
-
-**Fix** (P2) line 1 - promotional tone
-> before: "Built with a commitment to excellence"
-> after: (cut)
-
-### Summary
-- 11 findings, one paragraph, dominant AI voice
-- Rewrite: "An HTTP API client for Python. Handles auth, retries, and pagination. Works with any OpenAPI 3.x spec."
-- Down from 48 words to 22, with concrete claims instead of posture
-```
+- `references/audit-mode.md` - audit-mode workflow, scoping, density and severity scales, the
+  report template, and a worked example
+- `references/plain-speech.md` - abstract metaphor nouns, the concreteness test, the actor
+  test, sentence splitting, and voice restoration in long form with worked examples
+- `references/fiction-name-tells.md` - AI fallback character names, the phonetic pattern, and
+  when a fallback-set name is legitimate
+- `references/agent-hygiene.md` - cross-cutting agent hygiene checks shared across the collection
+- `references/output-contract.md` - the shared output contract
 
 ## Output Contract
 
@@ -469,7 +559,7 @@ See `references/output-contract.md` for the full contract.
 
 - **Skill name:** ANTI-AI-PROSE
 - **Deliverable bucket:** `audits`
-- **Mode:** always-on. Every invocation emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table.
+- **Mode:** conditional, split on the two modes above. **Audit mode** (a file, paste, diff, or directory handed over for review) emits the full contract - boxed inline header, body summary inline plus per-finding detail in the deliverable file, boxed conclusion, conclusion table. **Inline mode** (filtering your own conversational output as you write it) emits nothing: no header, no findings, no deliverable, no announcement that the skill ran.
 - **Deliverable path:** `docs/local/audits/anti-ai-prose/<YYYY-MM-DD>-<slug>.md`
 - **Severity scale:** `P0 | P1 | P2 | P3 | info` (see shared contract).
 
@@ -493,3 +583,6 @@ See `references/output-contract.md` for the full contract.
 6. **Keep the voice of the author.** The goal is prose that sounds like a specific human, not a generic "good writing" rewrite. If you do not know the author's voice, leave stylistic calls alone and only flag the mechanical tells.
 7. **Do not pad the report.** If there are three findings, list three. Not five. Not one inflated to three.
 8. **Run the AI Self-Check** before returning any audit.
+9. **Inline mode is silent.** Applying these rules to your own output produces cleaner prose and nothing else. No report, no findings, no deliverable, no note that the skill ran. A user who wanted an audit will ask for one.
+10. **The user's style outranks these rules.** Explicit instructions, then project instruction files, then genre convention, then this skill. A house style that mandates em dashes or title case is not a finding.
+11. **In your own output, drop the density thresholds.** They exist to stop overflagging someone else's long document. One chat artifact in your own reply is one too many.

--- a/skills/anti-ai-prose/SKILL.md
+++ b/skills/anti-ai-prose/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: anti-ai-prose
 description: >
-  · Strip AI tells from prose in docs, PRs, emails, and your own replies. Apply to every response by default; full audit on request. Triggers: 'unslop', 'ai writing', 'sounds like chatgpt', 'llm voice'. Not for code (use anti-slop).
+  · Strip AI tells from prose in docs, PRs, emails, and your own replies. Filters every response once loaded; full audit on request. Triggers: 'unslop', 'ai writing', 'sounds like chatgpt', 'llm voice'. Not for code (use anti-slop).
 license: MIT
 compatibility: "None - works on any prose or text input"
 metadata:
@@ -21,13 +21,9 @@ Based in part on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/
 
 ## When to use
 
-- Auditing a README, doc page, or wiki article that feels machine-written
-- Reviewing a PR body, commit message, or release note draft before publishing
-- Polishing a blog post, email, or presentation script you wrote with LLM help
-- Checking creative writing (fiction, essays) for AI tells after an LLM-assisted pass
-- Reviewing docstrings and code comments for the same prose patterns
-- Any time someone says "this sounds like ChatGPT wrote it"
-- Self-check after a heavy LLM-drafting session
+- Auditing a README, doc page, or wiki article that feels machine-written, or a PR body, commit message, or release note draft before publishing
+- Polishing a blog post, email, script, or creative writing drafted with LLM help, or reviewing docstrings and code comments for the same patterns
+- Any time someone says "this sounds like ChatGPT wrote it", or self-checking after heavy LLM drafting
 - Filtering your own replies, explanations, and drafts as you write them (inline mode, see below)
 
 ## When NOT to use
@@ -36,8 +32,7 @@ Based in part on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/
 - Doc drift after a feature change, API rename, or config update - use **update-docs**
 - Generating or restructuring a prompt from rough notes - use **prompt-generator**
 - Correctness bugs, logic errors, edge cases - use **code-review**
-- Security review of auth, secrets, or attack surface - use **security-audit**
-- Full multi-dimensional repo audit - use **full-review**
+- Security review of auth, secrets, or attack surface - use **security-audit**, or **full-review** for a full multi-dimensional repo audit
 
 ---
 
@@ -45,72 +40,64 @@ Based in part on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/
 
 This skill runs in one of two modes. Pick the mode from the trigger, not from the content.
 
-### Inline mode (default, always on)
+### Inline mode (default)
 
-Applies to your own conversational output: chat replies, explanations, summaries, commit bodies,
-PR descriptions, and any prose you draft for the user. Runs on every response without being asked.
+Applies to your own conversational output: chat replies, explanations, summaries, commit
+bodies, PR descriptions, and any prose you draft for the user. Apply it to every response for
+as long as this skill is in context, without being asked again. It cannot clean replies drafted
+before it loaded, so load it early when prose quality matters.
 
-- Apply the pattern rules silently while writing. This filters drafting, it does not review a
-  finished draft.
-- Emit **no report, no findings, no severity ratings, no deliverable file**, and no note that the
-  skill ran.
+- Apply the pattern rules silently while writing. This filters drafting, it does not review a finished draft.
+- Emit **no report, no findings, no severity ratings, no deliverable file**, and no note that the skill ran.
 - Do not restructure the user's own words when quoting them back.
 - Density thresholds do not apply. Fix every tell you catch in your own output.
-- Ask before sending: "what in this reply reads as machine generated?" Fix what that surfaces.
+- Before sending, ask: "what in this reply reads as machine generated?" Fix what that surfaces.
 
 ### Audit mode (explicit)
 
 Applies to text the user hands over: a file, a paste, a diff, a directory. Triggered by an
-explicit request ("audit this", "does this sound like AI", "unslop this doc") or by invoking the
-skill against a target. Run the full Workflow below, emit the full output contract, and apply the
-density thresholds so isolated instances in long documents are not flagged.
+explicit request ("audit this", "does this sound like AI", "unslop this doc") or by invoking
+the skill against a target. Run the full Workflow below, emit the full output contract, and
+apply the density thresholds so isolated instances in long documents are not flagged.
 
 ### Precedence
 
-When rules conflict, later entries lose:
-
-1. The user's explicit instruction in this conversation
-2. Project instruction files (`CLAUDE.md`, `AGENTS.md`, repo style guide)
-3. Genre convention of the text being written (see "What NOT to Flag")
-4. This skill's pattern rules
-
-A house style that mandates em dashes, title-case headings, or a formal register is not a finding.
-Inline mode adapts to it rather than overriding it.
+When rules conflict, later entries lose: (1) the user's explicit instruction in this
+conversation, (2) project instruction files (`CLAUDE.md`, `AGENTS.md`, repo style guide),
+(3) genre convention of the text being written, (4) this skill's pattern rules. A house style
+that mandates em dashes, title-case headings, or a formal register is not a finding. Inline
+mode adapts to it rather than overriding it.
 
 ---
 
 ## AI Self-Check
 
-Before returning any audit, verify:
+Always, in both modes:
 
-- [ ] **Findings are patterns, not taste**: the issue is a demonstrable AI tell (from the Wikipedia guide or observed LLM output), not personal writing preference
-- [ ] **Context respected**: academic and technical prose can look formal without being AI-generated. Journalism, marketing, and tourism writing have legitimate conventions that overlap with AI tells. Do not flag genre conventions as AI tells
-- [ ] **Direct quotes preserved**: do not edit quoted material from other authors, even if it contains banned vocabulary
-- [ ] **Domain terms kept**: `pivotal` in hinge hardware specs, `landscape` in horticulture, `foster` as a verb in child welfare, `realm` in fantasy fiction - these are not tells in context
-- [ ] **Code blocks untouched**: do not flag identifiers, strings, or code comments that contain banned words as part of functional code
-- [ ] **Rewrites are real improvements**: every "after" is shorter, clearer, or more specific than the "before". No lateral rewrites that just swap synonyms
-- [ ] **Severity is honest**: do not inflate P3 findings to P2 to pad the report
-- [ ] **Density and short-text rule applied**: density heuristic applied before assigning severity; for text under 100 words, 2+ tells in one paragraph = P1 regardless of per-500-word threshold
-- [ ] **Audit output itself uses no AI-prose tells** (apply these rules to your own output)
-- [ ] **AI fallback names checked (fiction)**: protagonist and major-character names compared against the documented fallback set (Elara, Lyra, Aurora, Kael, Vale, Cassius, etc.) and the phonetic tell (2 soft syllables, A/L/R/N consonants, no demographic anchor); fallback-set names allowed only when the setting and population organically produce them
-- [ ] **Adverb stacking checked**: `-ly` adverb density scanned; passages with multiple adverb-modified speech tags or adjacent adverb clusters flagged at the same density threshold as vocabulary tells
-- [ ] **Confident filler checked**: emphasis crutches, rhetorical setups, and faux-profundity fragments flagged by pattern/density, not on isolated earned uses
 - [ ] **Mode picked correctly**: inline mode emitted no report, no findings list, and no deliverable file; audit mode emitted the full contract. The two were not mixed in one response
-- [ ] **House style respected**: project instruction files and explicit user instructions took precedence over this skill's pattern rules; a mandated em dash or title-case convention was not reported as a finding
-- [ ] **Plain-speech checks run**: participle tails, false ranges, unnamed-actor passives, dense sentence stacking, and feeling-instead-of-mechanism scanned alongside the vocabulary tells
 - [ ] **Chat artifacts cleared**: no `Great question!`, `I hope this helps!`, `Certainly!`, or cutoff disclaimer survived into the output, in either mode
-- [ ] **Voice restored, not imposed**: rewrites carry a position, varied rhythm, and specifics; voice suggestions are marked `Consider`, never `Fix`
-- [ ] **Overflagging avoided**: plain but valid technical prose is not labeled AI-written without concrete evidence
+
+Audit only:
+
+- [ ] **Findings are patterns, not taste**: every finding is a demonstrable AI tell, not a writing preference, and plain-but-valid technical prose was not labeled AI-written without concrete evidence
+- [ ] **Context respected**: genre conventions (academic, journalism, marketing, tourism) and domain terms of art were not flagged - `pivotal` in hinge hardware, `landscape` in horticulture, `foster` in child welfare, `realm` in Kerberos
+- [ ] **Direct quotes preserved**: quoted material from other authors was not edited, even when it contains banned vocabulary
+- [ ] **Code untouched, prose audited**: identifiers, string literals, and API names were not flagged for containing a banned word. Prose *inside* comments and docstrings is a valid target; the code around it is not
+- [ ] **All four categories scanned**, including the checks that are easy to skip: adverb stacking, confident filler, the plain-speech set (participle tails, false ranges, unnamed-actor passives, dense sentence stacking, feeling-instead-of-mechanism), and fiction fallback names
+- [ ] **Density and short-text rule applied**: density set severity, and text under 100 words with 2+ tells in one paragraph was rated P1 regardless of the per-500-word threshold
+- [ ] **Severity is honest**: no P3 inflated to P2 to pad the report, and no finding count padded
+- [ ] **Rewrites are real improvements**: every "after" is shorter, clearer, or more specific than the "before", carries a position and specifics, and invents no fact the source did not have. No lateral synonym swaps, and voice suggestions are marked `Consider`, never `Fix`
 - [ ] **Audience preserved**: edits keep the author's domain vocabulary, intent, and required formality
+- [ ] **House style respected**: explicit user instructions and project instruction files outranked this skill's pattern rules; a mandated em dash or title-case convention was not reported as a finding
+- [ ] **Audit output itself uses no AI-prose tells** (apply these rules to your own output)
 - [ ] Cross-cutting agent hygiene applied - see `references/agent-hygiene.md`
 
 ---
 
 ## Performance
 
-- Review a representative sample first, then expand only if the same pattern repeats across the document.
-- Group repeated prose issues by pattern instead of leaving near-duplicate comments on every paragraph.
-- Prioritize high-visibility text: titles, summaries, intros, conclusions, and user-facing docs.
+- Read the whole piece before flagging - density is a per-500-word ratio and a sample cannot produce it. Sampling decides whether a *directory* is worth auditing, not how a document scores.
+- Group repeated issues by pattern instead of near-duplicate comments on every paragraph, and prioritize high-visibility text: titles, summaries, intros, conclusions, user-facing docs.
 
 ---
 
@@ -122,7 +109,7 @@ Before returning any audit, verify:
 
 ## Workflow
 
-Audit mode only. Full detail in `references/audit-mode.md`: scoping rules, the text-kind table,
+Audit mode only. Full detail in `references/audit-mode.md`: scoping rules, the text-kind list,
 the density heuristic, the action and severity scales, and the report template with a worked
 example.
 
@@ -130,9 +117,14 @@ example.
    then to docstrings in changed files, then ask.
 2. **Detect text kind.** Technical docs, README/PR/commit, marketing, fiction, wiki, email, and
    slides each carry conventions that change what counts as a tell.
-3. **Scan.** Apply the four categories below. Read surrounding context before flagging: one AI word
-   in 5000 words is noise, three in three paragraphs is a pattern. Density sets severity, and text
-   under 100 words with 2+ tells in a paragraph is P1 regardless.
+3. **Scan.** Apply the four categories below. Read surrounding context before flagging: one AI
+   word in 5000 words is noise, three in three paragraphs is a pattern. Density sets severity;
+   text under 100 words with 2+ tells in a paragraph is P1 regardless. Some checks skip density
+   because one instance is already the finding: travel-guide voice, promotional tone, the
+   formulaic article shape, chat artifacts, and an AI fallback character name. Trust breaches
+   skip it too, at P0 in text meant to ship - a fabricated citation, an invented fact, a leaked
+   secret, generator residue, or a cutoff disclaimer under a human byline.
+   `references/audit-mode.md` holds the authoritative gated/not-gated list.
 4. **Report and fix.** Group by category, show the concrete rewrite, keep every rewrite shorter or
    more specific than the original. **Plan first, apply that plan only:** when the user asks for
    fixes, change only what the report flagged. New findings during application become a second
@@ -142,53 +134,39 @@ example.
 
 ## The Four Categories of AI Prose Slop
 
-### 1. Vocabulary Tells (Noise)
+### 1. Vocabulary Tells
 
 Specific words that LLMs overuse far beyond their natural English frequency.
 
 **Flagged vocabulary** (context-sensitive - see exceptions below):
 
-| AI word | Natural alternatives |
-|---|---|
-| delve | look at, examine, dig into, cover |
-| tapestry | mix, range, variety (or just drop the metaphor) |
-| testament | proof, evidence, example |
-| pivotal | key, important, central (or drop if padding) |
-| crucial | important, needed (or drop if padding) |
-| realm | area, field, world |
-| landscape | scene, field, mix |
-| showcase | show, display, feature |
-| empower | help, enable, let (or rewrite with a specific claim) |
-| foster | build, grow, support, encourage |
-| navigate | handle, work through, manage |
-| nestled | set, located, built |
-| vibrant | lively, active, busy (or drop) |
-| underscore | show, highlight, confirm |
-| garner | get, earn, attract |
-| enduring | lasting, long-running |
-| boast | have (just "has") |
-| leverage | use |
-| utilize | use |
-| facilitate | help, enable |
-| seamless | smooth (or drop) |
-| robust | reliable, solid (or drop if padding) |
-| commitment to | cares about, focuses on |
-| dive deep into | look at, cover |
-| embark on | start, begin |
-| nuanced | subtle, careful, specific (or drop - almost always padding) |
-| multifaceted | has many sides, covers a lot (or drop) |
-| holistic | whole, end-to-end, full (or drop) |
-| synergy | fit, overlap, how X and Y work together (or drop) |
-| innovative | new, novel (or name what is new) |
-| commence | start, begin |
-| journey toward | work toward, move toward, aim for (or drop) |
-| moving forward | from now on, next, going forward (or drop) |
-| additionally | also, and (or start the sentence with the content) |
-| enhance | improve, speed up, extend (or name the change) |
-| interplay | how X and Y interact (or drop) |
-| intricate | detailed, complex (or drop - usually padding) |
-| numerous | many |
-| ensure | make sure, guarantee (or name the mechanism) |
+Grouped by the fix. `(or cut)` marks the words that are usually padding, where the phrase
+should go rather than get a substitute.
+
+**Say "use":** leverage, utilize -> use. facilitate -> help, enable.
+
+**Use a plain verb:** delve / dive deep into -> look at, examine, dig into, cover. showcase ->
+show, display, feature. navigate -> handle, work through, manage. garner -> get, earn, attract.
+underscore -> show, highlight, confirm. enhance -> improve, speed up, extend (or name the
+change). ensure -> make sure, guarantee (or name the mechanism). empower -> help, enable, let.
+foster -> build, grow, support, encourage. boast -> has. commence / embark on -> start, begin.
+
+**Use a plain noun:** realm -> area, field, world. landscape -> scene, field, mix. tapestry ->
+mix, range, variety (or cut the metaphor). testament -> proof, evidence, example. interplay ->
+how X and Y interact (or cut). synergy -> fit, overlap, how X and Y work together (or cut).
+
+**Use a plainer adjective:** enduring -> lasting, long-running. numerous -> many. nestled ->
+set, located, built. innovative -> new, novel (or name what is new).
+
+**Padding adjectives**, all `(or cut)` by default - substitute only when the adjective does
+real work: pivotal / crucial -> key, important, central, needed. nuanced -> subtle, careful,
+specific. intricate -> detailed, complex. multifaceted -> has many sides, covers a lot.
+holistic -> whole, end-to-end, full. seamless -> smooth. robust -> reliable, solid. vibrant ->
+lively, active, busy.
+
+**Padding phrases**, same rule: commitment to -> cares about, focuses on. journey toward ->
+work toward, move toward, aim for. moving forward -> from now on, next. additionally -> also,
+and (or start the sentence with the content).
 
 **Detect:**
 - Multiple flagged words in the same paragraph
@@ -201,9 +179,9 @@ See "What NOT to Flag" below for domain exceptions (horticulture `landscape`, ch
 
 #### AI fallback character names (fiction)
 
-Generated fiction often converges on soft, no-baggage names such as `Elara`, `Kael`, or
-`Voss`. If a prose audit includes invented character names, read
-`references/fiction-name-tells.md` for the fallback-name pattern, exceptions, and fix guidance.
+Generated fiction converges on soft, no-baggage names such as `Elara`, `Kael`, or `Voss`. Not
+density-gated: one such protagonist name is the finding. See `references/fiction-tells.md` for
+the phonetic test and the exceptions.
 
 #### Abstract metaphor nouns
 
@@ -211,24 +189,20 @@ Nouns that read as technical but stand in for a plainer word: `substrate`, `wedg
 `locus`, `vantage`, `nexus`, `primitive` (as noun), `harness` (as metaphor), `surface` (as in
 "API surface"), `bedrock`, `scaffolding` (as metaphor), `modality`, `paradigm`, `gold-plating`.
 
-**Detect:** the noun carries no measurement, no referent, and no consequence.
+**Detect:** the noun carries no measurement, no referent, and no consequence. **Fix:** name the
+concrete thing - `substrate` -> `base`, `wedge in` -> `add`, `vector` -> `way`. **Exception:** each
+is a term of art somewhere (`vector` in linear algebra, `locus` in genetics); full table in
+`references/plain-speech.md`.
 
-**Fix:** name the concrete thing. `substrate` -> `base`, `wedge in` -> `add`, `vector` -> `way`.
-
-**Exception:** each is a term of art somewhere (`vector` in linear algebra, `locus` in
-genetics). Full table and per-term exceptions in `references/plain-speech.md`.
-
-### 2. Syntax Tells (Noise + Soul)
+### 2. Syntax Tells
 
 Sentence structures LLMs reach for to sound balanced or significant.
 
 #### Negative parallelism
 
-LLMs overuse `not X but Y` and `not just X, but also Y` constructions to signal balance and sophistication. In moderation this is fine English. In quantity it is a clear tell.
+`not X but Y` and `not just X, but also Y`, used to signal balance. Fine English in moderation, a clear tell in quantity.
 
-**Detect:**
-- Three or more `not X but Y` / `not just X, but Y` / `it's not about X, it's about Y` structures in a single piece
-- Used where a direct claim would work: `this isn't just a tool, it's a platform` -> `this is a platform`
+**Detect:** three or more `not X but Y` / `it's not about X, it's about Y` structures in one piece, or one used where a direct claim would work: `this isn't just a tool, it's a platform` -> `this is a platform`.
 
 **Fix:** State the positive claim directly. If the contrast matters, keep one instance and rewrite the rest.
 
@@ -237,8 +211,7 @@ LLMs overuse `not X but Y` and `not just X, but also Y` constructions to signal 
 `X, Y, and Z` lists used for rhythm rather than enumeration. LLMs default to three items even when two or four would be more accurate.
 
 **Detect:**
-- Adjective triplets where one adjective would carry the meaning: `a fast, reliable, and scalable system`
-- Noun triplets that are really the same concept: `clarity, precision, and accuracy`
+- Adjective triplets where one adjective carries the meaning (`a fast, reliable, and scalable system`), or noun triplets that are really one concept (`clarity, precision, and accuracy`)
 - Three-item lists where the third item is obviously padded to hit the count
 
 **Fix:** Drop the weakest item. Use two items when the point is a contrast, four or more when it is an actual list.
@@ -247,71 +220,54 @@ LLMs overuse `not X but Y` and `not just X, but also Y` constructions to signal 
 
 LLMs avoid plain `is` / `are` / `has` / `have` in favor of elaborate constructions: `serves as`, `marks`, `represents`, `features`, `offers`, `boasts`, `stands as`.
 
-**Detect:**
-- `serves as` where `is` works: `it serves as a backup` -> `it is a backup`
-- `represents` used as a replacement for `is`: `this represents a shift` -> `this is a shift`
-- `boasts` used for `has`: `the app boasts 50 features` -> `the app has 50 features`
-- `marks` used to inflate: `this marks the first time` -> `this is the first time`
+**Detect:** `it serves as a backup` -> `it is a backup`. `this represents a shift` -> `this is
+a shift`. `the app boasts 50 features` -> `the app has 50 features`. `this marks the first
+time` -> `this is the first time`.
 
 **Fix:** Use the plain copula. Elaborate verbs should carry weight - do not spend them on simple identity claims.
 
-#### Adverb crutch (-ly modifiers)
+#### Adverb crutch and elegant variation
 
-LLMs reach for `-ly` adverbs to inflate description and dodge precise verb choice: `said softly`, `ran quickly`, `smiled warmly`, `walked slowly`, `whispered quietly`. Each one in isolation is acceptable English. Density is the tell. The classical fiction-editing test (Stephen King and most line editors): if dropping the adverb does not change the meaning, the verb is the problem.
+Two line-editing tells. **Adverb crutch:** `-ly` adverbs inflating description in place of a
+precise verb (`said softly`, `ran quickly`, `whispered quietly`). Density is the tell, not any
+single use. Test: drop the adverb. If only rhythm shifts, the verb was weak - `said softly` ->
+`whispered`. Keep adverbs carrying information the verb cannot (`answered honestly`).
 
-**Detect:**
-- `-ly` adverbs modifying speech tags: `said softly`, `whispered quietly`, `shouted loudly`, `replied curtly`
-- Adverbs that restate the verb: `whispered quietly`, `shouted loudly`, `ran quickly`, `mumbled under his breath`
-- Multiple `-ly` adverbs in adjacent sentences (a passage sprinkled with them rather than one used for emphasis)
-- Stacking with hedges: `gently`, `slightly`, `rather`, `somewhat` modifying the same verb or following each other across a paragraph (cross-references "Hedging and qualifier stacking" in Tonal Tells)
+**Elegant variation:** the same entity named by 3+ strained synonyms in close proximity -
+Alice becomes `the protagonist`, `the young woman`, `the eponymous heroine`. Fix: use the name
+or a pronoun. Repetition beats forced variation.
 
-**Fix:** Prefer a stronger verb. `said softly` -> `whispered`. `ran quickly` -> `sprinted`. `smiled warmly` -> `beamed`. `looked carefully at` -> `studied`. Delete adverbs that restate the verb outright.
+Detect lists, worked fixes, and exceptions for both: `references/fiction-tells.md`.
 
-**Exception:** Keep the adverb when it carries information the verb cannot. `said reluctantly`, `answered honestly`, `arrived late`, `she nodded slowly` (when the slowness is the point) all earn their place. The test: drop the adverb. If meaning shifts, keep it. If only rhythm shifts, the verb was weak.
-
-#### Elegant variation
-
-LLMs avoid repeating a noun within a paragraph, substituting increasingly strained synonyms. A character named Alice becomes `the protagonist`, `the main character`, `the young woman`, `the eponymous heroine` in four consecutive sentences.
-
-**Detect:**
-- The same entity referred to by 3+ different nouns in close proximity
-- Strained synonyms where a pronoun or name repetition would be natural
-- Different technical terms for the same concept within one document
-
-**Fix:** Use the name, or a pronoun. Repetition is fine. Forced variation is worse than repetition.
 
 #### Superficial participle tails
 
 A sentence ending in a comma plus an `-ing` clause that restates what the sentence already
-said. Implies consequence without asserting one.
+said, implying consequence without asserting one: `..., highlighting the need for X`, `...,
+ensuring reliability`, `..., reflecting a broader shift`, `..., showcasing the team's
+expertise`, `..., underscoring its importance`.
 
-**Detect:** `..., highlighting the need for X`, `..., ensuring reliability`, `..., reflecting
-a broader shift`, `..., showcasing the team's expertise`, `..., underscoring its importance`.
-Test: cut the clause. If nothing is lost, it was decoration.
-
-**Fix:** Delete the tail. If the consequence is real, promote it to its own sentence with a
-stated mechanism: `..., ensuring reliability` -> `Retries cover the transient failures.`
+**Detect:** cut the clause. If nothing is lost, it was decoration. **Fix:** delete the tail; if
+the consequence is real, promote it to its own sentence with a stated mechanism - `..., ensuring
+reliability` -> `Retries cover the transient failures.`
 
 #### False ranges
 
-`from X to Y` where X and Y do not sit on a shared scale, used to imply comprehensive coverage
-of what is really two examples.
+`from X to Y` where X and Y do not sit on a shared scale, implying comprehensive coverage of
+what is really two examples: `everything from authentication to deployment`, `from startups to
+enterprises` with no middle named.
 
-**Detect:** `everything from authentication to deployment`, `from startups to enterprises` with
-no middle named. Test for a meaningful midpoint: `from 10ms to 2s` is a real range, `from CI to
-observability` is not.
-
-**Fix:** List the items directly. `covers authentication and deployment`.
+**Detect:** test for a meaningful midpoint. `from 10ms to 2s` is a real range, `from CI to
+observability` is not. **Fix:** list the items directly - `covers authentication and deployment`.
 
 #### Passive voice with an unnamed actor
 
 `is/are/was/were + past participle` that drops the actor: `queries are validated`, `errors are
 logged`. Ask who does it; if the answer is in the document but not the sentence, name it.
 
-**Fix:** Promote the actor to subject. `the compiler validates queries`.
-
-**Exception:** correct when the actor is unknown, irrelevant, or withheld on purpose (incident
-writeups, scientific method sections). See `references/plain-speech.md`.
+**Fix:** promote the actor to subject - `the compiler validates queries`. **Exception:** passive
+is correct when the actor is unknown, irrelevant, or withheld on purpose (incident writeups,
+scientific method sections). See `references/plain-speech.md`.
 
 #### Dense sentence stacking
 
@@ -321,35 +277,33 @@ backtracking is: flag sentences needing a second pass to locate the verb.
 **Fix:** Split at the clause boundary, or drop the clause carrying the least. One idea per
 sentence. Worked before/after in `references/plain-speech.md`.
 
-### 3. Tonal Tells (Soul)
+### 3. Tonal Tells
 
-The voice of the text gives away the author even when the words are individually defensible.
+The voice gives away the author even when the words are individually defensible. Travel-guide
+voice, promotional tone, the formulaic shape, chat artifacts, and cutoff disclaimers are not
+density-gated: one instance is the finding. The sentence-level tells here - vague attribution,
+significance padding, hedging, scaffolding, confident filler, feeling-instead-of-mechanism -
+are gated like the vocabulary tells.
 
 #### Travel-guide voice
 
-`Nestled between rolling hills, this vibrant city boasts a rich cultural heritage and a thriving arts scene`. LLMs default to this register for any geographic or cultural topic.
+`Nestled between rolling hills, this vibrant city boasts a rich cultural heritage and a thriving arts scene`. The default register for any geographic or cultural topic.
 
-**Detect:** `nestled`, `rolling hills`, `vibrant`, `thriving`, `rich heritage`, `bustling`, `charming`, `picturesque`
-
-**Fix:** State facts. `The city has 300,000 people, two universities, and a jazz festival in August.`
+**Detect:** `nestled`, `rolling hills`, `vibrant`, `thriving`, `rich heritage`, `bustling`, `charming`, `picturesque`. **Fix:** state facts - `The city has 300,000 people, two universities, and a jazz festival in August.`
 
 #### Promotional tone
 
-`Our commitment to excellence ensures we foster innovation and empower our customers to succeed.` LLMs reach for press-release cadence when asked to describe any organization or product.
+`Our commitment to excellence ensures we foster innovation and empower our customers to succeed.` Press-release cadence, reached for when describing any organization or product.
 
-**Detect:** `commitment to`, `empower`, `foster`, `ensure`, `strive`, `dedicated to`, `passionate about`, `industry-leading`, `cutting-edge`, `next-generation`
-
-**Fix:** Replace with specific claims. `We help X customers do Y` beats `We empower customers to succeed`.
+**Detect:** `commitment to`, `empower`, `foster`, `ensure`, `strive`, `dedicated to`, `passionate about`, `industry-leading`, `cutting-edge`, `next-generation`. **Fix:** replace with specific claims - `We help X customers do Y` beats `We empower customers to succeed`.
 
 #### Vague attribution
 
 `Experts say`, `industry reports indicate`, `observers have noted`, `many believe`. LLMs use these when they want to assert something without a source. Real writers either cite or own the claim.
 
-**Detect:**
-- `experts say` / `experts agree` without naming experts
-- `industry reports` / `studies show` without a study
-- `observers have noted` / `critics argue` without names
-- Plural `sources say` pointing to at most one source
+**Detect:** `experts say` / `experts agree` with no expert named, `industry reports` /
+`studies show` with no study, `observers have noted` / `critics argue` with no names, plural
+`sources say` pointing to at most one source.
 
 **Fix:** Cite the source. Or own the claim. Or cut it - most of the time the surrounding sentence works without the attribution.
 
@@ -357,13 +311,8 @@ The voice of the text gives away the author even when the words are individually
 
 `This marks a pivotal moment, underscoring broader trends in the industry.` LLMs inflate the weight of routine events to pad word count.
 
-**Detect:**
-- `marks a pivotal moment`
-- `underscoring broader trends`
-- `highlighting the importance of`
-- `serves as a reminder that`
-- `in an era where`
-- `in today's fast-paced world`
+**Detect:** `marks a pivotal moment`, `underscoring broader trends`, `highlighting the
+importance of`, `serves as a reminder that`, `in an era where`, `in today's fast-paced world`.
 
 **Fix:** Delete the whole sentence. If what follows does not make sense without the padding, rewrite the surrounding paragraph.
 
@@ -372,10 +321,9 @@ The voice of the text gives away the author even when the words are individually
 LLMs stack hedges and qualifiers to sound cautious or balanced. Each hedge by itself is fine English; stacking them makes every claim feel tentative.
 
 **Detect:**
-- Frequent `generally`, `typically`, `often`, `usually`, `in many cases`, `for the most part`
-- Weak modal stacking: `may`, `can`, `might`, `could potentially`, `arguably`, `relatively`
+- Frequent `generally`, `typically`, `often`, `usually`, `in many cases`, `for the most part`, or weak modal stacking: `may`, `can`, `might`, `could potentially`, `arguably`, `relatively`
 - Two or more hedges in the same clause: `can generally be considered to be relatively reliable`
-- Hedges on claims that the author clearly knows are true: `this may help with performance` (when benchmarks are already in the paragraph)
+- Hedges on claims the author clearly knows are true: `this may help with performance`, when benchmarks are already in the paragraph
 
 **Fix:** Delete the hedge and state the claim. If the claim really does need a caveat, state it concretely: `on Linux only`, `for connections over 1000 RPS` - not `generally speaking`.
 
@@ -384,12 +332,9 @@ LLMs stack hedges and qualifiers to sound cautious or balanced. Each hedge by it
 Phrases that wrap around the actual content without adding information. LLMs lean on these to sound organized or conversational.
 
 **Detect:**
-- `it's worth noting that`, `it's important to note`, `it's worth mentioning`
-- `in this article, we'll explore` / `in this guide, we'll cover` (meta-commentary about the piece itself)
-- `let's dive into` / `let's explore` / `let's take a look at`
-- `here's the thing:` / `the fact is:` / `the truth is:`
-- `at the end of the day` / `when all is said and done`
-- `as we've seen` / `as mentioned earlier` / `as previously discussed` (when the reader just read it)
+- `it's worth noting that`, `it's important to note`, `it's worth mentioning`, `here's the thing:`, `the fact is:`, `the truth is:`, `at the end of the day`, `when all is said and done`
+- Meta-commentary about the piece itself: `in this article, we'll explore`, `in this guide, we'll cover`, `let's dive into`, `let's explore`, `let's take a look at`
+- `as we've seen` / `as mentioned earlier` / `as previously discussed`, when the reader just read it
 - Wordy connectives with a one-word equivalent: `in order to` -> `to`, `due to the fact that` -> `because`, `in the event that` -> `if`, `for the purpose of` -> `to`, `with regard to` -> `about`, `a large number of` -> `many`, `at this point in time` -> `now`
 
 **Fix:** Cut the wrapper and keep the content. `It's worth noting that X` becomes `X`. `In this article, we'll explore Y` becomes a first sentence that is about Y.
@@ -405,13 +350,18 @@ LLMs punctuate with manufactured confidence and rhetorical scaffolding that anno
 
 **Fix:** Cut the wrapper; make the claim carry its own weight. Density is the tell: one earned `that's it` is voice, three is a tic. Overlaps significance padding (`serves as a reminder that`) and scaffolding padding (`let's dive into`); when a phrase fits more than one bucket, count it once under the densest cluster, not in every bucket it touches.
 
-#### "Despite its X, faces challenges"
+#### Formulaic article shape
 
-LLMs reach for a formula when asked to describe any organization or project: positives first, then a "however" paragraph listing challenges, often ending with a "future outlook" paragraph.
+The default structure LLMs reach for when describing any organization or project: paragraph 1
+positive, paragraph 2 opening with `Despite` or `However` to list challenges, paragraph 3
+opening with `Looking ahead` or `The future`. The shape is the tell, not the words. Its closing
+move also stands alone: a paragraph gesturing at the future without committing - `The future
+looks bright`, `Only time will tell`, `As the space continues to evolve`, `The possibilities
+are endless`.
 
-**Detect:** the shape of the article more than specific words. Three-paragraph structure where paragraph 1 is positive, paragraph 2 starts with `Despite` or `However`, and paragraph 3 starts with `Looking ahead` or `The future`.
-
-**Fix:** Reorganize around the actual story. If there is no story, the piece probably should not exist.
+**Fix:** Reorganize around the actual story; if there is no story, the piece should not exist.
+For the closer specifically, state a plan, a date, or a fact, or end on the last real point. A
+piece does not need a conclusion paragraph to be finished.
 
 #### Chat artifacts and sycophancy
 
@@ -444,64 +394,33 @@ follow your schema` all fail that test.
 string sent to the database.` If no concrete restatement exists, cut the sentence. Table and
 exceptions in `references/plain-speech.md`.
 
-#### Generic forward-looking conclusions
+### 4. Formatting Tells
 
-A closing paragraph gesturing at the future without committing: `The future looks bright`,
-`Only time will tell`, `As the space continues to evolve`, `The possibilities are endless`.
-
-**Fix:** State a specific plan, date, or fact, or end on the last real point. A piece does not
-need a conclusion paragraph to be finished.
-
-### 4. Formatting Tells (Noise)
-
-Layout and punctuation patterns that LLMs default to.
+Layout and punctuation patterns that LLMs default to. The four below fire on almost every
+draft. The long tail - curly quotes, emoji, decorative `---` breaks, three-bullet-happy
+layouts, markdown artifacts, LLM output bugs (`turn0search0`, `oaicite`), the mid-sentence
+colon connector, and self-restating inline headers - is in `references/formatting-tells.md`.
 
 **Detect:**
-- **Em dashes** (Unicode U+2014, or the `--` double-dash substitute) used as sentence breaks. LLMs overuse them to imitate journalistic cadence. Replace with single `-` or restructure the sentence. Do not swap in parentheses or en dashes instead: that trades one tell for another. If the thought needs separation, end the sentence or use a comma.
-- **Title Case in section headings** (`Understanding the Core Concepts` vs `Understanding the core concepts`). AI defaults to title case even in sentence-case conventions. Match the project's style.
-- **Excessive bold** - every third noun bolded for no reason. Bold earns its use by signaling a term or path.
-- **Bullet salad** - prose turned into bullets when a paragraph would read better. Lists are for enumerations, not for every idea.
-- **Three-bullet-happy layouts** - suspicious when every list has exactly three items
-- **Curly quotes** (`"`, `'`) in technical writing that should use ASCII
-- **Emoji** in professional prose where decoration is the only purpose
-- **Decorative thematic breaks** - `---` before every `##`. Dividers that mark a real phase change are fine; decoration is not
-- **Markdown artifacts in rendered text** - `**bold**` appearing as literal characters because the paste lost its format
-- **LLM output bugs** - `turn0search0`, `contentReference`, `oaicite`, `+1`, `attached_file`, hallucinated wiki-style shortcuts
+- **Em dashes** (U+2014, or the `--` substitute) as sentence breaks in prose. Replace with a
+  single `-` or restructure; parentheses and en dashes just trade one tell for another. Never
+  rewrite `--` inside code or fenced blocks - there it is real syntax.
+- **Title Case in section headings** (`Understanding the Core Concepts`) where the project uses sentence case.
+- **Excessive bold** - every third noun bolded. Bold signals a term or path, nothing else.
+- **Bullet salad** - prose bulleted when a paragraph would read better.
 
-**Fix:** Match the surrounding project's conventions. If there is no convention, default to plain ASCII, sentence case, minimal bold, paragraph prose.
-
-#### Colon as a mid-sentence connector
-
-A colon whose right side is a full clause that would read the same as its own sentence, adding
-a beat of false setup: `If you're coming from traditional automation: instead of registering
-event handlers, you describe conditions.`
-
-**Fix:** End the sentence, or rewrite so the point stands without the comparison framing.
-
-**Exception:** colons before lists, definitions, quotes, and code blocks are correct, as is one
-introducing a real specification (`One rule: never force-push shared branches`).
-
-#### Inline-header lists that restate themselves
-
-A bold label followed by a colon whose text repeats the label:
-`**Performance:** Performance improved by 12%.`
-
-**Fix:** Convert to prose, or drop the label. `Performance improved by 12%.`
-
-**Exception:** a bold lead-in ending in a period that names the item and is followed by new
-detail is a definition list, not a tell: `**Schema in TypeScript.** Tables live in one file.`
+**Fix:** Match project conventions. With none, default to plain ASCII, sentence case, minimal bold, paragraph prose.
 
 ---
 
 ## Restoring Voice
 
-Removing tells is half the work. Prose stripped of every pattern and given nothing back reads as
-sterile, which is its own tell. Rewrites should carry a position, varied rhythm, acknowledged
-complexity, first person where it fits, and specifics. Long form in `references/plain-speech.md`.
-
-In **audit mode**, voice notes are `Consider`-level, never `Fix`. Voice belongs to the author.
-Never rewrite a piece into your own voice under the banner of removing AI tells. In **inline
-mode**, apply this to your own drafting rather than reporting on it.
+Removing tells is half the work. Prose stripped of every pattern and given nothing back reads
+as sterile, which is its own tell. Rewrites should carry a position, varied rhythm,
+acknowledged complexity, first person where it fits, and specifics. Long form in
+`references/plain-speech.md`. In **audit mode** voice notes are `Consider`-level, never `Fix`:
+voice belongs to the author, so never rewrite a piece into your own under the banner of
+removing AI tells. In **inline mode** apply this to your own drafting instead of reporting it.
 
 ---
 
@@ -511,27 +430,19 @@ These look like AI tells but are not:
 
 - **Direct quotations** - do not edit words written by someone else, even if they contain banned vocabulary
 - **Genre conventions** - travel writing uses travel-guide voice because that is what travel writing sounds like. Marketing copy uses promotional tone. Journalism uses em-dashes. Fiction uses elegant variation and tricolons intentionally. Respect the genre.
-- **Technical terms of art** - `pivotal` in mechanical engineering, `realm` in networking or identity (Kerberos, OIDC), `foster` in child welfare, `landscape` in horticulture or graphic design, `crucial experiment` in philosophy of science
-- `landscape` in ML/AI contexts (optimization landscape, loss landscape, feature landscape)
-- `robust` in statistics/ML (robust estimation, robust optimization, robust regression)
+- **Technical terms of art** - `pivotal` in mechanical engineering, `realm` in networking or identity (Kerberos, OIDC) and in fantasy fiction, `foster` in child welfare, `landscape` in horticulture, graphic design, or ML (loss landscape), `robust` in statistics and ML (robust estimation), `crucial experiment` in philosophy of science. Each per-check `Exception:` block above applies here too - domain context always overrides a pattern match
 - **Deliberate register play** - satire, parody, pastiche, and stylistic experiments
 - **Direct speech / dialog** in fiction - characters can sound however they sound
 - **Lists that are actually lists** - a three-item list is only suspicious if the items are padded. An enumeration of three real things is fine
-- **Bold where it signals a term or path** - bolding a defined term on first use is standard
 - **Em dashes in publications that require them** - some style guides (Chicago, AP) allow or require em dashes. The rule applies to your project's conventions
-- **Deliberate passive voice** - when the actor is unknown, irrelevant, or withheld on purpose. Incident writeups keep blame off individuals by design. Scientific method sections use passive by convention
-- **Colons before lists, definitions, quotes, or code blocks** - that is what colons are for. Only the mid-sentence clause joint is a tell
-- **Definition-list bold lead-ins** - `**Term.** New detail follows.` is a real pattern. The tell is only the label that restates itself: `**Performance:** Performance improved...`
 - **Real ranges** - `from 10ms to 2s`, `from v1 to v4` sit on a shared scale. Only ranges with no meaningful midpoint are false ranges
-- **Long sentences that parse on first read** - length is not the tell, backtracking is
-- **Terms of art among the abstract metaphor nouns** - `vector` in linear algebra, `primitive` in cryptography, `locus` in genetics, `harness` in test tooling
 - **A genuine rhetorical question or single hard fragment** - one "What if X?" that the piece actually answers, or one deliberate "That's it." landing a point, is voice. Flag the pattern (stacked setups, repeated faux-profundity fragments), not the isolated use. An earned single use is not a tell, so it does not count toward the short-text density threshold or escalate to P1 on its own - it is the stacking that carries the severity.
 
 ### Counter-example (prose that looks AI but is fine)
 
 > Nestled in the loss landscape near a sharp minimum, the model's robust features fail to generalize. This underscores a pivotal result from Keskar et al. (2017): flat minima tend to foster better test accuracy than sharp ones.
 
-Looks flagged at a glance: `nestled`, `landscape`, `robust`, `underscores`, `pivotal`, `foster`. But every term is a term of art (ML optimization, statistics), `underscores` has a real referent, and the citation is real. Verdict: **Fine**. Do not flag. Domain context overrides vocabulary match.
+Looks flagged at a glance: `nestled`, `landscape`, `robust`, `underscores`, `pivotal`, `foster`. But `loss landscape` and `robust` are terms of art in ML and statistics, `underscores` has a real referent, `pivotal` and `foster` describe a checkable cited result rather than inflating a routine one, and `nestled` is doing literal spatial work. Six matches, one real cluster's worth of suspicion, zero tells. Verdict: **Fine**. Do not flag. Note the reasoning: domain context and a real referent each override a vocabulary match, and they are different arguments.
 
 ---
 
@@ -544,13 +455,11 @@ Inline mode has no output format: the cleaned prose is the output.
 
 ## Reference Files
 
-- `references/audit-mode.md` - audit-mode workflow, scoping, density and severity scales, the
-  report template, and a worked example
-- `references/plain-speech.md` - abstract metaphor nouns, the concreteness test, the actor
-  test, sentence splitting, and voice restoration in long form with worked examples
-- `references/fiction-name-tells.md` - AI fallback character names, the phonetic pattern, and
-  when a fallback-set name is legitimate
-- `references/agent-hygiene.md` - cross-cutting agent hygiene checks shared across the collection
+- `references/audit-mode.md` - audit workflow, scoping, density and severity scales, report template, worked example
+- `references/plain-speech.md` - abstract metaphor nouns, the concreteness and actor tests, sentence splitting, voice restoration
+- `references/fiction-tells.md` - AI fallback character names, adverb crutch, elegant variation
+- `references/formatting-tells.md` - the formatting long tail
+- `references/agent-hygiene.md` - cross-cutting agent hygiene shared across the collection
 - `references/output-contract.md` - the shared output contract
 
 ## Output Contract
@@ -565,11 +474,11 @@ See `references/output-contract.md` for the full contract.
 
 ## Related Skills
 
-- **anti-slop** - code quality audit. When auditing a repo, run anti-slop for code and anti-ai-prose for docs. The two are deliberately complementary.
-- **update-docs** - keeps docs accurate and trimmed after feature changes. Anti-ai-prose focuses on voice; update-docs focuses on factual drift.
-- **prompt-generator** - structures a rough draft into an LLM prompt. If the user wants to generate cleaner prose next time, this helps shape the prompt.
-- **full-review** - orchestrates code-review, anti-slop, security-audit, and update-docs. Not wired into full-review by default - invoke anti-ai-prose separately when the repo has substantial prose worth auditing.
-- **code-review** - catches logic and correctness issues. Anti-ai-prose only touches prose; code-review handles the code itself.
+- **anti-slop** - code quality audit. When auditing a repo, run anti-slop for code and anti-ai-prose for docs. Deliberately complementary.
+- **update-docs** - keeps docs accurate after feature changes. Anti-ai-prose covers voice, update-docs covers factual drift.
+- **prompt-generator** - structures a rough draft into an LLM prompt, for generating cleaner prose next time.
+- **full-review** - orchestrates code-review, anti-slop, security-audit, and update-docs. Anti-ai-prose is not wired in by default; invoke it separately when the repo has substantial prose.
+- **code-review** - logic and correctness. Anti-ai-prose only touches prose.
 
 ---
 
@@ -579,10 +488,9 @@ See `references/output-contract.md` for the full contract.
 2. **Never edit quoted material.** Original words from other authors stay as written.
 3. **Respect genre conventions.** Travel writing, marketing, fiction, and academic prose have legitimate conventions that overlap with AI tells. Flag only when the writing is worse for the device, not because it matches a pattern.
 4. **Every rewrite must be shorter or more specific.** Lateral synonym swaps are not improvements. If the rewrite is longer, the original was fine.
-5. **Plan first, apply that plan only.** When applying fixes after the audit, change only what the report flagged. Do not freelance edits, do not rewrite adjacent prose, and do not chain a second pass of new fixes on top of the applied ones. New findings during application become a follow-up audit, not silent edits.
-6. **Keep the voice of the author.** The goal is prose that sounds like a specific human, not a generic "good writing" rewrite. If you do not know the author's voice, leave stylistic calls alone and only flag the mechanical tells.
+5. **Plan first, apply that plan only.** When applying fixes after the audit, change only what the report flagged. New findings during application become a follow-up audit, not silent edits.
+6. **Keep the voice of the author.** The goal is prose that sounds like a specific human, not a generic "good writing" rewrite. If you do not know the author's voice, flag only the mechanical tells.
 7. **Do not pad the report.** If there are three findings, list three. Not five. Not one inflated to three.
-8. **Run the AI Self-Check** before returning any audit.
-9. **Inline mode is silent.** Applying these rules to your own output produces cleaner prose and nothing else. No report, no findings, no deliverable, no note that the skill ran. A user who wanted an audit will ask for one.
-10. **The user's style outranks these rules.** Explicit instructions, then project instruction files, then genre convention, then this skill. A house style that mandates em dashes or title case is not a finding.
-11. **In your own output, drop the density thresholds.** They exist to stop overflagging someone else's long document. One chat artifact in your own reply is one too many.
+8. **Inline mode is silent.** Applying these rules to your own output produces cleaner prose and nothing else: no report, no findings, no deliverable, no note that the skill ran. A user who wanted an audit will ask for one.
+9. **In your own output, drop the density thresholds.** They exist to stop overflagging someone else's long document. One chat artifact in your own reply is one too many.
+10. **Run the AI Self-Check.** The two mode items apply to every response; the rest before returning an audit.

--- a/skills/anti-ai-prose/references/audit-mode.md
+++ b/skills/anti-ai-prose/references/audit-mode.md
@@ -187,4 +187,3 @@ Report:
   neither says more than the rewrite already does. Ask the author for the missing specifics;
   inventing them would be a P0 trust breach, whoever writes it.
 ```
-

--- a/skills/anti-ai-prose/references/audit-mode.md
+++ b/skills/anti-ai-prose/references/audit-mode.md
@@ -1,0 +1,135 @@
+# Audit mode: workflow and report format
+
+Everything here applies to **audit mode** only - a file, paste, diff, or directory handed over
+for review. Inline mode (filtering your own conversational output) runs none of it: no scoping,
+no severity, no report.
+
+## Workflow
+
+### Step 1: Scope the audit
+
+Default scope based on context:
+- If invoked on a specific file or paste - audit that text
+- If invoked with no target and there are uncommitted changes to `.md` / `.txt` / doc files - audit those
+- If invoked in a code repo with recent commits - audit the docstrings and comments in changed files
+- Otherwise - ask the user for a target
+
+Available scopes:
+- **Single file** - one doc, README, draft, or source file
+- **Directory** - all `.md` / `.rst` / `.txt` under a path
+- **Pasted text** - inline block the user supplies
+- **Recent changes** - git diff against a base
+- **Comments and docstrings only** - scan code files but audit only prose regions
+
+### Step 2: Detect text kind
+
+Different text types have different conventions. Before flagging, identify which applies:
+- **Technical docs** - formal is OK, but vocabulary bans still apply
+- **README / PR / commit** - concise is expected, significance padding is especially jarring
+- **Marketing / product copy** - tonal tells (`boast`, `showcase`) may be intentional but still weaken the writing
+- **Creative fiction** - many tells (tricolons, elegant variation) are legitimate devices; flag only when they read as mechanical
+- **Wiki article** - neutral voice required, promotional language is always a finding
+- **Email** - conversational is expected, formality inflation is a tell
+- **Slides / presentation** - fragments are fine, but vocabulary and tonal tells still apply
+
+### Step 3: Scan for patterns
+
+Apply the four categories (see below). For each match, read the surrounding context - a single instance of an AI word in a 5000-word document is probably noise, but three instances in three paragraphs is a pattern.
+
+**Density heuristic** (rough guide, not a hard rule):
+- **Under 1 flagged item per 500 words** - noise, usually do not flag
+- **2-3 per 500 words** - a pattern, flag the cluster as P2
+- **4+ per 500 words** - dominant voice, P1 severity, recommend structural rewrite
+
+**Short text scaling:** for text under 100 words, any 2+ tells in a single paragraph is P1 severity regardless of the per-500-words threshold. A single sentence crammed with AI vocabulary is worse than a long doc with scattered instances.
+
+Density only applies to vocabulary and syntax tells. A single travel-guide paragraph is enough to flag on its own. One fabricated citation is always P1.
+
+Classify each finding by category, action, and severity:
+
+**Action:**
+- **Fix** - clearly a tell, should change
+- **Consider** - judgment call, present it and let the user decide
+- **Fine** - matches the pattern but is justified (note why, move on)
+
+**Severity:**
+- **P1** - cluster of tells that makes the piece sound unmistakably AI-written; vague attribution passing opinion as fact; fabricated citations or broken references
+- **P2** - vocabulary or syntax tells that dull the voice without breaking trust; formulaic structures ("Despite its X, faces challenges..."); travel-guide voice in non-travel writing
+- **P3** - single instances of banned vocabulary; formatting nits (em-dash usage, unnecessary bold); tricolon overuse
+
+### Step 4: Report and fix
+
+Present findings grouped by category. For each Fix-level item, show the concrete rewrite. Rewrites should be **shorter** or **more specific** - never longer.
+
+**Plan first, apply that plan only.** Produce the audit report as the improvement plan before any
+rewrites are merged. If the user then asks for the fixes to be applied, change only what the plan
+flagged. Do not freelance edits outside the plan, do not "while we're here" rewrite adjacent
+prose, and do not chain a second pass of new fixes on top of the applied ones in the same step.
+This keeps the work auditable and prevents a cheap model from re-drafting the piece worse than
+the original. If new findings emerge while applying, surface them as a second audit, not as
+silent edits.
+
+---
+
+````markdown
+## Anti-AI-Prose Audit: [scope]
+
+### Findings
+
+#### [Category Name] ([count] items)
+
+**[action]** ([severity]) `path/to/file:line` - [description]
+
+> before: [quoted text from the source]
+
+> after: [suggested rewrite]
+
+### Summary
+- X findings across Y files / sections
+- [overall read: does the piece sound human?]
+- [top-level observation: e.g., "vocabulary is mostly fine but the structure is formulaic"]
+````
+
+Rules for the report itself:
+- **Omit empty categories.** If there are no formatting tells, do not write an empty "Formatting Tells (0 items)" heading
+- **Order within a category** P1 > P2 > P3
+- **Deletion fixes have no "after"** - write `> after: (cut)` or just state the delete in the description
+- **Apply these rules to your own audit.** Run the Self-Check on the report before returning it - an audit written in AI-slop voice is not credible
+
+Keep it concise. Show the before/after pair. Do not lecture about why AI writing is bad - the user already knows.
+
+### Worked example (anchor the format)
+
+Input (README snippet, 48 words):
+
+> In today's fast-paced world, our platform empowers developers to seamlessly navigate the complex landscape of modern APIs. Built with a commitment to excellence, it boasts robust features and fosters innovation. Whether you're a beginner or expert, this tool serves as a pivotal resource for your journey toward better software.
+
+Report:
+
+```
+## Anti-AI-Prose Audit: README snippet (48 words)
+
+### Findings
+
+#### Vocabulary Tells (9 items)
+
+**Fix** (P1) line 1 - cluster of 9 flagged words in 48 words: far above 4/500 threshold
+> before: empowers / seamlessly / navigate / landscape / commitment to / boasts / fosters / pivotal / journey toward
+> after: (rewrite, see below)
+
+#### Tonal Tells (2 items)
+
+**Fix** (P1) line 1 - scaffolding padding and significance padding
+> before: "In today's fast-paced world"
+> after: (cut)
+
+**Fix** (P2) line 1 - promotional tone
+> before: "Built with a commitment to excellence"
+> after: (cut)
+
+### Summary
+- 11 findings, one paragraph, dominant AI voice
+- Rewrite: "An HTTP API client for Python. Handles auth, retries, and pagination. Works with any OpenAPI 3.x spec."
+- Down from 48 words to 22, with concrete claims instead of posture
+```
+

--- a/skills/anti-ai-prose/references/audit-mode.md
+++ b/skills/anti-ai-prose/references/audit-mode.md
@@ -34,16 +34,37 @@ Different text types have different conventions. Before flagging, identify which
 
 ### Step 3: Scan for patterns
 
-Apply the four categories (see below). For each match, read the surrounding context - a single instance of an AI word in a 5000-word document is probably noise, but three instances in three paragraphs is a pattern.
+Apply the four categories from `SKILL.md`. For each match, read the surrounding context - a single instance of an AI word in a 5000-word document is probably noise, but three instances in three paragraphs is a pattern.
 
 **Density heuristic** (rough guide, not a hard rule):
-- **Under 1 flagged item per 500 words** - noise, usually do not flag
-- **2-3 per 500 words** - a pattern, flag the cluster as P2
+- **Under 1 flagged item per 500 words** - noise. Do not flag, unless the instance sits in a
+  high-visibility position (title, opening sentence, summary, callout), where a single tell
+  still shapes the reader's impression. Those isolated flags are P3, never higher
+- **1 to under 2 per 500 words** - borderline. Flag only what a reader would notice, at P3
+- **2 to under 4 per 500 words** - a pattern, flag the cluster as P2
 - **4+ per 500 words** - dominant voice, P1 severity, recommend structural rewrite
 
-**Short text scaling:** for text under 100 words, any 2+ tells in a single paragraph is P1 severity regardless of the per-500-words threshold. A single sentence crammed with AI vocabulary is worse than a long doc with scattered instances.
+**Short text scaling:** for text under 100 words, 2+ tells in a single paragraph is P1 regardless of the per-500-word threshold. A single sentence crammed with AI vocabulary is worse than a long doc with scattered instances. Formatting nits do not count toward that 2, and never escalate past P3 on their own: two curly quotes in a short paragraph is P3, not P1.
 
-Density only applies to vocabulary and syntax tells. A single travel-guide paragraph is enough to flag on its own. One fabricated citation is always P1.
+**What density gates.** One list, authoritative:
+
+- **Gated** (need a cluster before they are findings): every check in category 1 (vocabulary)
+  and category 2 (syntax, which includes participle tails, false ranges, unnamed-actor
+  passives, and dense sentence stacking), plus the sentence-level checks in category 3 -
+  hedging and qualifier stacking, scaffolding padding, confident filler, vague attribution,
+  significance padding, feeling-instead-of-mechanism. One instance is noise; the pattern is
+  the finding. Exception: an AI fallback character name is a category 1 check that is not
+  gated - one such protagonist name is the finding, per `references/fiction-tells.md`.
+- **Not gated** (one instance is the finding): whole-passage register tells, meaning
+  travel-guide voice and promotional tone, at P2; the formulaic article shape, which is a
+  document-level structure occurring once, at P2; chat artifacts, where one is one too many in
+  either mode, at P2 in delivered text; and trust breaches at P0. Cutoff disclaimers are a
+  trust breach, not a chat artifact: they assert a limit the named author does not have, so
+  they are P0 in anything shipped under a human byline.
+
+Formatting tells sit outside the ratio entirely: they do not count toward the per-500-word
+denominator, isolated nits are P3, and they never escalate on density alone. The exception is
+the LLM output bugs, which are trust breaches at P0.
 
 Classify each finding by category, action, and severity:
 
@@ -52,10 +73,12 @@ Classify each finding by category, action, and severity:
 - **Consider** - judgment call, present it and let the user decide
 - **Fine** - matches the pattern but is justified (note why, move on)
 
-**Severity:**
-- **P1** - cluster of tells that makes the piece sound unmistakably AI-written; vague attribution passing opinion as fact; fabricated citations or broken references
-- **P2** - vocabulary or syntax tells that dull the voice without breaking trust; formulaic structures ("Despite its X, faces challenges..."); travel-guide voice in non-travel writing
+**Severity** (the shared contract's `P0 | P1 | P2 | P3 | info` scale, mapped to prose):
+- **P0** - the text misleads or exposes the author: a fabricated citation, a factual claim invented to fill a gap, an unredacted secret or private hostname, or raw generator residue (`turn0search0`, `oaicite`, `As of my last update`) left in published text. P0 is about trust, not voice
+- **P1** - cluster of tells that makes the piece sound unmistakably AI-written; vague attribution passing opinion as fact; broken references
+- **P2** - vocabulary or syntax tells that dull the voice without breaking trust; formulaic article shape; travel-guide voice in non-travel writing
 - **P3** - single instances of banned vocabulary; formatting nits (em-dash usage, unnecessary bold); tricolon overuse
+- **info** - a pattern match you checked and cleared (a domain term of art, a genre convention), worth recording so the next reader does not re-litigate it. Never an action item
 
 ### Step 4: Report and fix
 
@@ -71,6 +94,28 @@ silent edits.
 
 ---
 
+## Report template
+
+Audit mode produces two surfaces, and they are shaped differently. Do not try to nest one
+inside the other.
+
+1. **In the transcript:** the boxed contract header, the category-grouped summary templated
+   below, then the boxed conclusion and conclusion table. This is where before/after pairs go,
+   because that is what the reader is scanning.
+2. **In the deliverable file** (`docs/local/audits/anti-ai-prose/<date>-<slug>.md`): the shared
+   contract's own shape - findings grouped by priority under `## P0 - Must fix` style headings,
+   each a `- [ ]` checkbox with `File` / `Description` / `Suggested action` / `Fix applied`.
+   Number findings `#1`, `#2`, ... monotonically across the whole file; the conclusion table's
+   `#` column refers to those numbers. See `references/output-contract.md` for the exact shape.
+
+Same findings, same numbering, two renderings. **Assign `#N` in priority order** - all P0s
+first, then P1, P2, P3, info - and carry that number into both surfaces and the conclusion
+table. Numbering by priority rather than by category is what keeps the deliverable file
+monotonic when it regroups under `## P0 - Must fix` style headings; the transcript then shows
+the same numbers out of order within its category grouping, which is expected. A finding is one record with one
+number, however many individual flagged items it covers: a cluster of nine vocabulary hits
+reported as one cluster is one finding, not nine. The template below is surface 1.
+
 ````markdown
 ## Anti-AI-Prose Audit: [scope]
 
@@ -78,7 +123,7 @@ silent edits.
 
 #### [Category Name] ([count] items)
 
-**[action]** ([severity]) `path/to/file:line` - [description]
+**#[N] [action]** ([severity]) `path/to/file:line` - [description]
 
 > before: [quoted text from the source]
 
@@ -92,44 +137,54 @@ silent edits.
 
 Rules for the report itself:
 - **Omit empty categories.** If there are no formatting tells, do not write an empty "Formatting Tells (0 items)" heading
-- **Order within a category** P1 > P2 > P3
+- **Order within a category** P0 > P1 > P2 > P3 > info
 - **Deletion fixes have no "after"** - write `> after: (cut)` or just state the delete in the description
 - **Apply these rules to your own audit.** Run the Self-Check on the report before returning it - an audit written in AI-slop voice is not credible
 
 Keep it concise. Show the before/after pair. Do not lecture about why AI writing is bad - the user already knows.
 
-### Worked example (anchor the format)
+### Worked example (anchors the body format; the contract still wraps it)
 
-Input (README snippet, 48 words):
+Input (README snippet, 49 words):
 
 > In today's fast-paced world, our platform empowers developers to seamlessly navigate the complex landscape of modern APIs. Built with a commitment to excellence, it boasts robust features and fosters innovation. Whether you're a beginner or expert, this tool serves as a pivotal resource for your journey toward better software.
 
 Report:
 
 ```
-## Anti-AI-Prose Audit: README snippet (48 words)
+## Anti-AI-Prose Audit: README snippet (49 words)
 
 ### Findings
 
-#### Vocabulary Tells (9 items)
+#### Vocabulary Tells (1 finding, 10 flagged words)
 
-**Fix** (P1) line 1 - cluster of 9 flagged words in 48 words: far above 4/500 threshold
-> before: empowers / seamlessly / navigate / landscape / commitment to / boasts / fosters / pivotal / journey toward
+**#1 Fix** (P1) `README.md:1` - cluster of 10 flagged words in 49 words: far above 4/500 threshold
+> before: empowers / seamlessly / navigate / landscape / commitment to / boasts / robust / fosters / pivotal / journey toward
 > after: (rewrite, see below)
 
-#### Tonal Tells (2 items)
+#### Syntax Tells (1 finding)
 
-**Fix** (P1) line 1 - scaffolding padding and significance padding
+**#3 Fix** (P2) `README.md:1` - copula avoidance
+> before: "this tool serves as a pivotal resource"
+> after: "this tool is X" (name the thing)
+
+#### Tonal Tells (2 findings)
+
+**#2 Fix** (P1) `README.md:1` - scaffolding padding and significance padding
 > before: "In today's fast-paced world"
 > after: (cut)
 
-**Fix** (P2) line 1 - promotional tone
+**#4 Fix** (P2) `README.md:1` - promotional tone
 > before: "Built with a commitment to excellence"
 > after: (cut)
 
 ### Summary
-- 11 findings, one paragraph, dominant AI voice
-- Rewrite: "An HTTP API client for Python. Handles auth, retries, and pagination. Works with any OpenAPI 3.x spec."
-- Down from 48 words to 22, with concrete claims instead of posture
+- 4 findings covering 13 flagged items, one paragraph, dominant AI voice
+- Rewrite, using only what the source actually claims: "A tool for working with modern APIs.
+  Usable by beginners and experts." 49 words down to 12.
+- Note what the rewrite cannot do: the source never says what the product *is*, so no honest
+  rewrite can add that. `platform` and `tool` are the only self-descriptions available, and
+  neither says more than the rewrite already does. Ask the author for the missing specifics;
+  inventing them would be a P0 trust breach, whoever writes it.
 ```
 

--- a/skills/anti-ai-prose/references/fiction-tells.md
+++ b/skills/anti-ai-prose/references/fiction-tells.md
@@ -1,13 +1,68 @@
-# Fiction Name Tells
+# Fiction and line-editing tells
+
+Deep-dive reference for the checks in `SKILL.md` that matter most in fiction and other
+long-form prose: invented character names, adverb density, and forced synonym variation.
+The first is fiction-only; the last two apply to any prose but earn their detail here
+because line editors hit them hardest in narrative text.
+
+---
+
+## Adverb crutch (-ly modifiers)
+
+LLMs reach for `-ly` adverbs to inflate description and dodge precise verb choice: `said
+softly`, `ran quickly`, `smiled warmly`, `walked slowly`, `whispered quietly`. Each one in
+isolation is acceptable English. Density is the tell. The classical fiction-editing test
+(Stephen King and most line editors): if dropping the adverb does not change the meaning,
+the verb is the problem.
+
+**Detect:**
+- `-ly` adverbs modifying speech tags: `said softly`, `whispered quietly`, `shouted loudly`,
+  `replied curtly`
+- Adverbs that restate the verb: `whispered quietly`, `shouted loudly`, `ran quickly`,
+  `mumbled under his breath`
+- Multiple `-ly` adverbs in adjacent sentences - a passage sprinkled with them rather than
+  one used for emphasis
+- Stacking with hedges: `gently`, `slightly`, `rather`, `somewhat` modifying the same verb or
+  following each other across a paragraph. Overlaps "Hedging and qualifier stacking" in
+  category 3; count it once, under the denser cluster
+
+**Fix:** Prefer a stronger verb. `said softly` -> `whispered`. `ran quickly` -> `sprinted`.
+`smiled warmly` -> `beamed`. `looked carefully at` -> `studied`. Delete adverbs that restate
+the verb outright.
+
+**Exception:** Keep the adverb when it carries information the verb cannot. `said
+reluctantly`, `answered honestly`, `arrived late`, `she nodded slowly` (when the slowness is
+the point) all earn their place. The test: drop the adverb. If meaning shifts, keep it. If
+only rhythm shifts, the verb was weak.
+
+---
+
+## Elegant variation
+
+LLMs avoid repeating a noun within a paragraph, substituting increasingly strained synonyms.
+A character named Alice becomes `the protagonist`, `the main character`, `the young woman`,
+`the eponymous heroine` in four consecutive sentences.
+
+**Detect:** the same entity referred to by 3+ different nouns in close proximity; strained
+synonyms where a pronoun or name repetition would be natural; different technical terms for
+the same concept within one document.
+
+**Fix:** Use the name, or a pronoun. Repetition is fine. Forced variation is worse than
+repetition.
+
+**Exception:** deliberate variation that carries information - `the witness` versus `the
+defendant` for the same person at different points in a trial narrative - is craft, not a
+tell. Flag only variation that adds nothing but novelty.
+
+---
 
 ## AI fallback character names
 
 A documented tell across Claude, ChatGPT, Gemini, DeepSeek, and most open-source models:
 when asked to invent character names without strong setting constraints, models converge on a
 small "no-baggage" set. The 2025 Name of the Year (per Namerology) is **Elara** specifically
-because of AI saturation. A high-school teacher's grading rubric now docks 99 points for
-protagonist=Elara. The phenomenon is well enough documented that the name from the fallback set
-is itself the tell.
+because of AI saturation. The phenomenon is documented well enough that a name from the
+fallback set is itself the tell.
 
 **The fallback set** (incomplete; the phonetic pattern below is more reliable than the list):
 
@@ -52,9 +107,6 @@ than reaching for `Dr. Thorne`.
 produces Aurora or Cassius can use them. The failure is the model reaching for these names
 because it had no other ideas, not the names themselves. For prior-draft characters whose names
 were chosen deliberately, do not rename without explicit permission.
-
-For fiction-specific handling with mechanism and fix detail, see the `short-form-fiction`
-skill's `ai-slop-fiction.md` reference (section: AI fallback character names).
 
 Sources: Namerology (2025 Name of the Year is Elara); ChuckMcSneed, "Name Diversity in LLMs
 Experiment" (HuggingFace); Guillaume Laforge, "The Sci-Fi Naming Problem" (glaforge.dev, 2025).

--- a/skills/anti-ai-prose/references/fiction-tells.md
+++ b/skills/anti-ai-prose/references/fiction-tells.md
@@ -60,9 +60,14 @@ tell. Flag only variation that adds nothing but novelty.
 
 A documented tell across Claude, ChatGPT, Gemini, DeepSeek, and most open-source models:
 when asked to invent character names without strong setting constraints, models converge on a
-small "no-baggage" set. The 2025 Name of the Year (per Namerology) is **Elara** specifically
-because of AI saturation. The phenomenon is documented well enough that a name from the
-fallback set is itself the tell.
+small "no-baggage" set. Namerology named **Elara** its 2025 Name of the Year explicitly as
+"the favorite name of AI", while the name remains rare in actual US birth data. The
+phenomenon is documented well enough that a name from the fallback set is itself the tell.
+
+The training data shows the same concentration. Laforge searched a Kaggle sci-fi dataset of
+roughly 10,000 books and found `Dr Thorne` in 26 book descriptions with 204 total
+appearances, and `Anya` across 8 descriptions with about the same number of appearances. The
+models are not inventing these names so much as returning the ones their corpus over-supplies.
 
 **The fallback set** (incomplete; the phonetic pattern below is more reliable than the list):
 
@@ -71,7 +76,7 @@ fallback set is itself the tell.
 | Female / femme-coded | Elara, Elena, Elana, Lena, Lyra, Aria, Aurora, Nova, Luna, Selene, Althea, Anya, Mira, Clara, Evelyn, Isabella, Seraphina, Isolde, Lily |
 | Male / masc-coded | Kael, Kaelan, Kaleb, Vale, Vance, Cassius, Caspian, Adrian, Orion, Atlas, Phoenix, Rylan, Theron, Damon, Silas, Ezra, Malachi, Jax, Dax, Rook |
 | Surnames | Voss, Vasquez, Thorne, Vale, Vance, Black, Hart, Cross, Reed, Knox, Stone, Hawk, Rourke |
-| Composite sci-fi | Elara Voss (DeepSeek), Elena Vasquez / Elana Vasquez (Claude Opus 4), Dr. Thorne / Dr. Aris Thorne (Gemini 2.5 Pro; 204 instances across 26 books in the 10,000-title Kaggle sci-fi corpus) |
+| Composite sci-fi | Elara Voss (DeepSeek), Elena Vasquez / Elana Vasquez (Claude Opus 4), Dr. Thorne / Dr. Aris Thorne (Gemini 2.5 Pro) |
 
 **The phonetic tell** (more reliable than memorizing the list):
 
@@ -86,9 +91,12 @@ fallback set is itself the tell.
 **Why it happens:** models filter names with demographic baggage to avoid offense or
 distraction. Brittany sounds millennial; Karen carries political residue; Mohammed signals
 Muslim; Mihai signals Romanian. What's left is the no-baggage set - names so unfamiliar that
-they cannot insult anyone, which is exactly why they keep recurring. Per the ChuckMcSneed
-HuggingFace experiment, instruct models showed up to 77% skew toward their top 10 names while
-base models stayed near 4% - the phenomenon is an artifact of alignment, not raw capability.
+they cannot insult anyone, which is exactly why they keep recurring. The ChuckMcSneed
+HuggingFace experiment measured the concentration: Mistral-Large put 77% of its generations
+into its top 10 names, and Qwen2.5-Instruct reached for one `K` name nearly a third of the
+time. Base models were mostly far flatter, topping out near 4% for their single most common
+pick - though base Qwen2.5 hit 28%, so the split is a strong tendency rather than a clean
+line. Instruction tuning drives most of the skew, not raw capability.
 
 **Detect:**
 
@@ -108,5 +116,11 @@ produces Aurora or Cassius can use them. The failure is the model reaching for t
 because it had no other ideas, not the names themselves. For prior-draft characters whose names
 were chosen deliberately, do not rename without explicit permission.
 
-Sources: Namerology (2025 Name of the Year is Elara); ChuckMcSneed, "Name Diversity in LLMs
-Experiment" (HuggingFace); Guillaume Laforge, "The Sci-Fi Naming Problem" (glaforge.dev, 2025).
+Sources (verified 2026-08-19):
+
+- Namerology, "The 2025 Name of the Year is Elara, the favorite name of AI" (2025-12-15):
+  <https://namerology.com/2025/12/15/2025-name-of-the-year-is-elara-the-favorite-name-of-ai/>
+- ChuckMcSneed, "Exploring Name Diversity in Modern LLMs: A Grimdark Trilogy Experiment"
+  (HuggingFace): <https://huggingface.co/blog/ChuckMcSneed/name-diversity-in-llms-experiment>
+- Guillaume Laforge, "The Sci-Fi naming problem: Are LLMs less creative than we think?"
+  (2025-07-22): <https://glaforge.dev/posts/2025/07/22/the-sci-fi-naming-problem-are-llms-less-creative-than-we-think/>

--- a/skills/anti-ai-prose/references/formatting-tells.md
+++ b/skills/anti-ai-prose/references/formatting-tells.md
@@ -1,0 +1,71 @@
+# Formatting tells: the long tail
+
+Deep-dive reference for category 4 in `SKILL.md`. The four highest-frequency formatting
+tells (em dashes, title-case headings, excessive bold, bullet salad) stay in `SKILL.md`
+because they fire on almost every draft. The rest live here.
+
+**Fix, for all of them:** match the surrounding project's conventions. With no convention,
+default to plain ASCII, sentence case, minimal bold, paragraph prose.
+
+---
+
+## Punctuation and character artifacts
+
+- **Curly quotes** (U+201C/U+201D and U+2018/U+2019) in technical writing that should use
+  ASCII `"` and `'`. Named by codepoint here because this collection is ASCII-only
+- **Emoji** in professional prose where decoration is the only purpose
+- **Markdown artifacts in rendered text** - `**bold**` appearing as literal characters
+  because the paste lost its formatting
+
+## Layout habits
+
+- **Three-bullet-happy layouts** - suspicious when every list has exactly three items.
+  Overlaps forced tricolons in category 2; count it once, under whichever cluster is denser
+- **Decorative thematic breaks** - `---` before every `##`. Dividers that mark a real phase
+  change are fine; decoration is not
+
+## LLM output bugs
+
+Residue from the generating tool that no human would type: `turn0search0`,
+`contentReference`, `oaicite`, `attached_file`, hallucinated wiki-style shortcuts.
+(`+1` is ordinary human writing - do not flag it.)
+
+**Fix:** delete. These are P0 in published text - they prove it was pasted from a chat window
+unread, which is a trust breach rather than a voice problem.
+
+---
+
+## Colon as a mid-sentence connector
+
+A colon whose right side is a full clause that would read the same as its own sentence,
+adding a beat of false setup: `If you're coming from traditional automation: instead of
+registering event handlers, you describe conditions.`
+
+**Fix:** End the sentence, or rewrite so the point stands without the comparison framing.
+
+**Exception:** colons before lists, definitions, quotes, and code blocks are correct, as is
+one introducing a real specification (`One rule: never force-push shared branches`).
+
+---
+
+## Inline-header lists that restate themselves
+
+A bold label followed by a colon whose text repeats the label:
+`**Performance:** Performance improved by 12%.`
+
+**Fix:** Convert to prose, or drop the label. `Performance improved by 12%.`
+
+**Exception:** a bold lead-in ending in a period that names the item and is followed by new
+detail is a definition list, not a tell: `**Schema in TypeScript.** Tables live in one file.`
+
+---
+
+## What NOT to flag from this reference
+
+- **Bold where it signals a term or path** - bolding a defined term on first use is standard
+- **Colons before lists, definitions, quotes, or code blocks** - that is what colons are for.
+  Only the mid-sentence clause joint is a tell
+- **Definition-list bold lead-ins** - `**Term.** New detail follows.` is a real pattern. The
+  tell is only the label that restates itself
+- **Emoji in projects that use them by convention** - changelogs and READMEs that already
+  carry a consistent emoji legend

--- a/skills/anti-ai-prose/references/output-contract.md
+++ b/skills/anti-ai-prose/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/anti-ai-prose/references/output-contract.md
+++ b/skills/anti-ai-prose/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/anti-ai-prose/references/plain-speech.md
+++ b/skills/anti-ai-prose/references/plain-speech.md
@@ -1,0 +1,150 @@
+# Plain speech: concreteness, actor, sentence load, voice
+
+Deep-dive reference for the plain-speech checks in `SKILL.md`. These four patterns
+are structural rather than lexical: no wordlist catches them, and each one needs a
+rewrite rather than a substitution.
+
+Folded in from [poteto/plugins](https://github.com/poteto/plugins) `pstack/skills/unslop`
+(MIT), which contributed the concreteness test, the actor test, and the voice-restoration
+guidance.
+
+---
+
+## 1. Abstract metaphor nouns
+
+Words that read as technical but usually stand in for a plainer, concrete one. LLMs
+reach for them when the text needs to sound like systems thinking.
+
+| Metaphor noun | Plain replacement |
+|---|---|
+| substrate | base, layer, foundation |
+| wedge | opening, first step, add |
+| vector | way, method, path |
+| locus | place, point, center |
+| vantage | view, position |
+| nexus | link, junction, hub |
+| primitive (as noun) | building block, basic type, operation |
+| harness (as metaphor) | setup, runner, wrapper |
+| surface (as in "API surface") | the API itself, the exposed calls |
+| bedrock | base, foundation |
+| scaffolding (as metaphor) | setup, structure, boilerplate |
+| modality | mode, kind, channel |
+| paradigm | model, approach, style |
+| gold-plating | more than the job needs |
+
+**Detect:** the noun carries no measurement, no referent, and no consequence. `We
+wedged the check into the auth vector` names nothing that exists in the codebase.
+
+**Fix:** name the concrete thing. `We added the check to the login handler.`
+
+**Exception:** these are terms of art in their home domains. `Substrate` in materials
+science and biology, `vector` in linear algebra, epidemiology, and graphics, `primitive`
+in graphics and cryptography, `harness` in test tooling, `locus` in genetics. Domain
+context overrides the flag, same as the vocabulary table in `SKILL.md`.
+
+---
+
+## 2. Say the concrete thing
+
+The tell is prose that names a feeling instead of a mechanism, or wraps a simple point
+in abstract framing. It reads well and tells the reader nothing they can act on.
+
+**Detect:** ask what the sentence tells the reader to do or know. If it cannot be
+restated as a concrete instruction, a fact, or a number, it is padding.
+
+| Names a feeling | Names the mechanism |
+|---|---|
+| the database stays close at hand | `db.query()` runs in-process, no network hop |
+| SQL you can read | `.toSQL()` returns the exact string sent to the database |
+| types that follow your schema | a column rename fails the build |
+| a smooth developer experience | one command, no config file |
+| the system scales gracefully | tested to 12k concurrent connections |
+
+**Fix:** replace with the mechanism, a number, or an instruction. If none exists, cut
+the sentence. A sentence that survives only as atmosphere is not carrying weight.
+
+**Exception:** genuine motivation paragraphs in a README or a design doc can state a
+goal before the mechanism. `We wanted queries to fail at compile time` is a stated
+intent, not a feeling substituted for a fact. Flag when the abstract sentence is the
+only thing on offer.
+
+---
+
+## 3. Passive voice with an unnamed actor
+
+LLMs default to `is/are/was/were + past participle`, which drops the actor. The reader
+then cannot tell what component is responsible.
+
+**Detect:** scan for the auxiliary plus participle, then ask who does it. If the answer
+is in the text but not in the sentence, the sentence is weaker than it needs to be.
+
+| Passive | Actor named |
+|---|---|
+| queries are validated | the compiler validates queries |
+| the file is parsed by the loader | the loader parses the file |
+| errors are logged | the middleware logs errors |
+| the token is refreshed automatically | the SDK refreshes the token before each call |
+
+**Fix:** promote the actor to subject.
+
+**Exception:** passive is correct when the actor is unknown, irrelevant, or deliberately
+withheld. `The record was deleted in 2019` is fine when nobody knows by whom. Incident
+writeups often use passive on purpose to keep blame off individuals. Scientific method
+sections use it by convention. Do not flag those.
+
+---
+
+## 4. Dense sentence stacking
+
+One idea per sentence. If the reader has to backtrack to parse a sentence, it is doing
+too much.
+
+**Detect:**
+- Three or more clauses chained with commas, `and`, `which`, and `while`
+- A sentence that needs a second read to find its subject
+- Nested qualifiers that push the verb far from its subject
+
+**Fix:** split at the clause boundary, or drop the clause that carries the least. Two
+plain sentences beat one balanced one.
+
+> before: The loader, which reads from the cache when a valid entry exists and otherwise
+> falls back to the network, parses the manifest before handing it to the resolver, which
+> then walks the dependency graph.
+
+> after: The loader reads from the cache, falling back to the network on a miss. It parses
+> the manifest and hands it to the resolver. The resolver walks the dependency graph.
+
+---
+
+## 5. Restoring voice
+
+Removing tells is half the work. Prose stripped of every pattern and given nothing back
+reads as sterile, which is its own tell. When the audit recommends a rewrite, the
+replacement should carry these:
+
+- **Have a position.** React to the facts rather than listing balanced pros and cons.
+  A recommendation with a reason beats a neutral survey.
+- **Vary rhythm.** Short sentences. Then a longer one that takes its time and earns the
+  extra clauses. Uniform sentence length is a machine signature.
+- **Acknowledge complexity.** "Fast, but it drops the connection under load" beats "fast".
+- **Use first person when it fits.** `I would not ship this` is not unprofessional.
+- **Allow some asymmetry.** Perfectly parallel structure across every section reads as
+  generated. A section that is longer because it needed to be is fine.
+- **Be specific.** Not "there are concerns about the schedule" but "the migration lands
+  the same week as the audit".
+
+**Applying this in an audit:** voice notes are `Consider`-level, never `Fix`. Voice is
+the author's call. Flag mechanical tells as findings; offer voice suggestions as options
+and say so explicitly. Do not rewrite a piece into your own voice under the banner of
+removing AI tells.
+
+---
+
+## What NOT to flag from this reference
+
+- **Domain terms of art** for the metaphor nouns above, per each entry's exception
+- **Deliberate passive** where the actor is unknown, irrelevant, or withheld on purpose
+- **Long sentences that parse on first read.** Length is not the tell; backtracking is
+- **Stated intent** in a motivation paragraph, when the mechanism follows it
+- **A single abstract sentence** in an otherwise concrete piece. All four patterns here
+  are density findings, subject to the same thresholds as the vocabulary tells

--- a/skills/anti-ai-prose/references/plain-speech.md
+++ b/skills/anti-ai-prose/references/plain-speech.md
@@ -1,12 +1,14 @@
 # Plain speech: concreteness, actor, sentence load, voice
 
-Deep-dive reference for the plain-speech checks in `SKILL.md`. These four patterns
-are structural rather than lexical: no wordlist catches them, and each one needs a
-rewrite rather than a substitution.
+Deep-dive reference for the plain-speech checks in `SKILL.md`: abstract metaphor nouns,
+the concreteness test, the actor test, sentence load, and voice restoration. The last four
+are structural rather than lexical - no wordlist catches them, and each needs a rewrite
+rather than a substitution. Two further plain-speech checks, superficial participle tails
+and false ranges, are fully covered in `SKILL.md` and have no deep dive here.
 
 Folded in from [poteto/plugins](https://github.com/poteto/plugins) `pstack/skills/unslop`
-(MIT), which contributed the concreteness test, the actor test, and the voice-restoration
-guidance.
+(MIT), which contributed the abstract-metaphor-noun list, the concreteness test, the actor
+test, the sentence-load test, and the voice-restoration guidance.
 
 ---
 
@@ -146,5 +148,5 @@ removing AI tells.
 - **Deliberate passive** where the actor is unknown, irrelevant, or withheld on purpose
 - **Long sentences that parse on first read.** Length is not the tell; backtracking is
 - **Stated intent** in a motivation paragraph, when the mechanism follows it
-- **A single abstract sentence** in an otherwise concrete piece. All four patterns here
-  are density findings, subject to the same thresholds as the vocabulary tells
+- **A single abstract sentence** in an otherwise concrete piece. The patterns here are
+  density findings, subject to the same thresholds as the vocabulary tells

--- a/skills/anti-slop/references/output-contract.md
+++ b/skills/anti-slop/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/anti-slop/references/output-contract.md
+++ b/skills/anti-slop/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/arch-btw/references/output-contract.md
+++ b/skills/arch-btw/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/arch-btw/references/output-contract.md
+++ b/skills/arch-btw/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/backend-api/references/output-contract.md
+++ b/skills/backend-api/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/backend-api/references/output-contract.md
+++ b/skills/backend-api/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/browse/references/output-contract.md
+++ b/skills/browse/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/browse/references/output-contract.md
+++ b/skills/browse/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/ci-cd/references/output-contract.md
+++ b/skills/ci-cd/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/ci-cd/references/output-contract.md
+++ b/skills/ci-cd/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/cluster-health/references/output-contract.md
+++ b/skills/cluster-health/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/cluster-health/references/output-contract.md
+++ b/skills/cluster-health/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/code-review/references/output-contract.md
+++ b/skills/code-review/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/code-review/references/output-contract.md
+++ b/skills/code-review/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/code-slimming/references/output-contract.md
+++ b/skills/code-slimming/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/code-slimming/references/output-contract.md
+++ b/skills/code-slimming/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/command-prompt/references/output-contract.md
+++ b/skills/command-prompt/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/command-prompt/references/output-contract.md
+++ b/skills/command-prompt/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/databases/references/output-contract.md
+++ b/skills/databases/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/databases/references/output-contract.md
+++ b/skills/databases/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/debian-ubuntu/references/output-contract.md
+++ b/skills/debian-ubuntu/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/debian-ubuntu/references/output-contract.md
+++ b/skills/debian-ubuntu/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/debug-triage/references/output-contract.md
+++ b/skills/debug-triage/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/debug-triage/references/output-contract.md
+++ b/skills/debug-triage/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/deep-audit/references/output-contract.md
+++ b/skills/deep-audit/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/deep-audit/references/output-contract.md
+++ b/skills/deep-audit/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/deep-grill/references/output-contract.md
+++ b/skills/deep-grill/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/deep-grill/references/output-contract.md
+++ b/skills/deep-grill/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/dev-cycle/references/output-contract.md
+++ b/skills/dev-cycle/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/dev-cycle/references/output-contract.md
+++ b/skills/dev-cycle/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/docker/references/output-contract.md
+++ b/skills/docker/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/docker/references/output-contract.md
+++ b/skills/docker/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/firewall-appliance/references/output-contract.md
+++ b/skills/firewall-appliance/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/firewall-appliance/references/output-contract.md
+++ b/skills/firewall-appliance/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/frontend-design/references/output-contract.md
+++ b/skills/frontend-design/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/frontend-design/references/output-contract.md
+++ b/skills/frontend-design/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/full-review/references/output-contract.md
+++ b/skills/full-review/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/full-review/references/output-contract.md
+++ b/skills/full-review/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/git/references/output-contract.md
+++ b/skills/git/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/git/references/output-contract.md
+++ b/skills/git/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/handoff/references/output-contract.md
+++ b/skills/handoff/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/handoff/references/output-contract.md
+++ b/skills/handoff/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/jekyll-hyde/references/output-contract.md
+++ b/skills/jekyll-hyde/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/jekyll-hyde/references/output-contract.md
+++ b/skills/jekyll-hyde/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/kali-linux/references/output-contract.md
+++ b/skills/kali-linux/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/kali-linux/references/output-contract.md
+++ b/skills/kali-linux/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/kubernetes/references/output-contract.md
+++ b/skills/kubernetes/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/kubernetes/references/output-contract.md
+++ b/skills/kubernetes/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/localize/references/output-contract.md
+++ b/skills/localize/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/localize/references/output-contract.md
+++ b/skills/localize/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/lockpick/references/output-contract.md
+++ b/skills/lockpick/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/lockpick/references/output-contract.md
+++ b/skills/lockpick/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/mcp/references/output-contract.md
+++ b/skills/mcp/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/mcp/references/output-contract.md
+++ b/skills/mcp/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/networking/references/output-contract.md
+++ b/skills/networking/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/networking/references/output-contract.md
+++ b/skills/networking/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/nixos-btw/references/output-contract.md
+++ b/skills/nixos-btw/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/nixos-btw/references/output-contract.md
+++ b/skills/nixos-btw/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/observability/references/output-contract.md
+++ b/skills/observability/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/observability/references/output-contract.md
+++ b/skills/observability/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/prompt-generator/references/output-contract.md
+++ b/skills/prompt-generator/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/prompt-generator/references/output-contract.md
+++ b/skills/prompt-generator/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/rhel-fedora/references/output-contract.md
+++ b/skills/rhel-fedora/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/rhel-fedora/references/output-contract.md
+++ b/skills/rhel-fedora/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/roadmap/references/output-contract.md
+++ b/skills/roadmap/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/roadmap/references/output-contract.md
+++ b/skills/roadmap/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/routine-writer/references/output-contract.md
+++ b/skills/routine-writer/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/routine-writer/references/output-contract.md
+++ b/skills/routine-writer/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/security-audit/references/output-contract.md
+++ b/skills/security-audit/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/security-audit/references/output-contract.md
+++ b/skills/security-audit/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/skill-creator/references/output-contract.md
+++ b/skills/skill-creator/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/skill-creator/references/output-contract.md
+++ b/skills/skill-creator/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/skill-refiner/references/output-contract.md
+++ b/skills/skill-refiner/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/skill-refiner/references/output-contract.md
+++ b/skills/skill-refiner/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/skill-refiner/references/test-cases.md
+++ b/skills/skill-refiner/references/test-cases.md
@@ -592,7 +592,7 @@ Quality signals:
 - Flags cluster of banned vocabulary (empowers, seamlessly, navigate, landscape, boasts, fosters, pivotal, journey toward)
 - Identifies scaffolding padding ("In today's fast-paced world") and promotional tone ("commitment to excellence")
 - Flags copula avoidance ("serves as" instead of "is")
-- Applies short-text density rule - assigns High severity for 2+ tells in one paragraph under 100 words
+- Applies short-text density rule - assigns P1 for 2+ tells in one paragraph under 100 words
 - Provides a rewrite that is shorter and more specific, not a lateral synonym swap
 - Does not flag quoted material or genre conventions
 
@@ -604,6 +604,23 @@ Quality signals:
 - Verdict is "Fine" or "no findings" - domain context overrides vocabulary match
 - Does not fabricate AI-prose findings to pad the report
 - Keeps direct quotations and citations untouched
+
+**Test 3: Inline mode stays silent**
+Prompt: "Explain in two sentences why this repo pins provider versions."
+Quality signals:
+- Answers the question directly, with no audit report, findings list, severity ratings, or deliverable file
+- Emits no announcement that the skill ran and no output-contract header or conclusion box
+- The answer itself carries no chat artifacts (`Great question!`, `I hope this helps!`) and no scaffolding padding
+- Does not restructure or "improve" the user's own wording when quoting the question back
+- Applies the rules to its own drafting only - does not audit the repo's prose unprompted
+
+**Test 4: Mode selection under an ambiguous prompt**
+Prompt: "This CONTRIBUTING.md reads like ChatGPT wrote it, can you take a look?"
+Quality signals:
+- Picks audit mode - the user handed over a target, so this is not inline filtering
+- Emits the full output contract and writes the deliverable to docs/local/audits/anti-ai-prose/
+- Does not mix the two modes: no silent rewrite of the file in place of a report
+- Respects house style from CLAUDE.md/AGENTS.md over the skill's own pattern rules
 
 ### backend-api
 

--- a/skills/skill-refiner/references/test-cases.md
+++ b/skills/skill-refiner/references/test-cases.md
@@ -589,10 +589,11 @@ Quality signals:
 **Test 1: README audit**
 Prompt: "Review this README opener for AI-prose tells:\n\nIn today's fast-paced world, our platform empowers developers to seamlessly navigate the complex landscape of modern APIs. Built with a commitment to excellence, it boasts robust features and fosters innovation. Whether you're a beginner or expert, this tool serves as a pivotal resource for your journey toward better software."
 Quality signals:
-- Flags cluster of banned vocabulary (empowers, seamlessly, navigate, landscape, boasts, fosters, pivotal, journey toward)
+- Flags cluster of banned vocabulary (empowers, seamlessly, navigate, landscape, commitment to, boasts, robust, fosters, pivotal, journey toward) as one clustered finding, not ten
 - Identifies scaffolding padding ("In today's fast-paced world") and promotional tone ("commitment to excellence")
 - Flags copula avoidance ("serves as" instead of "is")
 - Applies short-text density rule - assigns P1 for 2+ tells in one paragraph under 100 words
+- Numbers findings in priority order so the deliverable file stays monotonic when regrouped
 - Provides a rewrite that is shorter and more specific, not a lateral synonym swap
 - Does not flag quoted material or genre conventions
 

--- a/skills/skill-router/references/output-contract.md
+++ b/skills/skill-router/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/skill-router/references/output-contract.md
+++ b/skills/skill-router/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/synology-dsm/references/output-contract.md
+++ b/skills/synology-dsm/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/synology-dsm/references/output-contract.md
+++ b/skills/synology-dsm/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/terraform/references/output-contract.md
+++ b/skills/terraform/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/terraform/references/output-contract.md
+++ b/skills/terraform/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/testing/references/output-contract.md
+++ b/skills/testing/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/testing/references/output-contract.md
+++ b/skills/testing/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/update-docs/references/output-contract.md
+++ b/skills/update-docs/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/update-docs/references/output-contract.md
+++ b/skills/update-docs/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/virtualization/references/output-contract.md
+++ b/skills/virtualization/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/virtualization/references/output-contract.md
+++ b/skills/virtualization/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 

--- a/skills/zero-day/references/output-contract.md
+++ b/skills/zero-day/references/output-contract.md
@@ -6,20 +6,20 @@ How a skill reports its findings: an inline surface in the transcript and a writ
 
 The contract has two intentionally divergent shapes:
 
-- **Inline (transcript):** boxed Unicode-art header → compact body summary → boxed conclusion header → boxed conclusion table. Visual identity, scan-friendly, transient.
-- **File (deliverable):** pure markdown — H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
+- **Inline (transcript):** boxed Unicode-art header -> compact body summary -> boxed conclusion header -> boxed conclusion table. Visual identity, scan-friendly, transient.
+- **File (deliverable):** pure markdown - H1/H2 grouped by priority, native `- [ ]` checkboxes per finding, full per-finding detail, "Fix applied" placeholder for the implementer. Renders properly in GitHub, GitLab, VS Code, Obsidian.
 
 ## Inline format
 
 ### Header box
 
-Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection — boxes are static text the model emits directly.
+Double-line, exactly 80 characters wide, variable height. No figlet/toilet runtime detection - boxes are static text the model emits directly.
 
 Minimum form (3 lines):
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════╗
-║  CODE-REVIEW  →  docs/local/audits/code-review/2026-05-03-auth-review.md     ║
+║  CODE-REVIEW  ->  docs/local/audits/code-review/2026-05-03-auth-review.md    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -41,7 +41,7 @@ Conclusion header (same shape, name suffixed `· CONCLUSION`):
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-Skill name is the directory name uppercased (`code-review` → `CODE-REVIEW`).
+Skill name is the directory name uppercased (`code-review` -> `CODE-REVIEW`).
 
 ### Conclusion table
 
@@ -66,7 +66,7 @@ Column widths (cell content + 1 char padding either side):
 | #        | 4     | numeric, padded                                         |
 | Type     | 10    | `found` / `fixed` / `rec` / `skipped` / `error`         |
 | Priority | 10    | `P0` / `P1` / `P2` / `P3` / `info`                      |
-| Summary  | 38    | one-liner; truncate with `…` if it exceeds 36 chars     |
+| Summary  | 38    | one-liner; truncate with `...` if it exceeds 36 chars     |
 | Action   | 12    | `applied` / `proposed` / `recommend` / `open` / `n/a`   |
 
 Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened to fit; the unabridged description lives in the deliverable file's body.
@@ -76,7 +76,7 @@ Outer walls + 4 inner separators = 80 chars total. Long summaries are tightened 
 Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkboxes are interactive in GitHub, GitLab, VS Code, Obsidian.
 
 ```markdown
-# CODE-REVIEW — src/auth/ — 2026-05-03
+# CODE-REVIEW - src/auth/ - 2026-05-03
 
 - **Skill:** code-review
 - **Mode:** audit
@@ -86,7 +86,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
 
 ---
 
-## P0 — Must fix
+## P0 - Must fix
 
 - [ ] **#1 Missing CSRF check on POST /api/posts**
   - **File:** `src/auth/routes.ts:42`
@@ -100,7 +100,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Switch to prepared statement with `$1` binding.
   - **Fix applied:** _to be filled by implementer_
 
-## P1 — Should fix
+## P1 - Should fix
 
 - [ ] **#3 Race condition in worker pool reconnect path**
   - **File:** `src/worker/pool.go:142`
@@ -108,7 +108,7 @@ Pure markdown. No box-drawing characters. Renders in any viewer; `- [ ]` checkbo
   - **Suggested action:** Wrap reconnect in a semaphore acquired before pool registration.
   - **Fix applied:** _to be filled by implementer_
 
-## P2 — Nice to fix
+## P2 - Nice to fix
 
 - [ ] **#4 Extract repeated auth helper**
   - **File:** `src/auth/helpers.ts:12,55,89`
@@ -142,8 +142,8 @@ Notes:
 - Header is markdown H1 + a small bullet list of metadata. No box-drawing characters in the file.
 - Findings grouped by priority section. Sections with zero findings are omitted.
 - Each finding is a top-level `- [ ]` checkbox with bolded `#N Title`. Sub-bullets carry `File`, `Description`, `Suggested action`, `Fix applied`.
-- Numbering (`#1`, `#2`, …) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
-- Conclusion is a standard markdown table in the file, not box-drawing — that style is reserved for inline.
+- Numbering (`#1`, `#2`, ...) is monotonic across the whole report, not per-section. The conclusion table at the bottom uses the same numbers.
+- Conclusion is a standard markdown table in the file, not box-drawing - that style is reserved for inline.
 
 ### Deliverable filename
 
@@ -157,13 +157,13 @@ One scale, used in both inline and file:
 
 | Label  | Meaning                                              | File section heading       |
 |--------|------------------------------------------------------|----------------------------|
-| `P0`   | Must fix — breaks functionality, security, or build  | `## P0 — Must fix`         |
-| `P1`   | Should fix — significant correctness or design bug   | `## P1 — Should fix`       |
-| `P2`   | Nice to fix — improvement, lower urgency             | `## P2 — Nice to fix`      |
-| `P3`   | Backlog — track but not now                          | `## P3 — Backlog`          |
-| `info` | Informational — no action required                   | `## Info`                  |
+| `P0`   | Must fix - breaks functionality, security, or build  | `## P0 - Must fix`         |
+| `P1`   | Should fix - significant correctness or design bug   | `## P1 - Should fix`       |
+| `P2`   | Nice to fix - improvement, lower urgency             | `## P2 - Nice to fix`      |
+| `P3`   | Backlog - track but not now                          | `## P3 - Backlog`          |
+| `info` | Informational - no action required                   | `## Info`                  |
 
-Skills currently using a different scale must migrate. Document the old → new mapping inline at the top of the affected skill's `## Output Contract` section as a 3–5 line note.
+Skills currently using a different scale must migrate. Document the old -> new mapping inline at the top of the affected skill's `## Output Contract` section as a 3-5 line note.
 
 ## Storage layout
 
@@ -195,7 +195,7 @@ Each skill declares one of two modes in its `## Output Contract` section:
 
 ## Fix protocol
 
-**Layer 1 — Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
+**Layer 1 - Convention.** Any agent reading a deliverable file with `- [ ]` checkboxes and `_to be filled by implementer_` placeholders understands the protocol: as fixes land, flip the box to `- [x]`, replace the italic placeholder with a one-line description of what was actually done. Optionally append a commit SHA in parentheses.
 
 Example, before:
 
@@ -213,11 +213,11 @@ After:
   - **Fix applied:** Added `requireCsrf()` middleware to all state-changing /api routes (a1b2c3d).
 ```
 
-**Layer 2 — Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
+**Layer 2 - Same-conversation auto-fill.** When the user invokes a skill in audit-and-fix mode (e.g., "review my repo and fix what you find"), the agent:
 
 1. Runs the audit skill, writes the report to `docs/local/audits/<skill>/<date>-<slug>.md`.
 2. Iterates findings in priority order (P0 first).
-3. For each finding: implements the fix, updates the report file in place (checkbox → `[x]`, placeholder → one-line fix description), optionally commits the change atomically.
+3. For each finding: implements the fix, updates the report file in place (checkbox -> `[x]`, placeholder -> one-line fix description), optionally commits the change atomically.
 4. After the loop, emits an updated inline conclusion table reflecting the new `Type` (`fixed`) and `Action` (`applied`) values.
 
-Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up — not part of this contract.
+Layer 3 (a dedicated `apply-report` skill that takes a report path and runs the loop without re-running the auditor) is a future follow-up, not part of this contract.

--- a/skills/zero-day/references/output-contract.md
+++ b/skills/zero-day/references/output-contract.md
@@ -182,11 +182,16 @@ docs/local/
 
 Each skill declares one of two modes in its `## Output Contract` section:
 
-- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, anti-ai-prose, localize).
+- **Always-on:** every invocation emits the full contract. Used by audit/report skills (code-review, anti-slop, security-audit, deep-audit, full-review, update-docs, code-slimming, localize).
 
 - **Conditional:** the agent applies this rule per invocation:
 
   > When invoked to **analyze, review, audit, or improve** existing repo content, emit the full contract and write a deliverable file to the declared bucket. When invoked to **answer a question, teach a concept, build a new artifact, or generate content**, respond freely without the contract.
+
+  A conditional skill may also run as a background filter on the agent's own output, with no
+  target artifact at all (anti-ai-prose does this). That path emits no contract, no deliverable,
+  and no announcement: there is nothing to report on, so reporting would be noise. Only an
+  invocation against a real target produces a deliverable.
 
 ## Fix protocol
 


### PR DESCRIPTION
Adds an always-on inline mode to `anti-ai-prose` and folds in the plain-speech checks from `poteto/plugins` unslop, then fixes the defects that merge introduced.

Closes #124

## Inline mode

The skill now runs in one of two modes:

- **Inline** (default): filters the agent's own drafting silently. No report, no findings, no deliverable, no announcement. Density thresholds do not apply, since one chat artifact in your own reply is one too many.
- **Audit** (explicit): a file, paste, diff, or directory handed over for review. Full workflow, full output contract, density thresholds applied.

This is a new contract shape, so `_shared/output-contract.md` gained a conditional-silent path: a skill running as a background filter over its own output has no target artifact and emits no contract.

## Fixes on top of the merge

- **Size:** `SKILL.md` 588 -> 496 lines, clearing the repo's only lint warning. The vocabulary table was regrouped by fix (all 39 entries and their alternatives preserved), the formatting long tail extracted to `references/formatting-tells.md`, and the adverb-crutch and elegant-variation checks moved into `references/fiction-tells.md`.
- **Severity:** P0 and info are now defined for prose. Trust breaches (fabricated citation, invented fact, leaked secret, generator residue, cutoff disclaimer under a human byline) are P0 and skip density.
- **Density:** one authoritative gated/not-gated list in `audit-mode.md`, with both `SKILL.md` summaries aligned to it. Formatting nits sit outside the ratio and cap at P3.
- **Report format:** the transcript and the deliverable file are two renderings of the same findings, numbered in priority order so the file stays monotonic when it regroups under `## P0` headings.
- **Self-check** now covers both modes: two mode items on every response, the rest on audits.
- **Scope:** prose inside comments and docstrings is a valid audit target; the code around it is not.
- Removed a pointer to a skill outside this collection, an unsourced statistic, and `+1` from the generator-residue list (people write that).

## Collection-wide

`_shared/output-contract.md` is now ASCII in both prose and the emitted heading spec, so `## P0 - Must fix` matches what `README.md` already documented. Regenerated into all 47 skills; box art unchanged at exactly 80 columns. A sweep across every `SKILL.md` and reference now finds no stray Unicode punctuation.

Deliverables written from here on use `- ` instead of `— ` in priority headings. Existing local reports under the gitignored `docs/local/` keep the old form.

## Sources verified

The fiction claims now carry URLs and a verification date. Two checked out; one did not. The name-diversity figures compared 77% (share of generations in a model's top ten names) against 4% (share held by a single top pick) as though they were one measure, and omitted a base model at 28%. Now stated as separate measures with the outlier named.

## Verification

- 11 repo checks pass: lint, spec, contract sync, first paragraph, private-skill leaks, protected overlay, freshness dates, deep-audit coverage, and three self-tests. 0 errors, 0 warnings.
- 6 behavioral runs as fresh-context subagents. The discriminating ones: planted P0 traps were caught and ranked above voice findings; a 520-word mostly-good doc drew 3 findings and 1 info with no overflagging of valid technical passive; the docstring case audited prose while leaving code alone.
- Cross-model peer review over 4 rounds. All 18 flags verified real and fixed, none contested.
- `code-slimming` pre-merge gate: no deletions available in the diff, no orphans, no leftovers. One adjacent finding filed as #125.